### PR TITLE
Fix deployment issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Deploy to ${{ inputs.environment-name }}
         id: deploy-to-env
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@v2.2.6
         with:
           app-name: ${{ inputs.app-name }}
           slot-name: 'Production'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Deploy to ${{ inputs.environment-name }}
         id: deploy-to-env
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@v3
         with:
           app-name: ${{ inputs.app-name }}
           slot-name: 'Production'


### PR DESCRIPTION
Appears to be a breaking change in azure/deploy-webapp. Possibly a duplicate, different cased readme.md file.

> Download action repository 'azure/webapps-deploy@v2' (SHA:4ed4d429f1f77116d756b900be4070e3ae9bb76f)
> Error: The file 'D:\a\_actions\_temp_884ebe91-cfa8-4ce5-b7e2-41be187870f4\_staging\Azure-webapps-deploy-4ed4d42\node_modules\querystring\Readme.md' already exists.

`v2.2.7` appears to introduce the fault, trying the older version `v2.2.6`