### PR TITLE
#663 complete support for submissions

### DIFF
--- a/CourageScores.Tests/Models/ActionResultTests.cs
+++ b/CourageScores.Tests/Models/ActionResultTests.cs
@@ -1,0 +1,549 @@
+using CourageScores.Models;
+using CourageScores.Models.Dtos;
+using NUnit.Framework;
+
+namespace CourageScores.Tests.Models;
+
+[TestFixture]
+public class ActionResultTests
+{
+    [Test]
+    public void MergeActionResult_WhenCurrentSuccessfulAndOtherUnsuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResult<object>
+        {
+            Success = true,
+        };
+        var other = new ActionResult<object>
+        {
+            Success = false,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentUnsuccessfulAndOtherSuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResult<object>
+        {
+            Success = false,
+        };
+        var other = new ActionResult<object>
+        {
+            Success = true,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentUnsuccessfulAndOtherUnsuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResult<object>
+        {
+            Success = false,
+        };
+        var other = new ActionResult<object>
+        {
+            Success = false,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentSuccessfulAndOtherSuccessful_ReturnsSuccessful()
+    {
+        var current = new ActionResult<object>
+        {
+            Success = true,
+        };
+        var other = new ActionResult<object>
+        {
+            Success = true,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.True);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentHasAResultAndOtherHasAResult_ReturnsOtherResult()
+    {
+        var current = new ActionResult<string>
+        {
+            Result = "CURRENT",
+        };
+        var other = new ActionResult<string>
+        {
+            Result = "OTHER",
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("OTHER"));
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentHasNoResultAndOtherHasAResult_ReturnsOtherResult()
+    {
+        var current = new ActionResult<string>
+        {
+            Result = null,
+        };
+        var other = new ActionResult<string>
+        {
+            Result = "OTHER",
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("OTHER"));
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentHasNoResultAndOtherHasNoResult_ReturnsNoResult()
+    {
+        var current = new ActionResult<string>
+        {
+            Result = null,
+        };
+        var other = new ActionResult<string>
+        {
+            Result = null,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.Null);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentHasResultAndOtherHasNoResult_ReturnsCurrentResult()
+    {
+        var current = new ActionResult<string>
+        {
+            Result = "CURRENT",
+        };
+        var other = new ActionResult<string>
+        {
+            Result = null,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("CURRENT"));
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentDeleteAndOtherNotDelete_ReturnsDelete()
+    {
+        var current = new ActionResult<object>
+        {
+            Delete = true,
+        };
+        var other = new ActionResult<object>
+        {
+            Delete = false,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Delete, Is.True);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentNotDeleteAndOtherDelete_ReturnsDelete()
+    {
+        var current = new ActionResult<object>
+        {
+            Delete = false,
+        };
+        var other = new ActionResult<object>
+        {
+            Delete = true,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Delete, Is.True);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentDeleteAndOtherDelete_ReturnsDelete()
+    {
+        var current = new ActionResult<object>
+        {
+            Delete = true,
+        };
+        var other = new ActionResult<object>
+        {
+            Delete = true,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Delete, Is.True);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentNotDeleteAndOtherNotDelete_ReturnsNotDelete()
+    {
+        var current = new ActionResult<object>
+        {
+            Delete = false,
+        };
+        var other = new ActionResult<object>
+        {
+            Delete = false,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Delete, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResult_GivenMessagesInBoth_ReturnsMessagesConcatenated()
+    {
+        var current = new ActionResult<object>
+        {
+            Messages = { "CURRENT" },
+        };
+        var other = new ActionResult<object>
+        {
+            Messages = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Messages, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void MergeActionResult_GivenWarningsInBoth_ReturnsWarningsConcatenated()
+    {
+        var current = new ActionResult<object>
+        {
+            Warnings = { "CURRENT" },
+        };
+        var other = new ActionResult<object>
+        {
+            Warnings = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Warnings, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void MergeActionResult_GivenErrorsInBoth_ReturnsErrorsConcatenated()
+    {
+        var current = new ActionResult<object>
+        {
+            Errors = { "CURRENT" },
+        };
+        var other = new ActionResult<object>
+        {
+            Errors = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Errors, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentSuccessfulAndOtherUnsuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResult<object>
+        {
+            Success = true,
+        };
+        var other = new ActionResultDto<object>
+        {
+            Success = false,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentUnsuccessfulAndOtherSuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResult<object>
+        {
+            Success = false,
+        };
+        var other = new ActionResultDto<object>
+        {
+            Success = true,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentUnsuccessfulAndOtherUnsuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResult<object>
+        {
+            Success = false,
+        };
+        var other = new ActionResultDto<object>
+        {
+            Success = false,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentSuccessfulAndOtherSuccessful_ReturnsSuccessful()
+    {
+        var current = new ActionResult<object>
+        {
+            Success = true,
+        };
+        var other = new ActionResultDto<object>
+        {
+            Success = true,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.True);
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentHasAResultAndOtherHasAResult_ReturnsOtherResult()
+    {
+        var current = new ActionResult<string>
+        {
+            Result = "CURRENT",
+        };
+        var other = new ActionResultDto<string>
+        {
+            Result = "OTHER",
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("OTHER"));
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentHasNoResultAndOtherHasAResult_ReturnsOtherResult()
+    {
+        var current = new ActionResult<string>
+        {
+            Result = null,
+        };
+        var other = new ActionResultDto<string>
+        {
+            Result = "OTHER",
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("OTHER"));
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentHasNoResultAndOtherHasNoResult_ReturnsNoResult()
+    {
+        var current = new ActionResult<string>
+        {
+            Result = null,
+        };
+        var other = new ActionResultDto<string>
+        {
+            Result = null,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.Null);
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentHasResultAndOtherHasNoResult_ReturnsCurrentResult()
+    {
+        var current = new ActionResult<string>
+        {
+            Result = "CURRENT",
+        };
+        var other = new ActionResultDto<string>
+        {
+            Result = null,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("CURRENT"));
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentDelete_ReturnsDelete()
+    {
+        var current = new ActionResult<object>
+        {
+            Delete = true,
+        };
+        var other = new ActionResultDto<object>();
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Delete, Is.True);
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentNotDelete_ReturnsNotDelete()
+    {
+        var current = new ActionResult<object>
+        {
+            Delete = false,
+        };
+        var other = new ActionResultDto<object>();
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Delete, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResultDto_GivenMessagesInBoth_ReturnsMessagesConcatenated()
+    {
+        var current = new ActionResult<object>
+        {
+            Messages = { "CURRENT" },
+        };
+        var other = new ActionResultDto<object>
+        {
+            Messages = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Messages, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void MergeActionResultDto_GivenWarningsInBoth_ReturnsWarningsConcatenated()
+    {
+        var current = new ActionResult<object>
+        {
+            Warnings = { "CURRENT" },
+        };
+        var other = new ActionResultDto<object>
+        {
+            Warnings = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Warnings, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void MergeActionResultDto_GivenErrorsInBoth_ReturnsErrorsConcatenated()
+    {
+        var current = new ActionResult<object>
+        {
+            Errors = { "CURRENT" },
+        };
+        var other = new ActionResultDto<object>
+        {
+            Errors = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Errors, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void As_GivenResult_ReturnsResult()
+    {
+        var current = new ActionResult<string>
+        {
+            Errors = { "ERROR" },
+            Warnings = { "WARNING" },
+            Messages = { "MESSAGE" },
+            Delete = true,
+            Success = true,
+            Result = "CURRENT",
+        };
+
+        var result = current.As("NEW");
+
+        Assert.That(result.Errors, Is.EqualTo(new[] { "ERROR" }));
+        Assert.That(result.Warnings, Is.EqualTo(new[] { "WARNING" }));
+        Assert.That(result.Messages, Is.EqualTo(new[] { "MESSAGE" }));
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Delete, Is.True);
+        Assert.That(result.Result, Is.EqualTo("NEW"));
+    }
+
+    [Test]
+    public void As_GivenNoResult_ReturnsNoResult()
+    {
+        var current = new ActionResult<string>
+        {
+            Errors = { "ERROR" },
+            Warnings = { "WARNING" },
+            Messages = { "MESSAGE" },
+            Delete = true,
+            Success = true,
+            Result = "CURRENT",
+        };
+
+        var result = current.As<string>();
+
+        Assert.That(result.Errors, Is.EqualTo(new[] { "ERROR" }));
+        Assert.That(result.Warnings, Is.EqualTo(new[] { "WARNING" }));
+        Assert.That(result.Messages, Is.EqualTo(new[] { "MESSAGE" }));
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Delete, Is.True);
+        Assert.That(result.Result, Is.Null);
+    }
+}

--- a/CourageScores.Tests/Models/Adapters/Season/UpdateScoresAdapterTests.cs
+++ b/CourageScores.Tests/Models/Adapters/Season/UpdateScoresAdapterTests.cs
@@ -1,0 +1,335 @@
+using CourageScores.Models.Adapters.Season;
+using CourageScores.Models.Cosmos.Game;
+using CourageScores.Models.Cosmos.Game.Sayg;
+using CourageScores.Models.Dtos.Game;
+using CourageScores.Models.Dtos.Game.Sayg;
+using CourageScores.Models.Dtos.Identity;
+using CourageScores.Services;
+using CourageScores.Services.Identity;
+using Moq;
+using NUnit.Framework;
+
+namespace CourageScores.Tests.Models.Adapters.Season;
+
+[TestFixture]
+public class UpdateScoresAdapterTests
+{
+    private static readonly ScoreAsYouGo SaygModel = new ScoreAsYouGo();
+    private static readonly ScoreAsYouGoDto SaygDto = new ScoreAsYouGoDto();
+    private static readonly RecordScoresDto.RecordScoresGamePlayerDto HomePlayerDto = new() { Id = Guid.NewGuid(), Name = "HOME" };
+    private static readonly RecordScoresDto.RecordScoresGamePlayerDto AwayPlayerDto = new() { Id = Guid.NewGuid(), Name = "AWAY" };
+
+    private readonly CancellationToken _token = new CancellationToken();
+    private Mock<IAuditingHelper> _auditingHelper = null!;
+    private Mock<IUserService> _userService = null!;
+    private MockSimpleAdapter<ScoreAsYouGo,ScoreAsYouGoDto> _scoreAsYouGoAdapter = null!;
+    private UserDto? _user;
+
+    private UpdateScoresAdapter _adapter = null!;
+
+    [SetUp]
+    public void SetupEachTest()
+    {
+        _auditingHelper = new Mock<IAuditingHelper>();
+        _userService = new Mock<IUserService>();
+        _scoreAsYouGoAdapter = new MockSimpleAdapter<ScoreAsYouGo, ScoreAsYouGoDto>(SaygModel, SaygDto);
+        _adapter = new UpdateScoresAdapter(
+            _auditingHelper.Object,
+            _userService.Object,
+            _scoreAsYouGoAdapter);
+
+        _user = new UserDto
+        {
+            Access = new AccessDto
+            {
+                RecordScoresAsYouGo = true,
+            },
+        };
+        _userService.Setup(s => s.GetUser(_token)).ReturnsAsync(() => _user);
+    }
+
+    [Test]
+    public async Task AdaptToPlayer_GivenPlayer_AdaptsToGamePlayer()
+    {
+        var inputPlayer = new RecordScoresDto.RecordScoresGamePlayerDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "PLAYER",
+        };
+
+        var result = await _adapter.AdaptToPlayer(inputPlayer, _token);
+
+        Assert.That(result.Id, Is.EqualTo(inputPlayer.Id));
+        Assert.That(result.Name, Is.EqualTo(inputPlayer.Name));
+    }
+
+    [Test]
+    public async Task AdaptToPlayer_GivenPlayer_SetsUpdated()
+    {
+        var inputPlayer = new RecordScoresDto.RecordScoresGamePlayerDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "PLAYER",
+        };
+
+        var result = await _adapter.AdaptToPlayer(inputPlayer, _token);
+
+        _auditingHelper.Verify(h => h.SetUpdated(result, _token));
+    }
+
+    [Test]
+    public async Task AdaptToHiCheckPlayer_GivenPlayer_AdaptsToNotablePlayer()
+    {
+        var inputPlayer = new RecordScoresDto.GameOver100CheckoutDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "PLAYER",
+            Notes = "120",
+        };
+
+        var result = await _adapter.AdaptToHiCheckPlayer(inputPlayer, _token);
+
+        Assert.That(result.Id, Is.EqualTo(inputPlayer.Id));
+        Assert.That(result.Name, Is.EqualTo(inputPlayer.Name));
+        Assert.That(result.Notes, Is.EqualTo(inputPlayer.Notes));
+    }
+
+    [Test]
+    public async Task AdaptToHiCheckPlayer_GivenPlayer_SetsUpdated()
+    {
+        var inputPlayer = new RecordScoresDto.GameOver100CheckoutDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "PLAYER",
+            Notes = "120",
+        };
+
+        var result = await _adapter.AdaptToHiCheckPlayer(inputPlayer, _token);
+
+        _auditingHelper.Verify(h => h.SetUpdated(result, _token));
+    }
+
+    [Test]
+    public async Task AdaptToMatch_WhenLoggedOut_AdaptsToMatch()
+    {
+        _user = null;
+        var inputMatch = new RecordScoresDto.RecordScoresGameMatchDto
+        {
+            HomePlayers = { HomePlayerDto },
+            AwayPlayers = { AwayPlayerDto },
+            HomeScore = 1,
+            AwayScore = 2,
+            Sayg = SaygDto,
+        };
+
+        var result = await _adapter.AdaptToMatch(inputMatch, _token);
+
+        Assert.That(result.Id, Is.Not.EqualTo(Guid.Empty));
+        Assert.That(result.HomePlayers.Select(p => p.Id), Is.EqualTo(new[] { HomePlayerDto.Id }));
+        Assert.That(result.AwayPlayers.Select(p => p.Id), Is.EqualTo(new[] { AwayPlayerDto.Id }));
+        Assert.That(result.HomeScore, Is.EqualTo(inputMatch.HomeScore));
+        Assert.That(result.AwayScore, Is.EqualTo(inputMatch.AwayScore));
+        Assert.That(result.Sayg, Is.Null);
+        _auditingHelper.Verify(h => h.SetUpdated(result, _token));
+    }
+
+    [Test]
+    public async Task AdaptToMatch_WhenNotPermitted_AdaptsToMatch()
+    {
+        _user!.Access!.RecordScoresAsYouGo = false;
+        var inputMatch = new RecordScoresDto.RecordScoresGameMatchDto
+        {
+            HomePlayers = { HomePlayerDto },
+            AwayPlayers = { AwayPlayerDto },
+            HomeScore = 1,
+            AwayScore = 2,
+            Sayg = SaygDto,
+        };
+
+        var result = await _adapter.AdaptToMatch(inputMatch, _token);
+
+        Assert.That(result.Id, Is.Not.EqualTo(Guid.Empty));
+        Assert.That(result.HomePlayers.Select(p => p.Id), Is.EqualTo(new[] { HomePlayerDto.Id }));
+        Assert.That(result.AwayPlayers.Select(p => p.Id), Is.EqualTo(new[] { AwayPlayerDto.Id }));
+        Assert.That(result.HomeScore, Is.EqualTo(inputMatch.HomeScore));
+        Assert.That(result.AwayScore, Is.EqualTo(inputMatch.AwayScore));
+        Assert.That(result.Sayg, Is.Null);
+        _auditingHelper.Verify(h => h.SetUpdated(result, _token));
+    }
+
+    [Test]
+    public async Task AdaptToMatch_WhenPermitted_AdaptsToMatchWithSaygModel()
+    {
+        var inputMatch = new RecordScoresDto.RecordScoresGameMatchDto
+        {
+            HomePlayers = { HomePlayerDto },
+            AwayPlayers = { AwayPlayerDto },
+            HomeScore = 1,
+            AwayScore = 2,
+            Sayg = SaygDto,
+        };
+
+        var result = await _adapter.AdaptToMatch(inputMatch, _token);
+
+        Assert.That(result.Id, Is.Not.EqualTo(Guid.Empty));
+        Assert.That(result.HomePlayers.Select(p => p.Id), Is.EqualTo(new[] { HomePlayerDto.Id }));
+        Assert.That(result.AwayPlayers.Select(p => p.Id), Is.EqualTo(new[] { AwayPlayerDto.Id }));
+        Assert.That(result.HomeScore, Is.EqualTo(inputMatch.HomeScore));
+        Assert.That(result.AwayScore, Is.EqualTo(inputMatch.AwayScore));
+        Assert.That(result.Sayg, Is.SameAs(SaygModel));
+        _auditingHelper.Verify(h => h.SetUpdated(result, _token));
+    }
+
+    [Test]
+    public async Task UpdateMatch_WhenLoggedOut_AdaptsToMatch()
+    {
+        _user = null;
+        var currentMatch = new GameMatch
+        {
+            Id = Guid.NewGuid(),
+            HomeScore = 1,
+            AwayScore = 2,
+            Sayg = null,
+            HomePlayers = { new GamePlayer { Name = "OLD HOME PLAYER" } },
+            AwayPlayers = { new GamePlayer { Name = "OLD AWAY PLAYER" } },
+            Created = new DateTime(2001, 02, 03),
+            Author = "AUTHOR",
+            Deleted = new DateTime(2002, 03, 04),
+            Remover = "REMOVER",
+            Version = 2,
+        };
+        var updatedMatch = new RecordScoresDto.RecordScoresGameMatchDto
+        {
+            HomePlayers = { HomePlayerDto },
+            AwayPlayers = { AwayPlayerDto },
+            HomeScore = 2,
+            AwayScore = 3,
+            Sayg = SaygDto,
+        };
+
+        var result = await _adapter.UpdateMatch(currentMatch, updatedMatch, _token);
+
+        Assert.That(result.Author, Is.EqualTo("AUTHOR"));
+        Assert.That(result.Created, Is.EqualTo(new DateTime(2001, 02, 03)));
+        Assert.That(result.Remover, Is.EqualTo("REMOVER"));
+        Assert.That(result.Deleted, Is.EqualTo(new DateTime(2002, 03, 04)));
+        Assert.That(result.Id, Is.EqualTo(currentMatch.Id));
+        Assert.That(result.Version, Is.EqualTo(currentMatch.Version));
+        Assert.That(result.HomeScore, Is.EqualTo(2));
+        Assert.That(result.AwayScore, Is.EqualTo(3));
+        Assert.That(result.HomePlayers.Select(p => p.Id), Is.EqualTo(new[] { HomePlayerDto.Id }));
+        Assert.That(result.AwayPlayers.Select(p => p.Id), Is.EqualTo(new[] { AwayPlayerDto.Id }));
+        Assert.That(result.Sayg, Is.Null); // the current match has no sayg
+        _auditingHelper.Verify(h => h.SetUpdated(result, _token));
+    }
+
+    [Test]
+    public async Task UpdateMatch_WhenNotPermitted_AdaptsToMatch()
+    {
+        _user!.Access!.RecordScoresAsYouGo = false;
+        var currentMatch = new GameMatch
+        {
+            Id = Guid.NewGuid(),
+            HomeScore = 1,
+            AwayScore = 2,
+            Sayg = null,
+            HomePlayers = { new GamePlayer { Name = "OLD HOME PLAYER" } },
+            AwayPlayers = { new GamePlayer { Name = "OLD AWAY PLAYER" } },
+            Created = new DateTime(2001, 02, 03),
+            Author = "AUTHOR",
+            Deleted = new DateTime(2002, 03, 04),
+            Remover = "REMOVER",
+            Version = 2,
+        };
+        var updatedMatch = new RecordScoresDto.RecordScoresGameMatchDto
+        {
+            HomePlayers = { HomePlayerDto },
+            AwayPlayers = { AwayPlayerDto },
+            HomeScore = 2,
+            AwayScore = 3,
+            Sayg = SaygDto,
+        };
+
+        var result = await _adapter.UpdateMatch(currentMatch, updatedMatch, _token);
+
+        Assert.That(result.Author, Is.EqualTo("AUTHOR"));
+        Assert.That(result.Created, Is.EqualTo(new DateTime(2001, 02, 03)));
+        Assert.That(result.Remover, Is.EqualTo("REMOVER"));
+        Assert.That(result.Deleted, Is.EqualTo(new DateTime(2002, 03, 04)));
+        Assert.That(result.Id, Is.EqualTo(currentMatch.Id));
+        Assert.That(result.Version, Is.EqualTo(currentMatch.Version));
+        Assert.That(result.HomeScore, Is.EqualTo(2));
+        Assert.That(result.AwayScore, Is.EqualTo(3));
+        Assert.That(result.HomePlayers.Select(p => p.Id), Is.EqualTo(new[] { HomePlayerDto.Id }));
+        Assert.That(result.AwayPlayers.Select(p => p.Id), Is.EqualTo(new[] { AwayPlayerDto.Id }));
+        Assert.That(result.Sayg, Is.Null); // the current match has no sayg
+        _auditingHelper.Verify(h => h.SetUpdated(result, _token));
+    }
+
+    [Test]
+    public async Task UpdateMatch_WhenPermitted_AdaptsToMatchWithSaygModel()
+    {
+        var currentMatch = new GameMatch
+        {
+            Id = Guid.NewGuid(),
+            HomeScore = 1,
+            AwayScore = 2,
+            Sayg = null,
+            HomePlayers = { new GamePlayer { Name = "OLD HOME PLAYER" } },
+            AwayPlayers = { new GamePlayer { Name = "OLD AWAY PLAYER" } },
+            Created = new DateTime(2001, 02, 03),
+            Author = "AUTHOR",
+            Deleted = new DateTime(2002, 03, 04),
+            Remover = "REMOVER",
+            Version = 2,
+        };
+        var updatedMatch = new RecordScoresDto.RecordScoresGameMatchDto
+        {
+            HomePlayers = { HomePlayerDto },
+            AwayPlayers = { AwayPlayerDto },
+            HomeScore = 2,
+            AwayScore = 3,
+            Sayg = SaygDto,
+        };
+
+        var result = await _adapter.UpdateMatch(currentMatch, updatedMatch, _token);
+
+        Assert.That(result.Author, Is.EqualTo("AUTHOR"));
+        Assert.That(result.Created, Is.EqualTo(new DateTime(2001, 02, 03)));
+        Assert.That(result.Remover, Is.EqualTo("REMOVER"));
+        Assert.That(result.Deleted, Is.EqualTo(new DateTime(2002, 03, 04)));
+        Assert.That(result.Id, Is.EqualTo(currentMatch.Id));
+        Assert.That(result.Version, Is.EqualTo(currentMatch.Version));
+        Assert.That(result.HomeScore, Is.EqualTo(2));
+        Assert.That(result.AwayScore, Is.EqualTo(3));
+        Assert.That(result.HomePlayers.Select(p => p.Id), Is.EqualTo(new[] { HomePlayerDto.Id }));
+        Assert.That(result.AwayPlayers.Select(p => p.Id), Is.EqualTo(new[] { AwayPlayerDto.Id }));
+        Assert.That(result.Sayg, Is.EqualTo(SaygModel));
+        _auditingHelper.Verify(h => h.SetUpdated(result, _token));
+    }
+
+    [Test]
+    public async Task UpdateMatch_GivenNoHomeOrAwayPlayers_RemovesSaygFromCurrentAndUpdatedMatch()
+    {
+        var currentMatch = new GameMatch
+        {
+            Id = Guid.NewGuid(),
+            Sayg = SaygModel,
+            HomePlayers = { new GamePlayer { Name = "OLD HOME PLAYER" } },
+            AwayPlayers = { new GamePlayer { Name = "OLD AWAY PLAYER" } },
+        };
+        var updatedMatch = new RecordScoresDto.RecordScoresGameMatchDto
+        {
+            // players aren't set for home or away
+            HomeScore = 2,
+            AwayScore = 3,
+            Sayg = SaygDto,
+        };
+
+        var result = await _adapter.UpdateMatch(currentMatch, updatedMatch, _token);
+
+        Assert.That(currentMatch.Sayg, Is.Null);
+        Assert.That(updatedMatch.Sayg, Is.Null);
+        Assert.That(result.Sayg, Is.Null);
+    }
+}

--- a/CourageScores.Tests/Models/Dtos/ActionResultDtoTests.cs
+++ b/CourageScores.Tests/Models/Dtos/ActionResultDtoTests.cs
@@ -1,0 +1,470 @@
+using CourageScores.Models;
+using CourageScores.Models.Dtos;
+using NUnit.Framework;
+
+namespace CourageScores.Tests.Models.Dtos;
+
+[TestFixture]
+public class ActionResultDtoTests
+{
+    [Test]
+    public void MergeActionResult_WhenCurrentSuccessfulAndOtherUnsuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Success = true,
+        };
+        var other = new ActionResult<object>
+        {
+            Success = false,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentUnsuccessfulAndOtherSuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Success = false,
+        };
+        var other = new ActionResult<object>
+        {
+            Success = true,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentUnsuccessfulAndOtherUnsuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Success = false,
+        };
+        var other = new ActionResult<object>
+        {
+            Success = false,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentSuccessfulAndOtherSuccessful_ReturnsSuccessful()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Success = true,
+        };
+        var other = new ActionResult<object>
+        {
+            Success = true,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.True);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentHasAResultAndOtherHasAResult_ReturnsOtherResult()
+    {
+        var current = new ActionResultDto<string>
+        {
+            Result = "CURRENT",
+        };
+        var other = new ActionResult<string>
+        {
+            Result = "OTHER",
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("OTHER"));
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentHasNoResultAndOtherHasAResult_ReturnsOtherResult()
+    {
+        var current = new ActionResultDto<string>
+        {
+            Result = null,
+        };
+        var other = new ActionResult<string>
+        {
+            Result = "OTHER",
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("OTHER"));
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentHasNoResultAndOtherHasNoResult_ReturnsNoResult()
+    {
+        var current = new ActionResultDto<string>
+        {
+            Result = null,
+        };
+        var other = new ActionResult<string>
+        {
+            Result = null,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.Null);
+    }
+
+    [Test]
+    public void MergeActionResult_WhenCurrentHasResultAndOtherHasNoResult_ReturnsCurrentResult()
+    {
+        var current = new ActionResultDto<string>
+        {
+            Result = "CURRENT",
+        };
+        var other = new ActionResult<string>
+        {
+            Result = null,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("CURRENT"));
+    }
+
+    [Test]
+    public void MergeActionResult_GivenMessagesInBoth_ReturnsMessagesConcatenated()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Messages = { "CURRENT" },
+        };
+        var other = new ActionResult<object>
+        {
+            Messages = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Messages, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void MergeActionResult_GivenWarningsInBoth_ReturnsWarningsConcatenated()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Warnings = { "CURRENT" },
+        };
+        var other = new ActionResult<object>
+        {
+            Warnings = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Warnings, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void MergeActionResult_GivenErrorsInBoth_ReturnsErrorsConcatenated()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Errors = { "CURRENT" },
+        };
+        var other = new ActionResult<object>
+        {
+            Errors = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Errors, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentSuccessfulAndOtherUnsuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Success = true,
+        };
+        var other = new ActionResultDto<object>
+        {
+            Success = false,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentUnsuccessfulAndOtherSuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Success = false,
+        };
+        var other = new ActionResultDto<object>
+        {
+            Success = true,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentUnsuccessfulAndOtherUnsuccessful_ReturnsUnsuccessful()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Success = false,
+        };
+        var other = new ActionResultDto<object>
+        {
+            Success = false,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentSuccessfulAndOtherSuccessful_ReturnsSuccessful()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Success = true,
+        };
+        var other = new ActionResultDto<object>
+        {
+            Success = true,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Success, Is.True);
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentHasAResultAndOtherHasAResult_ReturnsOtherResult()
+    {
+        var current = new ActionResultDto<string>
+        {
+            Result = "CURRENT",
+        };
+        var other = new ActionResultDto<string>
+        {
+            Result = "OTHER",
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("OTHER"));
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentHasNoResultAndOtherHasAResult_ReturnsOtherResult()
+    {
+        var current = new ActionResultDto<string>
+        {
+            Result = null,
+        };
+        var other = new ActionResultDto<string>
+        {
+            Result = "OTHER",
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("OTHER"));
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentHasNoResultAndOtherHasNoResult_ReturnsNoResult()
+    {
+        var current = new ActionResultDto<string>
+        {
+            Result = null,
+        };
+        var other = new ActionResultDto<string>
+        {
+            Result = null,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.Null);
+    }
+
+    [Test]
+    public void MergeActionResultDto_WhenCurrentHasResultAndOtherHasNoResult_ReturnsCurrentResult()
+    {
+        var current = new ActionResultDto<string>
+        {
+            Result = "CURRENT",
+        };
+        var other = new ActionResultDto<string>
+        {
+            Result = null,
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Result, Is.EqualTo("CURRENT"));
+    }
+
+    [Test]
+    public void MergeActionResultDto_GivenMessagesInBoth_ReturnsMessagesConcatenated()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Messages = { "CURRENT" },
+        };
+        var other = new ActionResultDto<object>
+        {
+            Messages = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Messages, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void MergeActionResultDto_GivenWarningsInBoth_ReturnsWarningsConcatenated()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Warnings = { "CURRENT" },
+        };
+        var other = new ActionResultDto<object>
+        {
+            Warnings = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Warnings, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void MergeActionResultDto_GivenErrorsInBoth_ReturnsErrorsConcatenated()
+    {
+        var current = new ActionResultDto<object>
+        {
+            Errors = { "CURRENT" },
+        };
+        var other = new ActionResultDto<object>
+        {
+            Errors = { "OTHER" },
+        };
+
+        var result = current.Merge(other);
+
+        Assert.That(result.Errors, Is.EqualTo(new[]
+        {
+            "CURRENT",
+            "OTHER",
+        }));
+    }
+
+    [Test]
+    public void As_GivenResult_ReturnsResult()
+    {
+        var current = new ActionResultDto<string>
+        {
+            Errors = { "ERROR" },
+            Warnings = { "WARNING" },
+            Messages = { "MESSAGE" },
+            Success = true,
+            Result = "CURRENT",
+        };
+
+        var result = current.As("NEW");
+
+        Assert.That(result.Errors, Is.EqualTo(new[] { "ERROR" }));
+        Assert.That(result.Warnings, Is.EqualTo(new[] { "WARNING" }));
+        Assert.That(result.Messages, Is.EqualTo(new[] { "MESSAGE" }));
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Result, Is.EqualTo("NEW"));
+    }
+
+    [Test]
+    public void As_GivenNoResult_ReturnsNoResult()
+    {
+        var current = new ActionResultDto<string>
+        {
+            Errors = { "ERROR" },
+            Warnings = { "WARNING" },
+            Messages = { "MESSAGE" },
+            Success = true,
+            Result = "CURRENT",
+        };
+
+        var result = current.As<string>();
+
+        Assert.That(result.Errors, Is.EqualTo(new[] { "ERROR" }));
+        Assert.That(result.Warnings, Is.EqualTo(new[] { "WARNING" }));
+        Assert.That(result.Messages, Is.EqualTo(new[] { "MESSAGE" }));
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Result, Is.Null);
+    }
+
+    [Test]
+    public void ToActionResult_WhenCalled_ReturnsActionResult()
+    {
+        var current = new ActionResultDto<string>
+        {
+            Errors = { "ERROR" },
+            Warnings = { "WARNING" },
+            Messages = { "MESSAGE" },
+            Success = true,
+            Result = "CURRENT",
+        };
+
+        var result = current.ToActionResult();
+
+        Assert.That(result.Errors, Is.EqualTo(new[] { "ERROR" }));
+        Assert.That(result.Warnings, Is.EqualTo(new[] { "WARNING" }));
+        Assert.That(result.Messages, Is.EqualTo(new[] { "MESSAGE" }));
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Result, Is.EqualTo("CURRENT"));
+    }
+}

--- a/CourageScores.Tests/Services/Command/AddOrUpdateGameCommandTests.cs
+++ b/CourageScores.Tests/Services/Command/AddOrUpdateGameCommandTests.cs
@@ -248,18 +248,10 @@ public class AddOrUpdateGameCommandTests
         _teamService.Setup(s => s.Get(update.HomeTeamId, _token)).ReturnsAsync(_homeTeam);
         _teamService.Setup(s => s.Upsert(_homeTeam.Id, _addSeasonToTeamCommand.Object, _token)).ReturnsAsync(fail);
 
-        InvalidOperationException? thrownException = null;
-        try
-        {
-            await _command.WithData(update).ApplyUpdate(_game, _token);
-        }
-        catch (InvalidOperationException exc)
-        {
-            thrownException = exc;
-        }
+        var result = await _command.WithData(update).ApplyUpdate(_game, _token);
 
-        Assert.That(thrownException, Is.Not.Null);
-        Assert.That(thrownException!.Message, Is.EqualTo("Could not add season to team: Some error1, Some error2"));
+        Assert.That(result.Errors, Is.EquivalentTo(new[] { "Some error1", "Some error2" }));
+        Assert.That(result.Success, Is.False);
         _addSeasonToTeamCommand.Verify(c => c.ForSeason(_season.Id));
         _teamService.Verify(s => s.Upsert(_homeTeam.Id, _addSeasonToTeamCommand.Object, _token));
         Assert.That(_cacheFlags.EvictDivisionDataCacheForDivisionId, Is.EqualTo(_game.DivisionId));

--- a/CourageScores.Tests/Services/Command/AddOrUpdateGameCommandTests.cs
+++ b/CourageScores.Tests/Services/Command/AddOrUpdateGameCommandTests.cs
@@ -23,13 +23,14 @@ public class AddOrUpdateGameCommandTests
     private CancellationToken _token;
     private AddOrUpdateGameCommand _command = null!;
     private ScopedCacheManagementFlags _cacheFlags = null!;
-    private readonly CosmosGame _game;
-    private readonly SeasonDto _season;
-    private readonly TeamDto _homeTeam;
-    private readonly TeamDto _awayTeam;
-    private readonly TeamSeasonDto _teamSeason;
+    private CosmosGame _game = null!;
+    private SeasonDto _season = null!;
+    private TeamDto _homeTeam = null!;
+    private TeamDto _awayTeam = null!;
+    private TeamSeasonDto _teamSeason = null!;
 
-    public AddOrUpdateGameCommandTests()
+    [SetUp]
+    public void SetupEachTest()
     {
         _game = new CosmosGame
         {
@@ -56,11 +57,7 @@ public class AddOrUpdateGameCommandTests
             Created = DateTime.Now,
             Updated = DateTime.Now,
         };
-    }
 
-    [SetUp]
-    public void SetupEachTest()
-    {
         _seasonService = new Mock<ICachingSeasonService>();
         _commandFactory = new Mock<ICommandFactory>();
         _teamService = new Mock<ITeamService>();
@@ -184,6 +181,54 @@ public class AddOrUpdateGameCommandTests
     }
 
     [Test]
+    public async Task ApplyUpdates_WhenHomeTeamNotFound_ReturnsUnsuccessful()
+    {
+        var update = new EditGameDto
+        {
+            HomeTeamId = _homeTeam.Id,
+            AwayTeamId = _awayTeam.Id,
+            Id = _game.Id,
+            SeasonId = _season.Id,
+            LastUpdated = _game.Updated,
+            DivisionId = _game.DivisionId,
+        };
+        _seasonService.Setup(s => s.Get(_season.Id, _token)).ReturnsAsync(() => _season);
+        _teamService.Setup(s => s.Get(update.HomeTeamId, _token)).ReturnsAsync(() => null);
+
+        var result = await _command.WithData(update).ApplyUpdate(_game, _token);
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Errors, Is.EqualTo(new[] { "Unable to find team with id " + update.HomeTeamId }));
+    }
+
+    [Test]
+    public async Task ApplyUpdates_WhenAwayTeamNotFound_ReturnsUnsuccessful()
+    {
+        var update = new EditGameDto
+        {
+            HomeTeamId = _homeTeam.Id,
+            AwayTeamId = _awayTeam.Id,
+            Id = _game.Id,
+            SeasonId = _season.Id,
+            LastUpdated = _game.Updated,
+            DivisionId = _game.DivisionId,
+        };
+        var success = new ActionResultDto<TeamDto>
+        {
+            Success = true,
+        };
+        _seasonService.Setup(s => s.Get(_season.Id, _token)).ReturnsAsync(() => _season);
+        _teamService.Setup(s => s.Get(update.HomeTeamId, _token)).ReturnsAsync(_homeTeam);
+        _teamService.Setup(s => s.Upsert(_homeTeam.Id, _addSeasonToTeamCommand.Object, _token)).ReturnsAsync(success);
+        _teamService.Setup(s => s.Get(update.AwayTeamId, _token)).ReturnsAsync(() => null);
+
+        var result = await _command.WithData(update).ApplyUpdate(_game, _token);
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Errors, Is.EqualTo(new[] { "Unable to find team with id " + update.AwayTeamId }));
+    }
+
+    [Test]
     public async Task ApplyUpdates_WhenTeamsNotRegisteredToSeason_ThenRegistersTeamsWithSeason()
     {
         var update = new EditGameDto
@@ -211,6 +256,32 @@ public class AddOrUpdateGameCommandTests
         _addSeasonToTeamCommand.Verify(c => c.ForSeason(_season.Id));
         _teamService.Verify(s => s.Upsert(_homeTeam.Id, _addSeasonToTeamCommand.Object, _token));
         _teamService.Verify(s => s.Upsert(_awayTeam.Id, _addSeasonToTeamCommand.Object, _token));
+        Assert.That(_cacheFlags.EvictDivisionDataCacheForDivisionId, Is.EqualTo(_game.DivisionId));
+        Assert.That(_cacheFlags.EvictDivisionDataCacheForSeasonId, Is.EqualTo(_game.SeasonId));
+    }
+
+    [Test]
+    public async Task ApplyUpdates_WhenTeamsRegisteredToSeason_DoesNotRegisterTeamsToSeason()
+    {
+        var update = new EditGameDto
+        {
+            HomeTeamId = _homeTeam.Id,
+            AwayTeamId = _awayTeam.Id,
+            Id = _game.Id,
+            SeasonId = _season.Id,
+            LastUpdated = _game.Updated,
+            DivisionId = _game.DivisionId,
+        };
+        _seasonService.Setup(s => s.Get(_season.Id, _token)).ReturnsAsync(() => _season);
+        _teamService.Setup(s => s.Get(update.HomeTeamId, _token)).ReturnsAsync(_homeTeam);
+        _teamService.Setup(s => s.Get(update.AwayTeamId, _token)).ReturnsAsync(_awayTeam);
+        _homeTeam.Seasons.Add(new TeamSeasonDto { SeasonId = _season.Id });
+        _awayTeam.Seasons.Add(new TeamSeasonDto { SeasonId = _season.Id });
+
+        var result = await _command.WithData(update).ApplyUpdate(_game, _token);
+
+        Assert.That(result.Success, Is.True);
+        _teamService.Verify(s => s.Upsert(It.IsAny<Guid>(), _addSeasonToTeamCommand.Object, _token), Times.Never);
         Assert.That(_cacheFlags.EvictDivisionDataCacheForDivisionId, Is.EqualTo(_game.DivisionId));
         Assert.That(_cacheFlags.EvictDivisionDataCacheForSeasonId, Is.EqualTo(_game.SeasonId));
     }

--- a/CourageScores.Tests/Services/Command/UpdateScoresCommandTests.cs
+++ b/CourageScores.Tests/Services/Command/UpdateScoresCommandTests.cs
@@ -207,6 +207,7 @@ public class UpdateScoresCommandTests
 
         Assert.That(result.Messages, Is.EqualTo(new[]
         {
+            "Game updated",
             "Scores updated",
         }));
         Assert.That(result.Success, Is.True);
@@ -299,6 +300,7 @@ public class UpdateScoresCommandTests
 
         Assert.That(result.Messages, Is.EqualTo(new[]
         {
+            "Game updated",
             "Scores updated",
         }));
         Assert.That(result.Success, Is.True);
@@ -362,6 +364,7 @@ public class UpdateScoresCommandTests
 
         Assert.That(result.Messages, Is.EqualTo(new[]
         {
+            "Game updated",
             "Scores updated",
         }));
         Assert.That(result.Success, Is.True);
@@ -457,6 +460,7 @@ public class UpdateScoresCommandTests
 
         Assert.That(result.Messages, Is.EqualTo(new[]
         {
+            "Submission updated",
             "Scores updated",
         }));
         Assert.That(result.Success, Is.True);
@@ -531,6 +535,7 @@ public class UpdateScoresCommandTests
 
         Assert.That(result.Messages, Is.EqualTo(new[]
         {
+            "Submission updated",
             "Scores updated",
         }));
         Assert.That(result.Success, Is.True);
@@ -584,6 +589,8 @@ public class UpdateScoresCommandTests
         Assert.That(result.Success, Is.True);
         Assert.That(result.Messages, Is.EqualTo(new[]
         {
+            "Game updated",
+            "Game details updated",
             "Scores updated",
         }));
         Assert.That(_game.Address, Is.EqualTo("new address"));
@@ -711,6 +718,7 @@ public class UpdateScoresCommandTests
         }));
         Assert.That(result.Messages, Is.EqualTo(new[]
         {
+            "Game updated",
             "message",
             "message",
             "Could not add season to home and/or away teams",

--- a/CourageScores.Tests/Services/Command/UpdateScoresCommandTests.cs
+++ b/CourageScores.Tests/Services/Command/UpdateScoresCommandTests.cs
@@ -424,7 +424,6 @@ public class UpdateScoresCommandTests
         _user!.Access!.ManageScores = false;
         _user!.Access!.InputResults = true;
         _game.Home.Id = Guid.Parse(UserTeamId);
-
         var homePlayer1 = new RecordScoresDto.RecordScoresGamePlayerDto
         {
             Id = Guid.NewGuid(),
@@ -449,6 +448,7 @@ public class UpdateScoresCommandTests
             HomeScore = 1,
             AwayScore = 2,
         };
+        _scores.Home!.ManOfTheMatch = homePlayer1.Id;
         _scores.Matches.Add(match1);
         _scores.OneEighties.Add(homePlayer1);
         _scores.Over100Checkouts.Add(awayPlayer1);
@@ -471,6 +471,8 @@ public class UpdateScoresCommandTests
         Assert.That(_game.HomeSubmission!.Matches[0], Is.SameAs(match1Adapted));
         Assert.That(_game.HomeSubmission!.OneEighties[0], Is.SameAs(homePlayer1Adapted));
         Assert.That(_game.HomeSubmission!.Over100Checkouts[0], Is.SameAs(notablePlayer));
+        Assert.That(_game.HomeSubmission!.Home.ManOfTheMatch, Is.EqualTo(homePlayer1.Id));
+        Assert.That(_game.Home.ManOfTheMatch, Is.Null);
         Assert.That(_cacheFlags.EvictDivisionDataCacheForDivisionId, Is.Null);
         Assert.That(_cacheFlags.EvictDivisionDataCacheForSeasonId, Is.Null);
     }
@@ -566,6 +568,7 @@ public class UpdateScoresCommandTests
             HomeScore = 1,
             AwayScore = 2,
         };
+        _scores.Away!.ManOfTheMatch = awayPlayer1.Id;
         _scores.Matches.Add(match1);
         _scores.OneEighties.Add(homePlayer1);
         _scores.Over100Checkouts.Add(awayPlayer1);
@@ -588,6 +591,8 @@ public class UpdateScoresCommandTests
         Assert.That(_game.AwaySubmission!.Matches[0], Is.SameAs(match1Adapted));
         Assert.That(_game.AwaySubmission!.OneEighties[0], Is.SameAs(homePlayer1Adapted));
         Assert.That(_game.AwaySubmission!.Over100Checkouts[0], Is.SameAs(notablePlayer));
+        Assert.That(_game.AwaySubmission!.Away.ManOfTheMatch, Is.EqualTo(awayPlayer1.Id));
+        Assert.That(_game.Away.ManOfTheMatch, Is.Null);
         Assert.That(_cacheFlags.EvictDivisionDataCacheForDivisionId, Is.Null);
         Assert.That(_cacheFlags.EvictDivisionDataCacheForSeasonId, Is.Null);
     }

--- a/CourageScores.Tests/Services/Game/GameComparerTests.cs
+++ b/CourageScores.Tests/Services/Game/GameComparerTests.cs
@@ -1,0 +1,301 @@
+using CourageScores.Models.Cosmos.Game;
+using CourageScores.Services.Game;
+using Moq;
+using NUnit.Framework;
+using CosmosGame = CourageScores.Models.Cosmos.Game.Game;
+
+namespace CourageScores.Tests.Services.Game;
+
+[TestFixture]
+public class GameComparerTests
+{
+    private GameComparer _comparer = null!;
+    private Mock<IEqualityComparer<GameTeam>> _teamComparer = null!;
+    private Mock<IEqualityComparer<GameMatch>> _matchComparer = null!;
+    private Mock<IEqualityComparer<GameMatchOption?>> _matchOptionComparer = null!;
+    private Mock<IEqualityComparer<ICollection<GamePlayer>>> _oneEightiesComparer = null!;
+    private Mock<IEqualityComparer<ICollection<NotablePlayer>>> _hiChecksComparer = null!;
+
+    [SetUp]
+    public void SetupEachTest()
+    {
+        _teamComparer = new Mock<IEqualityComparer<GameTeam>>();
+        _matchComparer = new Mock<IEqualityComparer<GameMatch>>();
+        _matchOptionComparer = new Mock<IEqualityComparer<GameMatchOption?>>();
+        _oneEightiesComparer = new Mock<IEqualityComparer<ICollection<GamePlayer>>>();
+        _hiChecksComparer = new Mock<IEqualityComparer<ICollection<NotablePlayer>>>();
+
+        _comparer = new GameComparer(
+            _teamComparer.Object,
+            _matchComparer.Object,
+            _matchOptionComparer.Object,
+            _oneEightiesComparer.Object,
+            _hiChecksComparer.Object);
+    }
+
+    [Test]
+    public void Equals_WhenGivenBothNull_ReturnsTrue()
+    {
+        var result = _comparer.Equals(null, null);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_WhenFirstIsNull_ReturnsFalse()
+    {
+        var result = _comparer.Equals(null, new CosmosGame());
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenSecondIsNull_ReturnsFalse()
+    {
+        var result = _comparer.Equals(new CosmosGame(), null);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenIdsAreDifferent_ReturnsFalse()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        x.Id = Guid.NewGuid();
+        y.Id = Guid.NewGuid();
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(true);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(true);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(true);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(true);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(true);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenDatesAreDifferent_ReturnsFalse()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        x.Date = DateTime.Today;
+        y.Date = DateTime.Today.AddDays(1);
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(true);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(true);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(true);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(true);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(true);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenDivisionsAreDifferent_ReturnsFalse()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        x.DivisionId = Guid.NewGuid();
+        y.DivisionId = Guid.NewGuid();
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(true);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(true);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(true);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(true);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(true);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenSeasonsAreDifferent_ReturnsFalse()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        x.SeasonId = Guid.NewGuid();
+        y.SeasonId = Guid.NewGuid();
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(true);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(true);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(true);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(true);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(true);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenHomeTeamsAreDifferent_ReturnsFalse()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(false);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(true);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(true);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(true);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(true);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenAwayTeamsAreDifferent_ReturnsFalse()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(true);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(false);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(true);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(true);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(true);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenMatchesAreDifferent_ReturnsFalse()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(true);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(true);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(false);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(true);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(true);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenMatchOptionsAreDifferent_ReturnsFalse()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(true);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(true);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(true);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(false);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(true);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_When180sAreDifferent_ReturnsFalse()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(true);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(true);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(true);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(true);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(false);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenHiChecksAreDifferent_ReturnsFalse()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(true);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(true);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(true);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(true);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(true);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(false);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenEverythingEqual_ReturnsTrue()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(true);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(true);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(true);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(true);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(true);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void GetHashCode_WhenEverythingEqual_ReturnsSameHashCode()
+    {
+        var x = CreateGame();
+        var y = CreateGame();
+        _teamComparer.Setup(c => c.Equals(x.Home, y.Home)).Returns(true);
+        _teamComparer.Setup(c => c.Equals(x.Away, y.Away)).Returns(true);
+        _matchComparer.Setup(c => c.Equals(x.Matches[0], y.Matches[0])).Returns(true);
+        _matchOptionComparer.Setup(c => c.Equals(x.MatchOptions[0], y.MatchOptions[0])).Returns(true);
+        _oneEightiesComparer.Setup(c => c.Equals(x.OneEighties, y.OneEighties)).Returns(true);
+        _hiChecksComparer.Setup(c => c.Equals(x.Over100Checkouts, y.Over100Checkouts)).Returns(true);
+
+        var hashCodeX = _comparer.GetHashCode(x);
+        var hashCodeY = _comparer.GetHashCode(y);
+
+        Assert.That(hashCodeX, Is.EqualTo(hashCodeY));
+    }
+
+    private static CosmosGame CreateGame()
+    {
+        return new CosmosGame
+        {
+            Id = Guid.Parse("18A8B71C-6A4C-4A71-B082-693DCC29113B"),
+            Date = new DateTime(2001, 02, 03),
+            Home = new GameTeam(),
+            Away = new GameTeam(),
+            Matches =
+            {
+                new GameMatch(),
+            },
+            MatchOptions =
+            {
+                new GameMatchOption(),
+            },
+            DivisionId = Guid.Parse("4E4B2CEE-72F7-4AD4-809A-B7F3A36FBD43"),
+            SeasonId = Guid.Parse("4AE5BCF9-64AA-4C1E-B420-D1AD5232028C"),
+            OneEighties =
+            {
+                new GamePlayer(),
+            },
+            Over100Checkouts =
+            {
+                new NotablePlayer(),
+            },
+        };
+    }
+}

--- a/CourageScores.Tests/Services/Game/GameMatchComparerTests.cs
+++ b/CourageScores.Tests/Services/Game/GameMatchComparerTests.cs
@@ -1,0 +1,152 @@
+using CourageScores.Models.Cosmos.Game;
+using CourageScores.Services.Game;
+using Moq;
+using NUnit.Framework;
+
+namespace CourageScores.Tests.Services.Game;
+
+[TestFixture]
+public class GameMatchComparerTests
+{
+    private GameMatchComparer _comparer = null!;
+    private Mock<IEqualityComparer<ICollection<GamePlayer>>> _playerComparer = null!;
+
+    [SetUp]
+    public void SetupEachTest()
+    {
+        _playerComparer = new Mock<IEqualityComparer<ICollection<GamePlayer>>>();
+
+        _comparer = new GameMatchComparer(_playerComparer.Object);
+    }
+
+    [Test]
+    public void Equals_WhenGivenBothNull_ReturnsTrue()
+    {
+        var result = _comparer.Equals(null, null);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_WhenFirstIsNull_ReturnsFalse()
+    {
+        var result = _comparer.Equals(null, new GameMatch());
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenSecondIsNull_ReturnsFalse()
+    {
+        var result = _comparer.Equals(new GameMatch(), null);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentHomeScores_ReturnsFalse()
+    {
+        var x = CreateMatch();
+        var y = CreateMatch();
+        x.HomeScore = 1;
+        y.HomeScore = 2;
+        _playerComparer.Setup(c => c.Equals(x.HomePlayers, y.HomePlayers)).Returns(true);
+        _playerComparer.Setup(c => c.Equals(x.AwayPlayers, y.AwayPlayers)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+
+    }
+
+    [Test]
+    public void Equals_GivenDifferentAwayScores_ReturnsFalse()
+    {
+        var x = CreateMatch();
+        var y = CreateMatch();
+        x.AwayScore = 1;
+        y.AwayScore = 2;
+        _playerComparer.Setup(c => c.Equals(x.HomePlayers, y.HomePlayers)).Returns(true);
+        _playerComparer.Setup(c => c.Equals(x.AwayPlayers, y.AwayPlayers)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentHomePlayers_ReturnsFalse()
+    {
+        var x = CreateMatch();
+        var y = CreateMatch();
+        _playerComparer.Setup(c => c.Equals(x.HomePlayers, y.HomePlayers)).Returns(false);
+        _playerComparer.Setup(c => c.Equals(x.AwayPlayers, y.AwayPlayers)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentAwayPlayers_ReturnsFalse()
+    {
+        var x = CreateMatch();
+        var y = CreateMatch();
+        _playerComparer.Setup(c => c.Equals(x.HomePlayers, y.HomePlayers)).Returns(true);
+        _playerComparer.Setup(c => c.Equals(x.AwayPlayers, y.AwayPlayers)).Returns(false);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenSameMatch_ReturnsTrue()
+    {
+        var x = CreateMatch();
+        var y = CreateMatch();
+        _playerComparer.Setup(c => c.Equals(x.HomePlayers, y.HomePlayers)).Returns(true);
+        _playerComparer.Setup(c => c.Equals(x.AwayPlayers, y.AwayPlayers)).Returns(true);
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameMatch_ReturnsSameHashCode()
+    {
+        var x = CreateMatch();
+        var y = CreateMatch();
+
+        var hashCodeX = _comparer.GetHashCode(x);
+        var hashCodeY = _comparer.GetHashCode(y);
+
+        Assert.That(hashCodeX, Is.EqualTo(hashCodeY));
+    }
+
+    private static GameMatch CreateMatch()
+    {
+        return new GameMatch
+        {
+            HomePlayers =
+            {
+                new GamePlayer
+                {
+                    Id = Guid.Parse("32DD0C64-98D7-4704-9CED-A7310F751BC2"),
+                    Name = "HOME PLAYER",
+                },
+            },
+            AwayPlayers =
+            {
+                new GamePlayer
+                {
+                    Id = Guid.Parse("C9A104C3-5D05-4F73-BA33-0BC1843132CE"),
+                    Name = "AWAY PLAYER",
+                },
+            },
+            HomeScore = 2,
+            AwayScore = 1,
+        };
+    }
+}

--- a/CourageScores.Tests/Services/Game/GameMatchOptionComparerTests.cs
+++ b/CourageScores.Tests/Services/Game/GameMatchOptionComparerTests.cs
@@ -1,0 +1,115 @@
+using CourageScores.Models.Cosmos.Game;
+using CourageScores.Services.Game;
+using NUnit.Framework;
+
+namespace CourageScores.Tests.Services.Game;
+
+[TestFixture]
+public class GameMatchOptionComparerTests
+{
+    private readonly GameMatchOptionComparer _comparer = new GameMatchOptionComparer();
+
+    [Test]
+    public void Equals_WhenGivenBothNull_ReturnsTrue()
+    {
+        var result = _comparer.Equals(null, null);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_WhenFirstIsNull_ReturnsFalse()
+    {
+        var result = _comparer.Equals(null, new GameMatchOption());
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenSecondIsNull_ReturnsFalse()
+    {
+        var result = _comparer.Equals(new GameMatchOption(), null);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentStartingScores_ReturnsFalse()
+    {
+        var x = CreateMatchOption();
+        var y = CreateMatchOption();
+        x.StartingScore = 501;
+        y.StartingScore = 601;
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentNumberOfLegs_ReturnsFalse()
+    {
+        var x = CreateMatchOption();
+        var y = CreateMatchOption();
+        x.NumberOfLegs = 5;
+        y.NumberOfLegs = 3;
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentPlayerCounts_ReturnsFalse()
+    {
+        var x = CreateMatchOption();
+        var y = CreateMatchOption();
+        x.PlayerCount = 2;
+        y.PlayerCount = 1;
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenSameMatchOptions_ReturnsTrue()
+    {
+        var x = CreateMatchOption();
+        var y = CreateMatchOption();
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void GetHashCode_GivenSameMatchOptions_ReturnsSameHashCode()
+    {
+        var x = CreateMatchOption();
+        var y = CreateMatchOption();
+
+        var hashCodeX = _comparer.GetHashCode(x);
+        var hashCodeY = _comparer.GetHashCode(y);
+
+        Assert.That(hashCodeX, Is.EqualTo(hashCodeY));
+    }
+
+    [Test]
+    public void GetHashCode_GivenNull_Returns0()
+    {
+        var hashCode = _comparer.GetHashCode(null);
+
+        Assert.That(hashCode, Is.EqualTo(0));
+    }
+
+    private static GameMatchOption CreateMatchOption()
+    {
+        return new GameMatchOption
+        {
+            PlayerCount = 1,
+            StartingScore = 501,
+            NumberOfLegs = 3,
+        };
+    }
+}

--- a/CourageScores.Tests/Services/Game/GamePlayerComparerTests.cs
+++ b/CourageScores.Tests/Services/Game/GamePlayerComparerTests.cs
@@ -1,0 +1,187 @@
+using CourageScores.Models.Cosmos.Game;
+using CourageScores.Services.Game;
+using NUnit.Framework;
+
+namespace CourageScores.Tests.Services.Game;
+
+[TestFixture]
+public class GamePlayerComparerTests
+{
+    private readonly GamePlayerComparer _comparer = new GamePlayerComparer();
+
+    [Test]
+    public void Equals_GivenEmptyList_ReturnsTrue()
+    {
+        var result = _comparer.Equals(Array.Empty<GamePlayer>(), Array.Empty<GamePlayer>());
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameItemsInSameOrder_ReturnsTrue()
+    {
+        var x = new[] { CreatePlayer("1"), CreatePlayer("2") };
+        var y = new[] { CreatePlayer("1"), CreatePlayer("2") };
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameItemsInDifferentOrder_ReturnsTrue()
+    {
+        var x = new[] { CreatePlayer("2"), CreatePlayer("1") };
+        var y = new[] { CreatePlayer("1"), CreatePlayer("2") };
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentItems_ReturnsFalse()
+    {
+        var x = new[] { CreatePlayer("2"), CreatePlayer("1") };
+        var y = new[] { CreatePlayer("3"), CreatePlayer("4") };
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentIds_ReturnsFalse()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+        x.Id = Guid.NewGuid();
+        y.Id = Guid.NewGuid();
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentNames_ReturnsFalse()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+        x.Name = "AA";
+        y.Name = "BB";
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenNullItemInX_ReturnsFalse()
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        var x = new GamePlayer[] { null };
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+        var y = new[] { CreatePlayer() };
+
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        var result = _comparer.Equals(x, y);
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenNullItemInY_ReturnsFalse()
+    {
+        var x = new[] { CreatePlayer() };
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        var y = new GamePlayer[] { null };
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        var result = _comparer.Equals(x, y);
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenOnlyNullItems_ReturnsTrue()
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        var x = new GamePlayer[] { null };
+        var y = new GamePlayer[] { null };
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameNamesExceptForWhitespace_ReturnsTrue()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+        x.Name = "AA  ";
+        y.Name = "AA ";
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameNamesExceptForCase_ReturnsTrue()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+        x.Name = "aa";
+        y.Name = "AA";
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSamePlayerProperties_ReturnsTrue()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void GetHashCode_GivenSamePlayerProperties_ReturnsSameHashCode()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+
+        var hashCodeX = _comparer.GetHashCode(x);
+        var hashCodeY = _comparer.GetHashCode(y);
+
+        Assert.That(hashCodeY, Is.EqualTo(hashCodeX));
+    }
+
+    [Test]
+    public void GetHashCode_GivenEmptyList_Returns0()
+    {
+        var hashCode = _comparer.GetHashCode(Array.Empty<NotablePlayer>());
+
+        Assert.That(hashCode, Is.EqualTo(0));
+    }
+
+    private static GamePlayer CreatePlayer(string name = "PLAYER")
+    {
+        return new GamePlayer
+        {
+            Id = Guid.Parse("32DD0C64-98D7-4704-9CED-A7310F751BC2"),
+            Name = name,
+        };
+    }
+}

--- a/CourageScores.Tests/Services/Game/GameServiceTests.cs
+++ b/CourageScores.Tests/Services/Game/GameServiceTests.cs
@@ -46,6 +46,10 @@ public class GameServiceTests
             DivisionId = Guid.NewGuid(),
             SeasonId = Guid.NewGuid(),
             IsKnockout = true,
+            Author = "GAME AUTHOR",
+            Editor = "GAME EDITOR",
+            Created = new DateTime(2005, 02, 03),
+            Updated = new DateTime(2006, 02, 03),
         };
         _user = new UserDto
         {
@@ -131,6 +135,10 @@ public class GameServiceTests
         _game!.HomeSubmission = new GameDto
         {
             Matches = new List<GameMatchDto>(),
+            Author = "AUTHOR",
+            Editor = "EDITOR",
+            Created = new DateTime(2001, 02, 03),
+            Updated = new DateTime(2002, 03, 04),
         };
         _game!.AwaySubmission = new GameDto
         {
@@ -143,10 +151,57 @@ public class GameServiceTests
 
         Assert.That(result!.Matches, Is.SameAs(_game.HomeSubmission.Matches));
         AssertSubmissionHasGameProperties(result, _game);
+        AssertHasAuditProperties(result, _game.HomeSubmission);
     }
 
     [Test]
-    public async Task Get_WhenResultsUnpublishedUserCanInputResultsForAwayTeam_ShouldReturnHomeTeamSubmission()
+    public async Task Get_WhenResultsUnpublishedUserCanInputResultsForHomeTeamAndNoHomeSubmissionAuditProperties_ShouldReturnAuditPropertiesFromGame()
+    {
+        _game!.HomeSubmission = new GameDto
+        {
+            Matches = new List<GameMatchDto>(),
+        };
+        _game!.AwaySubmission = new GameDto
+        {
+            Matches = new List<GameMatchDto>(),
+        };
+        _user!.Access!.InputResults = true;
+        _user.TeamId = _game.Home.Id;
+
+        var result = await _service.Get(_game!.Id, _token);
+
+        Assert.That(result!.Matches, Is.SameAs(_game.HomeSubmission.Matches));
+        AssertSubmissionHasGameProperties(result, _game);
+        AssertHasAuditProperties(result, _game);
+    }
+
+    [Test]
+    public async Task Get_WhenResultsUnpublishedUserCanInputResultsForAwayTeam_ShouldReturnAwayTeamSubmission()
+    {
+        _game!.HomeSubmission = new GameDto
+        {
+            Matches = new List<GameMatchDto>(),
+        };
+        _game!.AwaySubmission = new GameDto
+        {
+            Matches = new List<GameMatchDto>(),
+            Author = "AUTHOR",
+            Editor = "EDITOR",
+            Created = new DateTime(2001, 02, 03),
+            Updated = new DateTime(2002, 03, 04),
+        };
+        _user!.Access!.InputResults = true;
+        _user.TeamId = _game.Away.Id;
+
+        var result = await _service.Get(_game!.Id, _token);
+
+        Assert.That(result!.Matches, Is.SameAs(_game.AwaySubmission.Matches));
+        AssertSubmissionHasGameProperties(result, _game);
+        AssertHasAuditProperties(result, _game.AwaySubmission);
+    }
+
+    [Test]
+    public async Task Get_WhenResultsUnpublishedUserCanInputResultsForAwayTeamAndNoAwaySubmissionAuditProperties_ShouldReturnAuditPropertiesFromGame()
     {
         _game!.HomeSubmission = new GameDto
         {
@@ -163,6 +218,7 @@ public class GameServiceTests
 
         Assert.That(result!.Matches, Is.SameAs(_game.AwaySubmission.Matches));
         AssertSubmissionHasGameProperties(result, _game);
+        AssertHasAuditProperties(result, _game);
     }
 
     [Test]
@@ -226,6 +282,10 @@ public class GameServiceTests
         _game!.HomeSubmission = new GameDto
         {
             Matches = new List<GameMatchDto>(),
+            Author = "AUTHOR",
+            Editor = "EDITOR",
+            Created = new DateTime(2001, 02, 03),
+            Updated = new DateTime(2002, 03, 04),
         };
         _game!.AwaySubmission = new GameDto
         {
@@ -238,10 +298,11 @@ public class GameServiceTests
 
         Assert.That(games.Single().Matches, Is.SameAs(_game.HomeSubmission.Matches));
         AssertSubmissionHasGameProperties(games.Single(), _game);
+        AssertHasAuditProperties(games.Single(), _game.HomeSubmission);
     }
 
     [Test]
-    public async Task GetAll_WhenResultsUnpublishedUserCanInputResultsForAwayTeam_ShouldReturnHomeTeamSubmission()
+    public async Task GetAll_WhenResultsUnpublishedUserCanInputResultsForAwayTeam_ShouldReturnAwayTeamSubmission()
     {
         _game!.HomeSubmission = new GameDto
         {
@@ -250,6 +311,10 @@ public class GameServiceTests
         _game!.AwaySubmission = new GameDto
         {
             Matches = new List<GameMatchDto>(),
+            Author = "AUTHOR",
+            Editor = "EDITOR",
+            Created = new DateTime(2001, 02, 03),
+            Updated = new DateTime(2002, 03, 04),
         };
         _user!.Access!.InputResults = true;
         _user.TeamId = _game.Away.Id;
@@ -258,6 +323,7 @@ public class GameServiceTests
 
         Assert.That(games.Single().Matches, Is.SameAs(_game.AwaySubmission.Matches));
         AssertSubmissionHasGameProperties(games.Single(), _game);
+        AssertHasAuditProperties(games.Single(), _game.AwaySubmission);
     }
 
     [Test]
@@ -321,6 +387,10 @@ public class GameServiceTests
         _game!.HomeSubmission = new GameDto
         {
             Matches = new List<GameMatchDto>(),
+            Author = "AUTHOR",
+            Editor = "EDITOR",
+            Created = new DateTime(2001, 02, 03),
+            Updated = new DateTime(2002, 03, 04),
         };
         _game!.AwaySubmission = new GameDto
         {
@@ -333,10 +403,11 @@ public class GameServiceTests
 
         Assert.That(games.Single().Matches, Is.SameAs(_game.HomeSubmission.Matches));
         AssertSubmissionHasGameProperties(games.Single(), _game);
+        AssertHasAuditProperties(games.Single(), _game.HomeSubmission);
     }
 
     [Test]
-    public async Task GetWhere_WhenResultsUnpublishedUserCanInputResultsForAwayTeam_ShouldReturnHomeTeamSubmission()
+    public async Task GetWhere_WhenResultsUnpublishedUserCanInputResultsForAwayTeam_ShouldReturnAwayTeamSubmission()
     {
         _game!.HomeSubmission = new GameDto
         {
@@ -345,6 +416,10 @@ public class GameServiceTests
         _game!.AwaySubmission = new GameDto
         {
             Matches = new List<GameMatchDto>(),
+            Author = "AUTHOR",
+            Editor = "EDITOR",
+            Created = new DateTime(2001, 02, 03),
+            Updated = new DateTime(2002, 03, 04),
         };
         _user!.Access!.InputResults = true;
         _user.TeamId = _game.Away.Id;
@@ -352,7 +427,7 @@ public class GameServiceTests
         var games = await _service.GetWhere("query", _token).ToList();
 
         Assert.That(games.Single().Matches, Is.SameAs(_game.AwaySubmission.Matches));
-        AssertSubmissionHasGameProperties(games.Single(), _game);
+        AssertSubmissionHasGameProperties(games.Single(), _game.AwaySubmission);
     }
 
     [TestCase(false, false)]
@@ -450,5 +525,13 @@ public class GameServiceTests
         Assert.That(submission.DivisionId, Is.EqualTo(game.DivisionId));
         Assert.That(submission.IsKnockout, Is.EqualTo(game.IsKnockout));
         Assert.That(submission.SeasonId, Is.EqualTo(game.SeasonId));
+    }
+
+    private static void AssertHasAuditProperties(AuditedDto actual, AuditedDto expected)
+    {
+        Assert.That(actual.Author, Is.EqualTo(expected.Author));
+        Assert.That(actual.Created, Is.EqualTo(expected.Created));
+        Assert.That(actual.Editor, Is.EqualTo(expected.Editor));
+        Assert.That(actual.Updated, Is.EqualTo(expected.Updated));
     }
 }

--- a/CourageScores.Tests/Services/Game/GameServiceTests.cs
+++ b/CourageScores.Tests/Services/Game/GameServiceTests.cs
@@ -1,6 +1,8 @@
+using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Game;
 using CourageScores.Models.Dtos.Identity;
 using CourageScores.Services;
+using CourageScores.Services.Command;
 using CourageScores.Services.Game;
 using CourageScores.Services.Identity;
 using Moq;
@@ -351,6 +353,90 @@ public class GameServiceTests
 
         Assert.That(games.Single().Matches, Is.SameAs(_game.AwaySubmission.Matches));
         AssertSubmissionHasGameProperties(games.Single(), _game);
+    }
+
+    [TestCase(false, false)]
+    [TestCase(true, false)]
+    public async Task Delete_WhenNotPermitted_ExcludesSubmissionsFromResult(bool loggedIn, bool inputResults)
+    {
+        _game!.HomeSubmission = new GameDto();
+        _game!.AwaySubmission = new GameDto();
+        _user!.Access!.InputResults = inputResults;
+        _user = loggedIn ? _user : null;
+        _underlyingService.Setup(s => s.Delete(_game.Id, _token)).ReturnsAsync(() => new ActionResultDto<GameDto>
+        {
+            Result = _game,
+            Success = true,
+        });
+
+        var game = await _service.Delete(_game.Id, _token);
+
+        _underlyingService.Verify(s => s.Delete(_game.Id, _token));
+        Assert.That(game.Result!.HomeSubmission, Is.Null);
+        Assert.That(game.Result!.AwaySubmission, Is.Null);
+    }
+
+    [TestCase(false, false)]
+    [TestCase(true, false)]
+    public async Task Delete_WhenNotPermitted_ReturnsNull(bool loggedIn, bool inputResults)
+    {
+        _game!.HomeSubmission = new GameDto();
+        _game!.AwaySubmission = new GameDto();
+        _user!.Access!.InputResults = inputResults;
+        _user = loggedIn ? _user : null;
+        _underlyingService.Setup(s => s.Delete(_game.Id, _token)).ReturnsAsync(() => new ActionResultDto<GameDto>
+        {
+            Result = null,
+            Success = true,
+        });
+
+        var game = await _service.Delete(_game.Id, _token);
+
+        _underlyingService.Verify(s => s.Delete(_game.Id, _token));
+        Assert.That(game.Result, Is.Null);
+    }
+
+    [TestCase(false, false)]
+    [TestCase(true, false)]
+    public async Task Upsert_WhenNotPermitted_ExcludesSubmissionsFromResult(bool loggedIn, bool inputResults)
+    {
+        _game!.HomeSubmission = new GameDto();
+        _game!.AwaySubmission = new GameDto();
+        _user!.Access!.InputResults = inputResults;
+        _user = loggedIn ? _user : null;
+        var command = new Mock<IUpdateCommand<CosmosGame, CosmosGame>>();
+        _underlyingService.Setup(s => s.Upsert(_game.Id, command.Object, _token)).ReturnsAsync(() => new ActionResultDto<GameDto>
+        {
+            Result = _game,
+            Success = true,
+        });
+
+        var game = await _service.Upsert(_game.Id, command.Object, _token);
+
+        _underlyingService.Verify(s => s.Upsert(_game.Id, command.Object, _token));
+        Assert.That(game.Result!.HomeSubmission, Is.Null);
+        Assert.That(game.Result!.AwaySubmission, Is.Null);
+    }
+
+    [TestCase(false, false)]
+    [TestCase(true, false)]
+    public async Task Upsert_WhenNotPermitted_ReturnsNull(bool loggedIn, bool inputResults)
+    {
+        _game!.HomeSubmission = new GameDto();
+        _game!.AwaySubmission = new GameDto();
+        _user!.Access!.InputResults = inputResults;
+        _user = loggedIn ? _user : null;
+        var command = new Mock<IUpdateCommand<CosmosGame, CosmosGame>>();
+        _underlyingService.Setup(s => s.Upsert(_game.Id, command.Object, _token)).ReturnsAsync(() => new ActionResultDto<GameDto>
+        {
+            Result = null,
+            Success = true,
+        });
+
+        var game = await _service.Upsert(_game.Id, command.Object, _token);
+
+        _underlyingService.Verify(s => s.Upsert(_game.Id, command.Object, _token));
+        Assert.That(game.Result, Is.Null);
     }
 
     private static void AssertSubmissionHasGameProperties(GameDto submission, GameDto game)

--- a/CourageScores.Tests/Services/Game/GameTeamComparerTests.cs
+++ b/CourageScores.Tests/Services/Game/GameTeamComparerTests.cs
@@ -1,0 +1,120 @@
+using CourageScores.Models.Cosmos.Game;
+using CourageScores.Services.Game;
+using NUnit.Framework;
+
+namespace CourageScores.Tests.Services.Game;
+
+[TestFixture]
+public class GameTeamComparerTests
+{
+    private readonly GameTeamComparer _comparer = new GameTeamComparer();
+
+    [Test]
+    public void Equals_WhenGivenBothNull_ReturnsTrue()
+    {
+        var result = _comparer.Equals(null, null);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_WhenFirstIsNull_ReturnsFalse()
+    {
+        var result = _comparer.Equals(null, new GameTeam());
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_WhenSecondIsNull_ReturnsFalse()
+    {
+        var result = _comparer.Equals(new GameTeam(), null);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentIds_ReturnsFalse()
+    {
+        var x = CreateTeam();
+        var y = CreateTeam();
+        x.Id = Guid.NewGuid();
+        y.Id = Guid.NewGuid();
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentNames_ReturnsFalse()
+    {
+        var x = CreateTeam();
+        var y = CreateTeam();
+        x.Name = "A";
+        y.Name = "B";
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenSameTeamNameExceptForWhitespace_ReturnsTrue()
+    {
+        var x = CreateTeam();
+        var y = CreateTeam();
+        x.Name = "A  ";
+        y.Name = "A ";
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameTeamNameExceptForCase_ReturnsTrue()
+    {
+        var x = CreateTeam();
+        var y = CreateTeam();
+        x.Name = "A";
+        y.Name = "a";
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameTeam_ReturnsTrue()
+    {
+        var x = CreateTeam();
+        var y = CreateTeam();
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameTeam_ReturnsSameHashCode()
+    {
+        var x = CreateTeam();
+        var y = CreateTeam();
+
+        var hashCodeX = _comparer.GetHashCode(x);
+        var hashCodeY = _comparer.GetHashCode(y);
+
+        Assert.That(hashCodeX, Is.EqualTo(hashCodeY));
+    }
+
+    private static GameTeam CreateTeam()
+    {
+        return new GameTeam
+        {
+            Id = Guid.Parse("6FDBB4C8-5050-468C-B6AA-EA8C6CF7244D"),
+            Name = "HOME",
+            ManOfTheMatch = Guid.Parse("589DF698-3E0F-4A0E-949C-73995A1302CE"),
+        };
+    }
+}

--- a/CourageScores.Tests/Services/Game/HiChecksComparerTests.cs
+++ b/CourageScores.Tests/Services/Game/HiChecksComparerTests.cs
@@ -1,0 +1,240 @@
+using CourageScores.Models.Cosmos.Game;
+using CourageScores.Services.Game;
+using NUnit.Framework;
+
+namespace CourageScores.Tests.Services.Game;
+
+[TestFixture]
+public class HiChecksComparerTests
+{
+    private readonly HiChecksComparer _comparer = new HiChecksComparer();
+
+    [Test]
+    public void Equals_GivenBothNull_ReturnsTrue()
+    {
+        ICollection<NotablePlayer>? players = null;
+
+        var result = _comparer.Equals(players, players);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenXIsNull_ReturnsFalse()
+    {
+        var result = _comparer.Equals(Array.Empty<NotablePlayer>(), null);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenYIsNull_ReturnsFalse()
+    {
+        var result = _comparer.Equals(null, Array.Empty<NotablePlayer>());
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenEmptyList_ReturnsTrue()
+    {
+        var result = _comparer.Equals(Array.Empty<NotablePlayer>(), Array.Empty<NotablePlayer>());
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameItemsInSameOrder_ReturnsTrue()
+    {
+        var x = new[] { CreatePlayer("1"), CreatePlayer("2") };
+        var y = new[] { CreatePlayer("1"), CreatePlayer("2") };
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameItemsInDifferentOrder_ReturnsTrue()
+    {
+        var x = new[] { CreatePlayer("2"), CreatePlayer("1") };
+        var y = new[] { CreatePlayer("1"), CreatePlayer("2") };
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentItems_ReturnsFalse()
+    {
+        var x = new[] { CreatePlayer("2"), CreatePlayer("1") };
+        var y = new[] { CreatePlayer("3"), CreatePlayer("4") };
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenNullItemInX_ReturnsFalse()
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        var x = new NotablePlayer[] { null };
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+        var y = new[] { CreatePlayer("1") };
+
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        var result = _comparer.Equals(x, y);
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenNullItemInY_ReturnsFalse()
+    {
+        var x = new[] { CreatePlayer("1") };
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        var y = new NotablePlayer[] { null };
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        var result = _comparer.Equals(x, y);
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenOnlyNullItems_ReturnsTrue()
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        var x = new NotablePlayer[] { null };
+        var y = new NotablePlayer[] { null };
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentIds_ReturnsFalse()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+        x.Id = Guid.NewGuid();
+        y.Id = Guid.NewGuid();
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentNames_ReturnsFalse()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+        x.Name = "AA";
+        y.Name = "BB";
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenDifferentNotes_ReturnsFalse()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+        x.Notes = "100";
+        y.Notes = "110";
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_GivenSameNamesExceptForWhitespace_ReturnsTrue()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+        x.Name = "AA  ";
+        y.Name = "AA ";
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameNamesExceptForCase_ReturnsTrue()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+        x.Name = "AA";
+        y.Name = "aa";
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSameNotesExceptForWhitespace_ReturnsTrue()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+        x.Notes = "110  ";
+        y.Notes = "110 ";
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Equals_GivenSamePlayerProperties_ReturnsTrue()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+
+        var result = _comparer.Equals(x, y);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void GetHashCode_GivenSamePlayerProperties_ReturnsSameHashCode()
+    {
+        var x = CreatePlayer();
+        var y = CreatePlayer();
+
+        var hashCodeX = _comparer.GetHashCode(x);
+        var hashCodeY = _comparer.GetHashCode(y);
+
+        Assert.That(hashCodeY, Is.EqualTo(hashCodeX));
+    }
+
+    [Test]
+    public void GetHashCode_GivenEmptyList_Returns0()
+    {
+        var hashCode = _comparer.GetHashCode(Array.Empty<NotablePlayer>());
+
+        Assert.That(hashCode, Is.EqualTo(0));
+    }
+
+    private static NotablePlayer CreatePlayer(string name = "PLAYER")
+    {
+        return new NotablePlayer
+        {
+            Id = Guid.Parse("32DD0C64-98D7-4704-9CED-A7310F751BC2"),
+            Name = name,
+            Notes = "120",
+        };
+    }
+}

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/ManOfTheMatchInput.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/ManOfTheMatchInput.js
@@ -3,7 +3,7 @@ import React from "react";
 import {distinct, sortBy} from "../../../helpers/collections";
 import {useApp} from "../../../AppContainer";
 
-export function ManOfTheMatchInput({fixtureData, access, saving, setFixtureData}) {
+export function ManOfTheMatchInput({fixtureData, access, saving, setFixtureData, disabled}) {
     const {account, onError} = useApp();
 
     function manOfTheMatchChanged(player, team) {
@@ -46,7 +46,7 @@ export function ManOfTheMatchInput({fixtureData, access, saving, setFixtureData}
             <td colSpan="2" className="text-end">
                 {account.teamId === fixtureData.home.id || access === 'admin' ? (<PlayerSelection
                     players={applicablePlayers()}
-                    disabled={access === 'readonly'}
+                    disabled={disabled || access === 'readonly'}
                     readOnly={saving}
                     selected={{id: fixtureData.home.manOfTheMatch}}
                     onChange={(elem, player) => manOfTheMatchChanged(player, 'home')}/>) : (<span>n/a</span>)}
@@ -55,7 +55,7 @@ export function ManOfTheMatchInput({fixtureData, access, saving, setFixtureData}
             <td colSpan="2">
                 {account.teamId === fixtureData.away.id || access === 'admin' ? (<PlayerSelection
                     players={applicablePlayers()}
-                    disabled={access === 'readonly'}
+                    disabled={disabled || access === 'readonly'}
                     readOnly={saving}
                     selected={{id: fixtureData.away.manOfTheMatch}}
                     onChange={(elem, player) => manOfTheMatchChanged(player, 'away')}/>) : (<span>n/a</span>)}

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/ManOfTheMatchInput.test.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/ManOfTheMatchInput.test.js
@@ -17,7 +17,7 @@ describe('ManOfTheMatchInput', () => {
         cleanUp(context);
     });
 
-    async function renderComponent(saving, account, fixtureData, access) {
+    async function renderComponent(saving, account, fixtureData, access, disabled) {
         reportedError = null;
         updatedFixtureData = null;
         context = await renderApp(
@@ -36,7 +36,8 @@ describe('ManOfTheMatchInput', () => {
                 saving={saving}
                 access={access}
                 fixtureData={fixtureData}
-                setFixtureData={setFixtureData}/>),
+                setFixtureData={setFixtureData}
+                disabled={disabled} />),
             null,
             null,
             'tbody');
@@ -45,10 +46,10 @@ describe('ManOfTheMatchInput', () => {
     function assertPlayers(container, names, displayed, selected) {
         names.unshift(' ');
 
-        const homePlayers = container.querySelectorAll('div.btn-group div[role="menu"] button[role="menuitem"]');
+        const players = container.querySelectorAll('div.btn-group div[role="menu"] button[role="menuitem"]');
         const displayedPlayer = container.querySelector('div.btn-group > button > span');
         const selectedPlayer = container.querySelector('div.btn-group div[role="menu"] button[role="menuitem"].active');
-        expect(Array.from(homePlayers).map(span => span.textContent)).toEqual(names);
+        expect(Array.from(players).map(span => span.textContent)).toEqual(names);
         expect(displayedPlayer.textContent).toEqual(displayed);
         if (selected) {
             expect(selectedPlayer).toBeTruthy();
@@ -61,12 +62,16 @@ describe('ManOfTheMatchInput', () => {
     }
 
     describe('when logged out', () => {
+        const account = null;
+        const saving = false;
+        const access = '';
+
         it('when no matches', async () => {
             const fixtureData = fixtureBuilder()
                 .playing('HOME', 'AWAY')
                 .build();
 
-            await renderComponent(false, null, fixtureData, '');
+            await renderComponent(saving, account, fixtureData, access);
 
             expect(context.container.innerHTML).toEqual('');
         });
@@ -77,7 +82,7 @@ describe('ManOfTheMatchInput', () => {
                 .withMatch(m => m.withHome().withAway())
                 .build();
 
-            await renderComponent(false, null, fixtureData, '');
+            await renderComponent(saving, account, fixtureData, access);
 
             expect(reportedError).toBeFalsy();
             expect(context.container.innerHTML).toEqual('');
@@ -91,7 +96,7 @@ describe('ManOfTheMatchInput', () => {
                 .withMatch(m => m.withHome(homePlayer).withAway(awayPlayer))
                 .build();
 
-            await renderComponent(false, null, fixtureData, '');
+            await renderComponent(saving, account, fixtureData, access);
 
             expect(reportedError).toBeFalsy();
             expect(context.container.innerHTML).toEqual('');
@@ -106,7 +111,7 @@ describe('ManOfTheMatchInput', () => {
                 .withMatch(m => m.withHome(homePlayer).withAway(awayPlayer))
                 .build();
 
-            await renderComponent(false, null, fixtureData, '');
+            await renderComponent(saving, account, fixtureData, access);
 
             expect(reportedError).toBeFalsy();
             expect(context.container.innerHTML).toEqual('');
@@ -121,7 +126,7 @@ describe('ManOfTheMatchInput', () => {
                 .withMatch(m => m.withHome(homePlayer).withAway(awayPlayer))
                 .build();
 
-            await renderComponent(false, null, fixtureData, '');
+            await renderComponent(saving, account, fixtureData, access);
 
             expect(reportedError).toBeFalsy();
             expect(context.container.innerHTML).toEqual('');
@@ -144,6 +149,24 @@ describe('ManOfTheMatchInput', () => {
                 expect(cells.length).toEqual(3);
                 assertPlayers(cells[0], [], ' ', null);
                 assertPlayers(cells[2], [], ' ', null);
+            });
+
+            it('when disabled', async () => {
+                const homePlayer = playerBuilder('HOME player').build();
+                const awayPlayer = playerBuilder('AWAY player').build();
+                const fixtureData = fixtureBuilder()
+                    .playing('HOME', 'AWAY')
+                    .manOfTheMatch(homePlayer, awayPlayer)
+                    .withMatch(m => m.withHome(homePlayer).withAway(awayPlayer))
+                    .build();
+
+                await renderComponent(false, account, fixtureData, 'admin', true);
+
+                expect(reportedError).toBeFalsy();
+                const cells = context.container.querySelectorAll('td');
+                expect(cells.length).toEqual(3);
+                expect(cells[0].querySelector('.dropdown-toggle').textContent).toEqual('HOME player');
+                expect(cells[2].querySelector('.dropdown-toggle').textContent).toEqual('AWAY player');
             });
 
             it('when no selected players', async () => {

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MatchPlayerSelection.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MatchPlayerSelection.js
@@ -215,7 +215,7 @@ export function MatchPlayerSelection({match, onMatchChanged, onMatchOptionsChang
             <td className={`${match.homeScore !== null && match.awayScore !== null && match.homeScore < match.awayScore ? 'bg-winner ' : ''}width-50-pc position-relative`}>
                 {matchOptionsDialogOpen ? renderMatchSettingsDialog() : null}
                 {readOnly ? null : (
-                    <button title={`${matchOptions.numberOfLegs} leg/s. Starting score: ${matchOptions.startingScore}`}
+                    <button tabIndex={-1} title={`${matchOptions.numberOfLegs} leg/s. Starting score: ${matchOptions.startingScore}`}
                             className="btn btn-sm right-0 position-absolute"
                             onClick={() => setMatchOptionsDialogOpen(true)}>🛠</button>)}
                 {repeat(matchOptions.playerCount).map(index => disabled

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MatchPlayerSelection.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MatchPlayerSelection.js
@@ -99,10 +99,14 @@ export function MatchPlayerSelection({match, onMatchChanged, onMatchOptionsChang
         }
     }
 
-    function exceptPlayers(playerIndex, propertyName) {
-        const exceptPlayerIds = distinct((otherMatches || []).flatMap(otherMatch => {
-            return (otherMatch[propertyName] || []).filter(p => p || false).map(player => player ? player.id : null);
-        }));
+    function exceptPlayers(playerIndex, side) {
+        const propertyName = side + 'Players';
+        const selectedPlayer = player(playerIndex, side);
+        const exceptPlayerIds = distinct((otherMatches || [])
+            .flatMap(otherMatch => {
+                return (otherMatch[propertyName] || []).filter(p => p || false).map(player => player ? player.id : null);
+            }))
+            .filter(id => id !== selectedPlayer.id); // dont exclude the currently selected player
 
         const playerList = match[propertyName];
         if (!playerList) {
@@ -110,7 +114,9 @@ export function MatchPlayerSelection({match, onMatchChanged, onMatchOptionsChang
         }
 
         const additionalPlayers = playerList.filter((_, index) => index !== playerIndex).map(player => player.id);
-        return exceptPlayerIds.concat(additionalPlayers);
+        return exceptPlayerIds
+            .concat(additionalPlayers)
+            .filter(id => id !== selectedPlayer.id); // dont exclude the currently selected player;
     }
 
     function renderMatchSettingsDialog() {
@@ -180,7 +186,7 @@ export function MatchPlayerSelection({match, onMatchChanged, onMatchOptionsChang
                         readOnly={readOnly}
                         players={homePlayers}
                         selected={player(index, 'home')}
-                        except={exceptPlayers(index, 'homePlayers')}
+                        except={exceptPlayers(index, 'home')}
                         onChange={(elem, player) => playerChanged(index, player, 'home')}/></div>))}
             </td>
             <td className={`narrow-column align-middle text-end ${match.homeScore !== null && match.awayScore !== null && match.homeScore > match.awayScore ? 'bg-winner' : ''}`}>
@@ -220,7 +226,7 @@ export function MatchPlayerSelection({match, onMatchChanged, onMatchOptionsChang
                             readOnly={readOnly}
                             players={awayPlayers}
                             selected={player(index, 'away')}
-                            except={exceptPlayers(index, 'awayPlayers')}
+                            except={exceptPlayers(index, 'away')}
                             onChange={(elem, player) => playerChanged(index, player, 'away')}/>
                     </div>))}
             </td>

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeHiCheckAnd180s.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeHiCheckAnd180s.js
@@ -31,9 +31,9 @@ export function MergeHiCheckAnd180s({fixtureData, data, setFixtureData}) {
     try {
         return (<tr>
             <td colSpan="2" className="text-end">
-                {(!fixtureData.oneEighties || isEmpty(fixtureData.oneEighties)) && (any(getRecordsToMerge('home', 'oneEighties')) || any(getRecordsToMerge('away', 'oneEighties')))
+                {any(getRecordsToMerge('home', 'oneEighties')) || any(getRecordsToMerge('home', 'over100Checkouts'))
                     ? (<div>
-                        {any(getRecordsToMerge('home', 'oneEighties')) ? (<div>
+                        {isEmpty(fixtureData.oneEighties || []) && any(getRecordsToMerge('home', 'oneEighties')) ? (<div datatype="home-180s">
                             <h6>
                                 from {data.homeSubmission.editor || 'Home'}
                                 <button className="btn btn-sm btn-success margin-left"
@@ -45,16 +45,16 @@ export function MergeHiCheckAnd180s({fixtureData, data, setFixtureData}) {
                                     <li key={rec.id}>{rec.name}</li>))}
                             </ol>
                         </div>) : null}
-                        {any(getRecordsToMerge('away', 'oneEighties')) ? (<div>
+                        {isEmpty(fixtureData.over100Checkouts || []) && any(getRecordsToMerge('home', 'over100Checkouts')) ? (<div datatype="home-hichecks">
                             <h6>
-                                from {data.awaySubmission.editor || 'Away'}
+                                from {data.homeSubmission.editor || 'Home'}
                                 <button className="btn btn-sm btn-success margin-left"
-                                        onClick={() => mergeRecords('away', 'oneEighties')}>Merge
+                                        onClick={() => mergeRecords('home', 'over100Checkouts')}>Merge
                                 </button>
                             </h6>
                             <ol className="d-inline-block">
-                                {getRecordsToMerge('away', 'oneEighties').map(rec => (
-                                    <li key={rec.id}>{rec.name}</li>))}
+                                {getRecordsToMerge('home', 'over100Checkouts').map(rec => (
+                                    <li key={rec.id}>{rec.name} ({rec.notes})</li>))}
                             </ol>
                         </div>) : null}
                     </div>)
@@ -67,21 +67,21 @@ export function MergeHiCheckAnd180s({fixtureData, data, setFixtureData}) {
                 </div>
             </td>
             <td colSpan="2">
-                {(!fixtureData.over100Checkouts || isEmpty(fixtureData.over100Checkouts)) && (any(getRecordsToMerge('home', 'over100Checkouts')) || any(getRecordsToMerge('away', 'over100Checkouts')))
+                {any(getRecordsToMerge('away', 'oneEighties')) || any(getRecordsToMerge('away', 'over100Checkouts'))
                     ? (<div>
-                        {any(getRecordsToMerge('home', 'over100Checkouts')) ? (<div>
+                        {isEmpty(fixtureData.oneEighties || []) && any(getRecordsToMerge('away', 'oneEighties')) ? (<div datatype="away-180s">
                             <h6>
-                                from {data.homeSubmission.editor || 'Home'}
+                                from {data.awaySubmission.editor || 'Away'}
                                 <button className="btn btn-sm btn-success margin-left"
-                                        onClick={() => mergeRecords('home', 'over100Checkouts')}>Merge
+                                        onClick={() => mergeRecords('away', 'oneEighties')}>Merge
                                 </button>
                             </h6>
                             <ol className="d-inline-block">
-                                {getRecordsToMerge('home', 'over100Checkouts').map(rec => (
-                                    <li key={rec.id}>{rec.name} ({rec.notes})</li>))}
+                                {getRecordsToMerge('away', 'oneEighties').map(rec => (
+                                    <li key={rec.id}>{rec.name}</li>))}
                             </ol>
                         </div>) : null}
-                        {any(getRecordsToMerge('away', 'over100Checkouts')) ? (<div>
+                        {isEmpty(fixtureData.over100Checkouts || []) && any(getRecordsToMerge('away', 'over100Checkouts')) ? (<div datatype="away-hichecks">
                             <h6>
                                 from {data.awaySubmission.editor || 'Away'}
                                 <button className="btn btn-sm btn-success margin-left"

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeHiCheckAnd180s.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeHiCheckAnd180s.js
@@ -30,7 +30,7 @@ export function MergeHiCheckAnd180s({fixtureData, data, setFixtureData}) {
 
     try {
         return (<tr>
-            <td colSpan="2">
+            <td colSpan="2" className="text-end">
                 {(!fixtureData.oneEighties || isEmpty(fixtureData.oneEighties)) && (any(getRecordsToMerge('home', 'oneEighties')) || any(getRecordsToMerge('away', 'oneEighties')))
                     ? (<div>
                         {any(getRecordsToMerge('home', 'oneEighties')) ? (<div>
@@ -40,7 +40,7 @@ export function MergeHiCheckAnd180s({fixtureData, data, setFixtureData}) {
                                         onClick={() => mergeRecords('home', 'oneEighties')}>Merge
                                 </button>
                             </h6>
-                            <ol>
+                            <ol className="d-inline-block">
                                 {getRecordsToMerge('home', 'oneEighties').map(rec => (
                                     <li key={rec.id}>{rec.name}</li>))}
                             </ol>
@@ -52,7 +52,7 @@ export function MergeHiCheckAnd180s({fixtureData, data, setFixtureData}) {
                                         onClick={() => mergeRecords('away', 'oneEighties')}>Merge
                                 </button>
                             </h6>
-                            <ol>
+                            <ol className="d-inline-block">
                                 {getRecordsToMerge('away', 'oneEighties').map(rec => (
                                     <li key={rec.id}>{rec.name}</li>))}
                             </ol>
@@ -76,7 +76,7 @@ export function MergeHiCheckAnd180s({fixtureData, data, setFixtureData}) {
                                         onClick={() => mergeRecords('home', 'over100Checkouts')}>Merge
                                 </button>
                             </h6>
-                            <ol>
+                            <ol className="d-inline-block">
                                 {getRecordsToMerge('home', 'over100Checkouts').map(rec => (
                                     <li key={rec.id}>{rec.name} ({rec.notes})</li>))}
                             </ol>
@@ -88,7 +88,7 @@ export function MergeHiCheckAnd180s({fixtureData, data, setFixtureData}) {
                                         onClick={() => mergeRecords('away', 'over100Checkouts')}>Merge
                                 </button>
                             </h6>
-                            <ol>
+                            <ol className="d-inline-block">
                                 {getRecordsToMerge('away', 'over100Checkouts').map(rec => (
                                     <li key={rec.id}>{rec.name} ({rec.notes})</li>))}
                             </ol>

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeHiCheckAnd180s.test.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeHiCheckAnd180s.test.js
@@ -49,10 +49,8 @@ describe('MergeHiCheckAnd180s', () => {
                 await renderComponent(data, fixtureData);
 
                 expect(reportedError).toBeNull();
-                const oneEightiesCell = context.container.querySelector('td:nth-child(1)');
-                expect(oneEightiesCell).toBeTruthy();
-                const homeSubmission = oneEightiesCell.querySelector('div > div:nth-child(1)');
-                expect(homeSubmission).toBeTruthy();
+                const homeSubmission = context.container.querySelector('div[datatype="home-180s"]');
+                expect(homeSubmission).not.toBeNull();
                 expect(homeSubmission.textContent).toContain('from HOME');
                 const oneEighties = Array.from(homeSubmission.querySelectorAll('ol > li')).map(li => li.textContent);
                 expect(oneEighties).toEqual(['NAME']);
@@ -68,10 +66,8 @@ describe('MergeHiCheckAnd180s', () => {
                 await renderComponent(data, fixtureData);
 
                 expect(reportedError).toBeNull();
-                const oneEightiesCell = context.container.querySelector('td:nth-child(1)');
-                expect(oneEightiesCell).toBeTruthy();
-                const awaySubmission = oneEightiesCell.querySelector('div > div:nth-child(1)');
-                expect(awaySubmission).toBeTruthy();
+                const awaySubmission = context.container.querySelector('div[datatype="away-180s"]');
+                expect(awaySubmission).not.toBeNull();
                 expect(awaySubmission.textContent).toContain('from AWAY');
                 const oneEighties = Array.from(awaySubmission.querySelectorAll('ol > li')).map(li => li.textContent);
                 expect(oneEighties).toEqual(['NAME']);
@@ -87,10 +83,10 @@ describe('MergeHiCheckAnd180s', () => {
                 await renderComponent(data, fixtureData);
 
                 expect(reportedError).toBeNull();
-                const oneEightiesCell = context.container.querySelector('td:nth-child(1)');
-                expect(oneEightiesCell).toBeTruthy();
-                const submissions = oneEightiesCell.querySelectorAll('div');
-                expect(submissions.length).toEqual(0);
+                const homeSubmission = context.container.querySelector('div[datatype="home-180s"]');
+                const awaySubmission = context.container.querySelector('div[datatype="away-180s"]');
+                expect(homeSubmission).toBeNull();
+                expect(awaySubmission).toBeNull();
             });
 
             it('when submissions merged', async () => {
@@ -105,10 +101,10 @@ describe('MergeHiCheckAnd180s', () => {
                 await renderComponent(data, fixtureData);
 
                 expect(reportedError).toBeNull();
-                const oneEightiesCell = context.container.querySelector('td:nth-child(1)');
-                expect(oneEightiesCell).toBeTruthy();
-                const submissions = oneEightiesCell.querySelectorAll('div');
-                expect(submissions.length).toEqual(0);
+                const homeSubmission = context.container.querySelector('div[datatype="home-180s"]');
+                const awaySubmission = context.container.querySelector('div[datatype="away-180s"]');
+                expect(homeSubmission).toBeNull();
+                expect(awaySubmission).toBeNull();
             });
 
             it('when no home submission', async () => {
@@ -120,8 +116,10 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent(data, fixtureData);
 
-                const oneEightiesCell = context.container.querySelector('td:nth-child(1)');
-                expect(oneEightiesCell.querySelectorAll('div > div').length).toEqual(1);
+                const homeSubmission = context.container.querySelector('div[datatype="home-180s"]');
+                const awaySubmission = context.container.querySelector('div[datatype="away-180s"]');
+                expect(homeSubmission).toBeNull();
+                expect(awaySubmission).not.toBeNull();
             });
 
             it('when no away submission', async () => {
@@ -133,8 +131,10 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent(data, fixtureData);
 
-                const oneEightiesCell = context.container.querySelector('td:nth-child(1)');
-                expect(oneEightiesCell.querySelectorAll('div > div').length).toEqual(1);
+                const homeSubmission = context.container.querySelector('div[datatype="home-180s"]');
+                const awaySubmission = context.container.querySelector('div[datatype="away-180s"]');
+                expect(homeSubmission).not.toBeNull();
+                expect(awaySubmission).toBeNull();
             });
 
             it('when no submissions', async () => {
@@ -145,8 +145,10 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent(data, fixtureData);
 
-                const oneEightiesCell = context.container.querySelector('td:nth-child(1)');
-                expect(oneEightiesCell.querySelectorAll('div > div').length).toEqual(0);
+                const homeSubmission = context.container.querySelector('div[datatype="home-180s"]');
+                const awaySubmission = context.container.querySelector('div[datatype="away-180s"]');
+                expect(homeSubmission).toBeNull();
+                expect(awaySubmission).toBeNull();
             });
         });
 
@@ -179,10 +181,9 @@ describe('MergeHiCheckAnd180s', () => {
                 const fixtureData = fixtureBuilder('2023-05-06')
                     .build();
                 await renderComponent(data, fixtureData);
-                const oneEightiesCell = context.container.querySelector('td:nth-child(1)');
-                const submission = oneEightiesCell.querySelector('div > div:nth-child(1)');
+                const awaySubmission = context.container.querySelector('div[datatype="away-180s"]');
 
-                await doClick(findButton(submission, 'Merge'));
+                await doClick(findButton(awaySubmission, 'Merge'));
 
                 expect(reportedError).toBeNull();
                 expect(updatedData).not.toBeNull();
@@ -204,10 +205,8 @@ describe('MergeHiCheckAnd180s', () => {
                 await renderComponent(data, fixtureData);
 
                 expect(reportedError).toBeNull();
-                const hiChecksCell = context.container.querySelector('td:nth-child(3)');
-                expect(hiChecksCell).toBeTruthy();
-                const homeSubmission = hiChecksCell.querySelector('div > div:nth-child(1)');
-                expect(homeSubmission).toBeTruthy();
+                const homeSubmission = context.container.querySelector('div[datatype="home-hichecks"]');
+                expect(homeSubmission).not.toBeNull();
                 expect(homeSubmission.textContent).toContain('from HOME');
                 const hiChecks = Array.from(homeSubmission.querySelectorAll('ol > li')).map(li => li.textContent);
                 expect(hiChecks).toEqual(['NAME (120)']);
@@ -224,12 +223,10 @@ describe('MergeHiCheckAnd180s', () => {
                 await renderComponent(data, fixtureData);
 
                 expect(reportedError).toBeNull();
-                const hiChecksCell = context.container.querySelector('td:nth-child(3)');
-                expect(hiChecksCell).toBeTruthy();
-                const homeSubmission = hiChecksCell.querySelector('div > div:nth-child(1)');
-                expect(homeSubmission).toBeTruthy();
-                expect(homeSubmission.textContent).toContain('from AWAY');
-                const hiChecks = Array.from(homeSubmission.querySelectorAll('ol > li')).map(li => li.textContent);
+                const awaySubmission = context.container.querySelector('div[datatype="away-hichecks"]');
+                expect(awaySubmission).not.toBeNull();
+                expect(awaySubmission.textContent).toContain('from AWAY');
+                const hiChecks = Array.from(awaySubmission.querySelectorAll('ol > li')).map(li => li.textContent);
                 expect(hiChecks).toEqual(['NAME (120)']);
             });
 
@@ -244,10 +241,10 @@ describe('MergeHiCheckAnd180s', () => {
                 await renderComponent(data, fixtureData);
 
                 expect(reportedError).toBeNull();
-                const hiChecksCell = context.container.querySelector('td:nth-child(3)');
-                expect(hiChecksCell).toBeTruthy();
-                const submissions = hiChecksCell.querySelectorAll('div > div');
-                expect(submissions.length).toEqual(0);
+                const homeSubmission = context.container.querySelector('div[datatype="home-hichecks"]');
+                const awaySubmission = context.container.querySelector('div[datatype="away-hichecks"]');
+                expect(homeSubmission).toBeNull();
+                expect(awaySubmission).toBeNull();
             });
 
             it('when submissions merged', async () => {
@@ -262,10 +259,10 @@ describe('MergeHiCheckAnd180s', () => {
                 await renderComponent(data, fixtureData);
 
                 expect(reportedError).toBeNull();
-                const hiChecksCell = context.container.querySelector('td:nth-child(3)');
-                expect(hiChecksCell).toBeTruthy();
-                const submissions = hiChecksCell.querySelectorAll('div > div');
-                expect(submissions.length).toEqual(0);
+                const homeSubmission = context.container.querySelector('div[datatype="home-hichecks"]');
+                const awaySubmission = context.container.querySelector('div[datatype="away-hichecks"]');
+                expect(homeSubmission).toBeNull();
+                expect(awaySubmission).toBeNull();
             });
 
             it('when no home submission', async () => {
@@ -277,8 +274,10 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent(data, fixtureData);
 
-                const oneEightiesCell = context.container.querySelector('td:nth-child(3)');
-                expect(oneEightiesCell.querySelectorAll('div > ol').length).toEqual(1);
+                const homeSubmission = context.container.querySelector('div[datatype="home-hichecks"]');
+                const awaySubmission = context.container.querySelector('div[datatype="away-hichecks"]');
+                expect(homeSubmission).toBeNull();
+                expect(awaySubmission).not.toBeNull();
             });
 
             it('when no away submission', async () => {
@@ -290,8 +289,10 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent(data, fixtureData);
 
-                const oneEightiesCell = context.container.querySelector('td:nth-child(3)');
-                expect(oneEightiesCell.querySelectorAll('div > ol').length).toEqual(1);
+                const homeSubmission = context.container.querySelector('div[datatype="home-hichecks"]');
+                const awaySubmission = context.container.querySelector('div[datatype="away-hichecks"]');
+                expect(homeSubmission).not.toBeNull();
+                expect(awaySubmission).toBeNull();
             });
 
             it('when no submissions', async () => {
@@ -302,8 +303,10 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent(data, fixtureData);
 
-                const oneEightiesCell = context.container.querySelector('td:nth-child(3)');
-                expect(oneEightiesCell.querySelectorAll('div > ol').length).toEqual(0);
+                const homeSubmission = context.container.querySelector('div[datatype="home-hichecks"]');
+                const awaySubmission = context.container.querySelector('div[datatype="away-hichecks"]');
+                expect(homeSubmission).toBeNull();
+                expect(awaySubmission).toBeNull();
             });
         });
 
@@ -317,10 +320,9 @@ describe('MergeHiCheckAnd180s', () => {
                 const fixtureData = fixtureBuilder('2023-05-06')
                     .build();
                 await renderComponent(data, fixtureData);
-                const hiChecksCell = context.container.querySelector('td:nth-child(3)');
-                const submission = hiChecksCell.querySelector('div > div:nth-child(1)');
+                const homeSubmission = context.container.querySelector('div[datatype="home-hichecks"]');
 
-                await doClick(findButton(submission, 'Merge'));
+                await doClick(findButton(homeSubmission, 'Merge'));
 
                 expect(reportedError).toBeNull();
                 expect(updatedData).not.toBeNull();
@@ -336,10 +338,9 @@ describe('MergeHiCheckAnd180s', () => {
                 const fixtureData = fixtureBuilder('2023-05-06')
                     .build();
                 await renderComponent(data, fixtureData);
-                const hiChecksCell = context.container.querySelector('td:nth-child(3)');
-                const submission = hiChecksCell.querySelector('div > div:nth-child(1)');
+                const awaySubmission = context.container.querySelector('div[datatype="away-hichecks"]');
 
-                await doClick(findButton(submission, 'Merge'));
+                await doClick(findButton(awaySubmission, 'Merge'));
 
                 expect(reportedError).toBeNull();
                 expect(updatedData).not.toBeNull();

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeManOfTheMatch.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeManOfTheMatch.js
@@ -22,7 +22,7 @@ export function MergeManOfTheMatch({data, setData, allPlayers}) {
     }
 
     return (<tr>
-        {data.home.manOfTheMatch ? (<td colSpan="2">Merged</td>) : (<td colSpan="2">
+        {data.home.manOfTheMatch ? (<td colSpan="2">Merged</td>) : (<td colSpan="2" className="text-end">
             {data.homeSubmission && data.homeSubmission.home.manOfTheMatch
                 ? (<button className="btn btn-success btn-sm" onClick={() => setManOfMatch('home', data.homeSubmission.home.manOfTheMatch)}>
                     Use {getName(data.homeSubmission.home.manOfTheMatch)}

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeManOfTheMatch.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeManOfTheMatch.js
@@ -16,21 +16,24 @@ export function MergeManOfTheMatch({data, setData, allPlayers}) {
         }
     }
 
+    function getName(playerId) {
+        const player = allPlayers.filter(p => p.id === playerId)[0];
+        return player.name;
+    }
+
     return (<tr>
         {data.home.manOfTheMatch ? (<td colSpan="2">Merged</td>) : (<td colSpan="2">
             {data.homeSubmission && data.homeSubmission.home.manOfTheMatch
-                ? (<button className="btn btn-success btn-sm"
-                           onClick={() => setManOfMatch('home', data.homeSubmission.home.manOfTheMatch)}>
-                    Use {allPlayers.filter(p => p.id === data.homeSubmission.home.manOfTheMatch)[0].name}
+                ? (<button className="btn btn-success btn-sm" onClick={() => setManOfMatch('home', data.homeSubmission.home.manOfTheMatch)}>
+                    Use {getName(data.homeSubmission.home.manOfTheMatch)}
                 </button>)
                 : (<button className="btn btn-secondary btn-sm" disabled={true}>Nothing to merge</button>)}
         </td>)}
         <td className="width-1 p-0"></td>
         {data.away.manOfTheMatch ? (<td colSpan="2">Merged</td>) : (<td colSpan="2">
             {data.awaySubmission && data.awaySubmission.away.manOfTheMatch
-                ? (<button className="btn btn-success btn-sm"
-                           onClick={() => setManOfMatch('away', data.awaySubmission.away.manOfTheMatch)}>
-                    Use {allPlayers.filter(p => p.id === data.awaySubmission.away.manOfTheMatch)[0].name}
+                ? (<button className="btn btn-success btn-sm" onClick={() => setManOfMatch('away', data.awaySubmission.away.manOfTheMatch)}>
+                    Use {getName(data.awaySubmission.away.manOfTheMatch)}
                 </button>)
                 : (<button className="btn btn-secondary btn-sm" disabled={true}>Nothing to merge</button>)}
         </td>)}

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeMatch.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeMatch.js
@@ -102,7 +102,7 @@ export function MergeMatch({
                 </div>
             </td>
             <td colSpan="2" className="hover-highlight">
-                <strong>from {awaySubmission.author} xx</strong>
+                <strong>from {awaySubmission.author}</strong>
                 {renderSubmissionMatch(awaySubmissionMatch)}
                 <div className="text-center">
                     <button disabled={readOnly} onClick={() => acceptSubmission(awaySubmissionMatch)}

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeMatch.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeMatch.js
@@ -48,7 +48,7 @@ export function MergeMatch({
 
         return (<span>
             <div>{homeSubmission.home.name}: {match.homeScore} - {awaySubmission.away.name}: {match.awayScore}</div>
-            <ol>
+            <ol className="d-inline-block">
                 {combinePlayers(match.homePlayers, match.awayPlayers).map(p => (
                     <li key={p.homePlayer.id || p.awayPlayer.id}>
                         <span className="text-nowrap">{p.homePlayer.name}</span> vs <span
@@ -65,7 +65,7 @@ export function MergeMatch({
     if (submissionsMatch && homeSubmissionMatch) {
         try {
             return (<tr>
-                <td colSpan="5">
+                <td colSpan="5" className="text-center">
                     {renderSubmissionMatch(homeSubmissionMatch)}
                     <div className="text-center">
                         <button disabled={readOnly} onClick={() => acceptSubmission(homeSubmissionMatch)}
@@ -86,7 +86,7 @@ export function MergeMatch({
 
     try {
         return (<tr>
-            <td colSpan="2" className="hover-highlight">
+            <td colSpan="2" className="hover-highlight pe-3 text-end">
                 <strong>from {homeSubmission.author}</strong>
                 {renderSubmissionMatch(homeSubmissionMatch)}
                 <div className="text-center">
@@ -97,11 +97,11 @@ export function MergeMatch({
             </td>
             <td>
                 <div className="vertical-text transform-top-left position-absolute text-nowrap"
-                     style={{marginLeft: '-5px'}}>
-                    <span className="text-nowrap" style={{marginLeft: '-60px'}}>Merge &rarr;</span>
+                     style={{marginLeft: '-15px'}}>
+                    <span className="text-nowrap bg-opacity-25 fw-bold bg-success p-2 shadow-sm" style={{marginLeft: '-75px'}}>Merge &rarr;</span>
                 </div>
             </td>
-            <td colSpan="2" className="hover-highlight">
+            <td colSpan="2" className="hover-highlight ps-3">
                 <strong>from {awaySubmission.author}</strong>
                 {renderSubmissionMatch(awaySubmissionMatch)}
                 <div className="text-center">

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
@@ -313,6 +313,10 @@ export function Score() {
 
             const newData = Object.assign({}, data);
             newData.matches = [{}, {}, {}, {}, {}, {}, {}, {}];
+            newData.home.manOfTheMatch = null;
+            newData.away.manOfTheMatch = null;
+            newData.oneEighties = [];
+            newData.over100Checkouts = [];
             newData.resultsPublished = false;
             setData(newData);
             if (submission) {

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
@@ -26,6 +26,7 @@ import {MatchTypeContainer} from "./MatchTypeContainer";
 import {getMatchDefaults, getMatchOptionDefaults, getMatchOptionsLookup} from "../../../helpers/matchOptions";
 import {PageError} from "../../common/PageError";
 import {LoadingSpinnerSmall} from "../../common/LoadingSpinnerSmall";
+import {DebugOptions} from "../../common/DebugOptions";
 
 export function Score() {
     const {fixtureId} = useParams();
@@ -540,12 +541,17 @@ export function Score() {
                         </tbody>)}
                     </table>
                     {access !== 'readonly' && (!data.resultsPublished || access === 'admin') ? (
-                        <button className="btn btn-primary" onClick={saveScores}>
+                        <button className="btn btn-primary margin-right" onClick={saveScores}>
                             {saving ? (<LoadingSpinnerSmall/>) : null}
                             Save
                         </button>) : null}
-                    {access === 'admin' && data.resultsPublished && (data.homeSubmission || data.awaySubmission) ? (
-                        <button className="btn btn-warning margin-left" onClick={unpublish}>Unpublish</button>) : null}
+                    {access === 'admin' && data.resultsPublished && (data.homeSubmission || data.awaySubmission)
+                        ? (<button className="btn btn-warning margin-right" onClick={unpublish}>Unpublish</button>)
+                        : null}
+                    <DebugOptions>
+                        <span className="dropdown-item">Access: {access}</span>
+                        {account ? (<span className="dropdown-item">Team: {teams[account.teamId] ? teams[account.teamId].name : account.teamId}</span>) : null}
+                    </DebugOptions>
                 </div>
             </LeagueFixtureContainer>
             {saveError ? (

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
@@ -464,7 +464,7 @@ export function Score() {
             homePlayers: homeTeam,
             awayPlayers: awayTeam,
             readOnly: !editable,
-            disabled: access === 'readonly',
+            disabled: access === 'readonly' || (fixtureData.resultsPublished && access !== 'admin'),
             home: data.home,
             away: data.away,
         }
@@ -551,6 +551,14 @@ export function Score() {
                     <DebugOptions>
                         <span className="dropdown-item">Access: {access}</span>
                         {account ? (<span className="dropdown-item">Team: {teams[account.teamId] ? teams[account.teamId].name : account.teamId}</span>) : null}
+                        <span className="dropdown-item">Data: {fixtureData && fixtureData.resultsPublished ? 'published' : 'draft'}</span>
+                        <span className="dropdown-item">
+                            Editable: {editable ? 'Yes' : 'No'}
+                            <span> | </span>
+                            Disabled: {leagueFixtureData.disabled ? 'Yes' : 'No'}
+                            <span> | </span>
+                            InputResults: {(account && account.access && account.access.inputResults) ? 'Yes' : 'No'}
+                        </span>
                     </DebugOptions>
                 </div>
             </LeagueFixtureContainer>

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
@@ -398,6 +398,7 @@ export function Score() {
                 fixtureData={fixtureData}
                 saving={saving}
                 access={access}
+                disabled={access === 'admin' && submission}
                 setFixtureData={setFixtureData}/>);
         }
 
@@ -417,7 +418,7 @@ export function Score() {
 
     function render180sAndHiCheckInput() {
         return (<HiCheckAnd180s
-            saving={saving}
+            saving={saving || (access === 'admin' && submission)}
             access={access}
             fixtureData={fixtureData}
             setFixtureData={setFixtureData}
@@ -457,14 +458,14 @@ export function Score() {
         const season = seasons[fixtureData.seasonId] || {id: EMPTY_ID, name: 'Not found'};
         const division = divisions[fixtureData.divisionId] || {id: EMPTY_ID, name: 'Not found'};
 
-        const editable = !saving && (access === 'admin' || (!fixtureData.resultsPublished && account && account.access && account.access.inputResults === true));
+        const editable = !saving && ((access === 'admin' && !submission) || (!fixtureData.resultsPublished && account && account.access && account.access.inputResults === true));
         const leagueFixtureData = {
             season: season,
             division: division,
             homePlayers: homeTeam,
             awayPlayers: awayTeam,
             readOnly: !editable,
-            disabled: access === 'readonly' || (fixtureData.resultsPublished && access !== 'admin'),
+            disabled: access === 'readonly' || (fixtureData.resultsPublished && access !== 'admin') || (access === 'admin' && submission),
             home: data.home,
             away: data.away,
         }
@@ -540,7 +541,7 @@ export function Score() {
                         </tr>
                         </tbody>)}
                     </table>
-                    {access !== 'readonly' && (!data.resultsPublished || access === 'admin') ? (
+                    {access !== 'readonly' && ((!data.resultsPublished && access === 'clerk') || (access === 'admin' && !submission)) ? (
                         <button className="btn btn-primary margin-right" onClick={saveScores}>
                             {saving ? (<LoadingSpinnerSmall/>) : null}
                             Save

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
@@ -406,6 +406,10 @@ export function Score() {
     }
 
     function renderMergeManOfTheMatch() {
+        if (submission) {
+            return null;
+        }
+
         function hasManOfTheMatch(data, side) {
             data = data || {};
             const dataSide = data[side] || {};
@@ -503,7 +507,7 @@ export function Score() {
                         ? (<GameDetails saving={saving} setFixtureData={setFixtureData} access={access}
                                         fixtureData={fixtureData}/>)
                         : null}
-                    <table className={`table${access !== 'readonly' ? ' minimal-padding' : ''}`}>
+                    <table className={`table${(access === 'admin' && !submission) || access === 'clerk' ? ' minimal-padding' : ''}`}>
                         <ScoreCardHeading access={access} data={data} winner={winner} setSubmission={setSubmission}
                                           setFixtureData={setFixtureData} submission={submission}/>
                         {hasBeenPlayed || access === 'admin' || (account && access === 'clerk' && ((data.away && account.teamId === data.away.id) || (account.teamId === data.home.id))) ? (

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
@@ -499,7 +499,7 @@ export function Score() {
                     <table className={`table${access !== 'readonly' ? ' minimal-padding' : ''}`}>
                         <ScoreCardHeading access={access} data={data} winner={winner} setSubmission={setSubmission}
                                           setFixtureData={setFixtureData} submission={submission}/>
-                        {hasBeenPlayed || (access === 'admin' || (account && data.away && account.teamId === data.away.id && access === 'clerk')) ? (
+                        {hasBeenPlayed || access === 'admin' || (account && access === 'clerk' && ((data.away && account.teamId === data.away.id) || (account.teamId === data.home.id))) ? (
                             <tbody>
                             <tr>
                                 <td colSpan="5" className="text-primary fw-bold text-center">Singles</td>

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.js
@@ -406,10 +406,16 @@ export function Score() {
     }
 
     function renderMergeManOfTheMatch() {
+        function hasManOfTheMatch(data, side) {
+            data = data || {};
+            const dataSide = data[side] || {};
+            return dataSide.manOfTheMatch;
+        }
+
         if (!fixtureData.resultsPublished
             && access === 'admin'
             && (data.homeSubmission || data.awaySubmission)
-            && ((!data.home.manOfTheMatch && data.homeSubmission.home.manOfTheMatch) || (!data.away.manOfTheMatch && data.awaySubmission.away.manOfTheMatch))) {
+            && ((!hasManOfTheMatch(data, 'home') && hasManOfTheMatch(data.homeSubmission, 'home')) || (!hasManOfTheMatch(data, 'away') && hasManOfTheMatch(data.awaySubmission, 'away')))) {
             return (<MergeManOfTheMatch data={data} setData={setData} allPlayers={allPlayers}/>);
         }
 

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.test.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.test.js
@@ -694,9 +694,9 @@ describe('Score', () => {
             const matches = Array.from(context.container.querySelectorAll('table tbody tr'));
             const allScores = matches.flatMap(match => {
                 const tds = Array.from(match.querySelectorAll('td')).filter(td => td.colSpan !== 2);
-                return Array.from(tds.flatMap(td => Array.from(td.querySelectorAll('input'))));
+                return Array.from(tds.flatMap(td => Array.from(td.querySelectorAll('strong')))).map(str => str.textContent);
             });
-            expect(allScores.map(input => input.value)).toEqual(repeat(16, _ => '1')); // 16 = 8 matches * 2 sides
+            expect(allScores).toEqual(repeat(16, _ => '1')); // 16 = 8 matches * 2 sides
         });
 
         it('can unpublish away submission', async () => {
@@ -723,9 +723,9 @@ describe('Score', () => {
             const matches = Array.from(context.container.querySelectorAll('table tbody tr'));
             const allScores = matches.flatMap(match => {
                 const tds = Array.from(match.querySelectorAll('td')).filter(td => td.colSpan !== 2);
-                return Array.from(tds.flatMap(td => Array.from(td.querySelectorAll('input'))));
+                return Array.from(tds.flatMap(td => Array.from(td.querySelectorAll('strong')))).map(str => str.textContent);
             });
-            expect(allScores.map(input => input.value)).toEqual(repeat(16, _ => '2')); // 16 = 8 matches * 2 sides
+            expect(allScores).toEqual(repeat(16, _ => '2')); // 16 = 8 matches * 2 sides
         });
     });
 

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.test.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.test.js
@@ -678,6 +678,16 @@ describe('Score', () => {
                 return Array.from(tds.flatMap(td => Array.from(td.querySelectorAll('input'))));
             });
             expect(allScores.map(input => input.value)).toEqual(repeat(16, _ => '')); // 16 = 8 matches * 2 sides
+            const manOfTheMatchHeadingRow = Array.from(context.container.querySelectorAll('td')).filter(td => td.textContent === 'Man of the match')[0];
+            const manOfTheMatchDataRow = manOfTheMatchHeadingRow.parentElement.nextSibling;
+            expect(manOfTheMatchDataRow.querySelector('td:nth-child(1) .dropdown-toggle').textContent).toEqual(' ');
+            expect(manOfTheMatchDataRow.querySelector('td:nth-child(3) .dropdown-toggle').textContent).toEqual(' ');
+            const oneEightiesAndHiChecksHeadingRow = Array.from(context.container.querySelectorAll('td')).filter(td => td.textContent.indexOf('Select some player/s to add 180s and hi-checks') === 0)[0];
+            const oneEightiesAndHiChecksDataRow = oneEightiesAndHiChecksHeadingRow.parentElement.nextSibling;
+            const oneEightiesRow = oneEightiesAndHiChecksDataRow.querySelector('td:nth-child(1)');
+            const hiChecksRow = oneEightiesAndHiChecksDataRow.querySelector('td:nth-child(3)');
+            expect(oneEightiesRow.querySelectorAll('button').length).toEqual(2); // merge buttons
+            expect(hiChecksRow.querySelectorAll('button').length).toEqual(2); // merge buttons
         });
 
         it('can unpublish home submission', async () => {

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.test.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.test.js
@@ -765,6 +765,32 @@ describe('Score', () => {
             assertMatchRow(matchRows[12], '', '', '');
             assertMatchRow(matchRows[13], 'Select some player/s to add 180s and hi-checks');
         });
+
+        it('renders published score card', async () => {
+            fixture.resultsPublished = true;
+
+            await renderComponent(fixture.id, appData, account);
+
+            expect(reportedError).toBeNull();
+            const container = context.container.querySelector('.content-background');
+            expect(container).toBeTruthy();
+            const tableBody = container.querySelector('table tbody');
+            expect(tableBody).toBeTruthy();
+            const matchRows = tableBody.querySelectorAll('tr');
+            expect(matchRows.length).toEqual(12);
+            assertMatchRow(matchRows[0], 'Singles');
+            assertMatchRow(matchRows[1], '', '', '', '', '');
+            assertMatchRow(matchRows[2], '', '', '', '', '');
+            assertMatchRow(matchRows[3], '', '', '', '', '');
+            assertMatchRow(matchRows[4], '', '', '', '', '');
+            assertMatchRow(matchRows[5], '', '', '', '', '');
+            assertMatchRow(matchRows[6], 'Pairs');
+            assertMatchRow(matchRows[7], '', '', '', '', '');
+            assertMatchRow(matchRows[8], '', '', '', '', '');
+            assertMatchRow(matchRows[9], 'Triples');
+            assertMatchRow(matchRows[10], '', '', '', '', '');
+            assertMatchRow(matchRows[11], '');
+        });
     });
 
     describe('when logged in as an away clerk', () => {
@@ -802,6 +828,32 @@ describe('Score', () => {
             assertMatchRow(matchRows[11], 'Man of the match');
             assertMatchRow(matchRows[12], '', '', '');
             assertMatchRow(matchRows[13], 'Select some player/s to add 180s and hi-checks');
+        });
+
+        it('renders published score card', async () => {
+            fixture.resultsPublished = true;
+
+            await renderComponent(fixture.id, appData, account);
+
+            expect(reportedError).toBeNull();
+            const container = context.container.querySelector('.content-background');
+            expect(container).toBeTruthy();
+            const tableBody = container.querySelector('table tbody');
+            expect(tableBody).toBeTruthy();
+            const matchRows = tableBody.querySelectorAll('tr');
+            expect(matchRows.length).toEqual(12);
+            assertMatchRow(matchRows[0], 'Singles');
+            assertMatchRow(matchRows[1], '', '', '', '', '');
+            assertMatchRow(matchRows[2], '', '', '', '', '');
+            assertMatchRow(matchRows[3], '', '', '', '', '');
+            assertMatchRow(matchRows[4], '', '', '', '', '');
+            assertMatchRow(matchRows[5], '', '', '', '', '');
+            assertMatchRow(matchRows[6], 'Pairs');
+            assertMatchRow(matchRows[7], '', '', '', '', '');
+            assertMatchRow(matchRows[8], '', '', '', '', '');
+            assertMatchRow(matchRows[9], 'Triples');
+            assertMatchRow(matchRows[10], '', '', '', '', '');
+            assertMatchRow(matchRows[11], '');
         });
     });
 });

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.test.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.test.js
@@ -728,4 +728,80 @@ describe('Score', () => {
             expect(allScores.map(input => input.value)).toEqual(repeat(16, _ => '2')); // 16 = 8 matches * 2 sides
         });
     });
+
+    describe('when logged in as a home clerk', () => {
+        const appData = getDefaultAppData();
+        const fixture = getUnplayedFixtureData(appData);
+        const account = {
+            access: {
+                manageScores: false,
+                inputResults: true,
+            },
+            teamId: fixture.home.id,
+        };
+
+        it('renders score card without results', async () => {
+            await renderComponent(fixture.id, appData, account);
+
+            expect(reportedError).toBeNull();
+            const container = context.container.querySelector('.content-background');
+            expect(container).toBeTruthy();
+            const tableBody = container.querySelector('table tbody');
+            expect(tableBody).toBeTruthy();
+            const matchRows = tableBody.querySelectorAll('tr');
+            expect(matchRows.length).toEqual(14);
+            assertMatchRow(matchRows[0], 'Singles');
+            assertMatchRow(matchRows[1], 'Home playerAdd a player...', '', '', '', 'Away playerAdd a player...');
+            assertMatchRow(matchRows[2], 'Home playerAdd a player...', '', '', '', 'Away playerAdd a player...');
+            assertMatchRow(matchRows[3], 'Home playerAdd a player...', '', '', '', 'Away playerAdd a player...');
+            assertMatchRow(matchRows[4], 'Home playerAdd a player...', '', '', '', 'Away playerAdd a player...');
+            assertMatchRow(matchRows[5], 'Home playerAdd a player...', '', '', '', 'Away playerAdd a player...');
+            assertMatchRow(matchRows[6], 'Pairs');
+            assertMatchRow(matchRows[7], 'Home playerAdd a player...  Home playerAdd a player...', '', '', '', 'Away playerAdd a player...  Away playerAdd a player...');
+            assertMatchRow(matchRows[8], 'Home playerAdd a player...  Home playerAdd a player...', '', '', '', 'Away playerAdd a player...  Away playerAdd a player...');
+            assertMatchRow(matchRows[9], 'Triples');
+            assertMatchRow(matchRows[10], 'Home playerAdd a player...  Home playerAdd a player...  Home playerAdd a player...', '', '', '', 'Away playerAdd a player...  Away playerAdd a player...  Away playerAdd a player...');
+            assertMatchRow(matchRows[11], 'Man of the match');
+            assertMatchRow(matchRows[12], '', '', '');
+            assertMatchRow(matchRows[13], 'Select some player/s to add 180s and hi-checks');
+        });
+    });
+
+    describe('when logged in as an away clerk', () => {
+        const appData = getDefaultAppData();
+        const fixture = getUnplayedFixtureData(appData);
+        const account = {
+            access: {
+                manageScores: false,
+                inputResults: true,
+            },
+            teamId: fixture.away.id,
+        };
+
+        it('renders score card without results', async () => {
+            await renderComponent(fixture.id, appData, account);
+
+            expect(reportedError).toBeNull();
+            const container = context.container.querySelector('.content-background');
+            expect(container).toBeTruthy();
+            const tableBody = container.querySelector('table tbody');
+            expect(tableBody).toBeTruthy();
+            const matchRows = tableBody.querySelectorAll('tr');
+            expect(matchRows.length).toEqual(14);
+            assertMatchRow(matchRows[0], 'Singles');
+            assertMatchRow(matchRows[1], 'Home playerAdd a player...', '', '', '', 'Away playerAdd a player...');
+            assertMatchRow(matchRows[2], 'Home playerAdd a player...', '', '', '', 'Away playerAdd a player...');
+            assertMatchRow(matchRows[3], 'Home playerAdd a player...', '', '', '', 'Away playerAdd a player...');
+            assertMatchRow(matchRows[4], 'Home playerAdd a player...', '', '', '', 'Away playerAdd a player...');
+            assertMatchRow(matchRows[5], 'Home playerAdd a player...', '', '', '', 'Away playerAdd a player...');
+            assertMatchRow(matchRows[6], 'Pairs');
+            assertMatchRow(matchRows[7], 'Home playerAdd a player...  Home playerAdd a player...', '', '', '', 'Away playerAdd a player...  Away playerAdd a player...');
+            assertMatchRow(matchRows[8], 'Home playerAdd a player...  Home playerAdd a player...', '', '', '', 'Away playerAdd a player...  Away playerAdd a player...');
+            assertMatchRow(matchRows[9], 'Triples');
+            assertMatchRow(matchRows[10], 'Home playerAdd a player...  Home playerAdd a player...  Home playerAdd a player...', '', '', '', 'Away playerAdd a player...  Away playerAdd a player...  Away playerAdd a player...');
+            assertMatchRow(matchRows[11], 'Man of the match');
+            assertMatchRow(matchRows[12], '', '', '');
+            assertMatchRow(matchRows[13], 'Select some player/s to add 180s and hi-checks');
+        });
+    });
 });

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/ScoreCardHeading.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/ScoreCardHeading.js
@@ -63,7 +63,7 @@ export function ScoreCardHeading({data, access, winner, submission, setSubmissio
     {access === 'admin' && submission ? (<tr>
         <th colSpan="5">
             <div className="alert alert-warning fw-normal">
-                You are viewing the submission from <strong>{data[submission].name}</strong>, created by <strong>{data.editor}</strong> as of <strong title={data.updated}>{renderDate(data.updated)}</strong>
+                You are viewing the submission from <strong>{data[submission].name}</strong>, created by <strong>{data[submission].editor}</strong> as of <strong title={data[submission].updated}>{renderDate(data[submission].updated)}</strong>
             </div>
         </th>
     </tr>) : null}

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/ScoreCardHeading.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/ScoreCardHeading.js
@@ -2,10 +2,13 @@ import React from "react";
 import {useApp} from "../../../AppContainer";
 import {useLeagueFixture} from "./LeagueFixtureContainer";
 import {EmbedAwareLink} from "../../common/EmbedAwareLink";
+import {renderDate} from "../../../helpers/rendering";
 
 export function ScoreCardHeading({data, access, winner, submission, setSubmission, setFixtureData}) {
-    const {account, onError} = useApp();
+    const {account, onError, teams} = useApp();
     const {division, season} = useLeagueFixture();
+    const submissionTeam = account && access === 'clerk' && account.teamId ? teams[account.teamId] : null;
+    const opposingTeam = submissionTeam && data.home.id === submissionTeam.id ? data.away : data.home;
 
     function toggleSubmission(submissionToShow) {
         try {
@@ -30,25 +33,39 @@ export function ScoreCardHeading({data, access, winner, submission, setSubmissio
 
     return (<thead>
     <tr>
-        <td colSpan="2" className={`text-end fw-bold width-50-pc ${winner === 'home' ? 'bg-winner' : ''}`}>
-            <EmbedAwareLink to={`/division/${division.name}/team:${data.home.name}/${season.name}`}
-                            className="margin-right">{data.home.name}</EmbedAwareLink>
+        <td colSpan="2" className={`text-end fw-bold width-50-pc ${winner === 'home' ? 'bg-winner' : ''}${submission === 'home' ? ' bg-warning' : ''}`}>
             {canShowSubmissionToggle(data.homeSubmission)
                 ? (<span onClick={() => toggleSubmission('home')}
                          className={`btn btn-sm ${submission === 'home' ? 'btn-primary' : 'btn-outline-secondary'}`}
-                         title="See home submission">📬</span>)
-                : null}
+                         title="See home submission">📬 {data.home.name}</span>)
+                : <EmbedAwareLink to={`/division/${division.name}/team:${data.home.name}/${season.name}`}
+                                  className="margin-right">{data.home.name}</EmbedAwareLink>}
         </td>
         <td className="text-center width-1 p-0"></td>
-        <td colSpan="2" className={`text-start fw-bold width-50-pc ${winner === 'away' ? 'bg-winner' : ''}`}>
-            <EmbedAwareLink to={`/division/${division.name}/team:${data.away.name}/${season.name}`}
-                            className="margin-right">{data.away.name}</EmbedAwareLink>
+        <td colSpan="2" className={`text-start fw-bold width-50-pc ${winner === 'away' ? 'bg-winner' : ''}${submission === 'away' ? ' bg-warning' : ''}`}>
             {canShowSubmissionToggle(data.awaySubmission)
                 ? (<span onClick={() => toggleSubmission('away')}
                          className={`btn btn-sm ${submission === 'away' ? 'btn-primary' : 'btn-outline-secondary'}`}
-                         title="See away submission">📬</span>)
-                : null}
+                         title="See away submission">📬 {data.away.name}</span>)
+                : <EmbedAwareLink to={`/division/${division.name}/team:${data.away.name}/${season.name}`}
+                                  className="margin-right">{data.away.name}</EmbedAwareLink>}
         </td>
     </tr>
+    {access === 'clerk' && !data.resultsPublished ? (<tr>
+        <th colSpan="5">
+            <div className="alert alert-warning fw-normal">
+                ⚠ You are editing {submissionTeam ? <>the submission from <strong>{submissionTeam.name}</strong></> : 'your submission'}, they are not visible on the website.<br />
+                <br />
+                The results will be published by an administrator, or automatically if {opposingTeam ? <>someone from <strong>{opposingTeam.name}</strong></> : 'the opponent'} submits matching results.
+            </div>
+        </th>
+    </tr>) : null}
+    {access === 'admin' && submission ? (<tr>
+        <th colSpan="5">
+            <div className="alert alert-warning fw-normal">
+                You are viewing the submission from <strong>{data[submission].name}</strong>, created by <strong>{data.editor}</strong> as of <strong title={data.updated}>{renderDate(data.updated)}</strong>
+            </div>
+        </th>
+    </tr>) : null}
     </thead>);
 }

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/ScoreCardHeading.test.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/ScoreCardHeading.test.js
@@ -2,6 +2,7 @@
 
 import React from "react";
 import {cleanUp, doClick, renderApp} from "../../../helpers/tests";
+import {toMap} from "../../../helpers/collections";
 import {ScoreCardHeading} from "./ScoreCardHeading";
 import {LeagueFixtureContainer} from "./LeagueFixtureContainer";
 import {divisionBuilder, fixtureBuilder, seasonBuilder, teamBuilder} from "../../../helpers/builders";
@@ -22,7 +23,7 @@ describe('ScoreCardHeading', () => {
         cleanUp(context);
     });
 
-    async function renderComponent(access, data, winner, account, submission, containerProps) {
+    async function renderComponent(access, data, winner, account, submission, containerProps, teams) {
         reportedError = null;
         updatedFixtureData = null;
         updatedSubmission = null;
@@ -37,7 +38,8 @@ describe('ScoreCardHeading', () => {
                     };
                 },
                 error: null,
-                account
+                account,
+                teams: toMap(teams || []),
             },
             (<LeagueFixtureContainer {...containerProps}>
                 <ScoreCardHeading
@@ -64,11 +66,9 @@ describe('ScoreCardHeading', () => {
     function assertToggleShown(home) {
         const heading = context.container.querySelector(`thead > tr > td:nth-child(${home ? 1 : 3})`);
         expect(heading).toBeTruthy();
-        const headingLink = heading.querySelector('a');
-        expect(headingLink.textContent).toContain(home ? 'HOME' : 'AWAY');
-        const toggle = heading.querySelector('span');
-        expect(toggle).toBeTruthy();
-        expect(toggle.textContent).toContain('📬');
+        const toggleButton = heading.querySelector('.btn');
+        expect(toggleButton.textContent).toContain(home ? 'HOME' : 'AWAY');
+        expect(toggleButton.textContent).toContain('📬');
     }
 
     async function assertRevertToFixtureData(home, data) {
@@ -117,7 +117,7 @@ describe('ScoreCardHeading', () => {
         expect(linkToTeam.href).toContain(`/division/${fixtureData.division.name}/team:${team.name}/${fixtureData.season.name}`);
     }
 
-    describe('when not logged in', () => {
+    describe('when logged out', () => {
         const access = '';
         const account = null;
         const division = divisionBuilder('DIVISION').build();

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/ScoreCardHeading.test.js
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/ScoreCardHeading.test.js
@@ -6,6 +6,7 @@ import {toMap} from "../../../helpers/collections";
 import {ScoreCardHeading} from "./ScoreCardHeading";
 import {LeagueFixtureContainer} from "./LeagueFixtureContainer";
 import {divisionBuilder, fixtureBuilder, seasonBuilder, teamBuilder} from "../../../helpers/builders";
+import {renderDate} from "../../../helpers/rendering";
 
 describe('ScoreCardHeading', () => {
     let context;
@@ -266,6 +267,17 @@ describe('ScoreCardHeading', () => {
                 season: seasonBuilder('SEASON', submissionData.seasonId).build(),
             };
 
+            it('shows unpublished alert when submission team identified', async () => {
+                const updated = '2023-04-05';
+                submissionData['home'].editor = 'EDITOR';
+                submissionData['home'].updated = updated;
+
+                await renderComponent(access, submissionData, winner, account, 'home', fixtureData, [team]);
+
+                const alert = context.container.querySelector('.alert');
+                expect(alert.textContent).toContain('You are viewing the submission from HOME, created by EDITOR as of ' + renderDate(updated));
+            });
+
             it('shows home submission toggle', async () => {
                 await renderComponent(access, submissionData, winner, account, null, fixtureData);
 
@@ -367,6 +379,23 @@ describe('ScoreCardHeading', () => {
                     division: divisionBuilder('DIVISION', submissionData.divisionId).build(),
                     season: seasonBuilder('SEASON', submissionData.seasonId).build(),
                 };
+
+                it('shows unpublished alert when submission team identified', async () => {
+                    const teams = [team];
+                    await renderComponent(access, submissionData, winner, account, null, fixtureData, teams);
+
+                    const alert = context.container.querySelector('.alert');
+                    expect(alert.textContent).toContain('⚠ You are editing the submission from TEAM, they are not visible on the website.');
+                    expect(alert.textContent).toContain('The results will be published by an administrator, or automatically if someone from HOME submits matching results.');
+                });
+
+                it('shows unpublished alert when no submission team', async () => {
+                    await renderComponent(access, submissionData, winner, account, null, fixtureData);
+
+                    const alert = context.container.querySelector('.alert');
+                    expect(alert.textContent).toContain('⚠ You are editing your submission, they are not visible on the website.');
+                    expect(alert.textContent).toContain('The results will be published by an administrator, or automatically if someone from HOME submits matching results.');
+                });
 
                 it('does not show home submission toggle', async () => {
                     await renderComponent(access, submissionData, winner, account, null, fixtureData);

--- a/CourageScores/DependencyInjectionExtensions.cs
+++ b/CourageScores/DependencyInjectionExtensions.cs
@@ -194,6 +194,8 @@ public static class DependencyInjectionExtensions
         services.AddScoped<ISimpleAdapter<FixtureTemplate, FixtureTemplateDto>, FixtureTemplateAdapter>();
         services.AddScoped<ISimpleAdapter<List<string>, List<TeamPlaceholderDto>>, SharedAddressAdapter>();
         services.AddScoped<ISimpleOnewayAdapter<Template, SeasonHealthDto>, TemplateToHealthCheckAdapter>();
+
+        services.AddScoped<IUpdateScoresAdapter, UpdateScoresAdapter>();
     }
 
     private static void AddAdapter<TModel, TDto, TAdapter>(IServiceCollection services)

--- a/CourageScores/DependencyInjectionExtensions.cs
+++ b/CourageScores/DependencyInjectionExtensions.cs
@@ -75,7 +75,18 @@ public static class DependencyInjectionExtensions
         AddRepositories(services);
         AddAdapters(services);
         AddCommands(services);
+        AddComparers(services);
         services.AddSingleton(ApplicationMetrics.Create());
+    }
+
+    private static void AddComparers(IServiceCollection services)
+    {
+        services.AddScoped<IEqualityComparer<Game>, GameComparer>();
+        services.AddScoped<IEqualityComparer<GameMatch>, GameMatchComparer>();
+        services.AddScoped<IEqualityComparer<GameTeam>, GameTeamComparer>();
+        services.AddScoped<IEqualityComparer<GameMatchOption?>, GameMatchOptionComparer>();
+        services.AddScoped<IEqualityComparer<ICollection<GamePlayer>>, GamePlayerComparer>();
+        services.AddScoped<IEqualityComparer<ICollection<NotablePlayer>>, HiChecksComparer>();
     }
 
     private static void AddCommands(IServiceCollection services)

--- a/CourageScores/Models/ActionResult.cs
+++ b/CourageScores/Models/ActionResult.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using CourageScores.Models.Dtos;
 
 namespace CourageScores.Models;
 
@@ -12,4 +13,45 @@ public class ActionResult<T> : IActionResult<T>
     public List<string> Errors { get; init; } = new();
     public List<string> Warnings { get; init; } = new();
     public List<string> Messages { get; init; } = new();
+
+    public ActionResult<T> Merge(IActionResult<T> from)
+    {
+        return new ActionResult<T>
+        {
+            Success = Success && from.Success,
+            Delete = Delete || from.Delete,
+            Messages = Messages.Concat(from.Messages).ToList(),
+            Warnings = Warnings.Concat(from.Warnings).ToList(),
+            Errors = Errors.Concat(from.Errors).ToList(),
+
+            Result = from.Result ?? Result,
+        };
+    }
+
+    public ActionResult<T> Merge(ActionResultDto<T> from)
+    {
+        return new ActionResult<T>
+        {
+            Success = Success && from.Success,
+            Delete = Delete,
+            Messages = Messages.Concat(from.Messages).ToList(),
+            Warnings = Warnings.Concat(from.Warnings).ToList(),
+            Errors = Errors.Concat(from.Errors).ToList(),
+
+            Result = from.Result ?? Result,
+        };
+    }
+
+    public ActionResult<TOther> As<TOther>(TOther? result = default)
+    {
+        return new ActionResult<TOther>
+        {
+            Success = Success,
+            Delete = Delete,
+            Messages = Messages,
+            Warnings = Warnings,
+            Errors = Errors,
+            Result = result,
+        };
+    }
 }

--- a/CourageScores/Models/Adapters/Season/IUpdateScoresAdapter.cs
+++ b/CourageScores/Models/Adapters/Season/IUpdateScoresAdapter.cs
@@ -1,0 +1,12 @@
+﻿using CourageScores.Models.Cosmos.Game;
+using CourageScores.Models.Dtos.Game;
+
+namespace CourageScores.Models.Adapters.Season;
+
+public interface IUpdateScoresAdapter
+{
+    Task<GamePlayer> AdaptToPlayer(RecordScoresDto.RecordScoresGamePlayerDto player, CancellationToken token);
+    Task<NotablePlayer> AdaptToHiCheckPlayer(RecordScoresDto.GameOver100CheckoutDto player, CancellationToken token);
+    Task<GameMatch> AdaptToMatch(RecordScoresDto.RecordScoresGameMatchDto updatedMatch, CancellationToken token);
+    Task<GameMatch> UpdateMatch(GameMatch currentMatch, RecordScoresDto.RecordScoresGameMatchDto updatedMatch, CancellationToken token);
+}

--- a/CourageScores/Models/Adapters/Season/UpdateScoresAdapter.cs
+++ b/CourageScores/Models/Adapters/Season/UpdateScoresAdapter.cs
@@ -1,0 +1,96 @@
+﻿using CourageScores.Models.Cosmos.Game;
+using CourageScores.Models.Cosmos.Game.Sayg;
+using CourageScores.Models.Dtos.Game;
+using CourageScores.Models.Dtos.Game.Sayg;
+using CourageScores.Services;
+using CourageScores.Services.Identity;
+
+namespace CourageScores.Models.Adapters.Season;
+
+public class UpdateScoresAdapter : IUpdateScoresAdapter
+{
+    private readonly IAuditingHelper _auditingHelper;
+    private readonly IUserService _userService;
+    private readonly ISimpleAdapter<ScoreAsYouGo, ScoreAsYouGoDto> _scoreAsYouGoAdapter;
+
+    public UpdateScoresAdapter(IAuditingHelper auditingHelper, IUserService userService, ISimpleAdapter<ScoreAsYouGo, ScoreAsYouGoDto> scoreAsYouGoAdapter)
+    {
+        _auditingHelper = auditingHelper;
+        _userService = userService;
+        _scoreAsYouGoAdapter = scoreAsYouGoAdapter;
+    }
+
+    public async Task<GamePlayer> AdaptToPlayer(RecordScoresDto.RecordScoresGamePlayerDto player, CancellationToken token)
+    {
+        var gamePlayer = new GamePlayer
+        {
+            Id = player.Id,
+            Name = player.Name,
+        };
+        await _auditingHelper.SetUpdated(gamePlayer, token);
+        return gamePlayer;
+    }
+
+    public async Task<NotablePlayer> AdaptToHiCheckPlayer(RecordScoresDto.GameOver100CheckoutDto player, CancellationToken token)
+    {
+        var gamePlayer = new NotablePlayer
+        {
+            Id = player.Id,
+            Name = player.Name,
+            Notes = player.Notes,
+        };
+        await _auditingHelper.SetUpdated(gamePlayer, token);
+        return gamePlayer;
+    }
+
+    public async Task<GameMatch> AdaptToMatch(RecordScoresDto.RecordScoresGameMatchDto updatedMatch, CancellationToken token)
+    {
+        var user = await _userService.GetUser(token);
+        var permitted = user?.Access?.RecordScoresAsYouGo == true;
+
+        var match = new GameMatch
+        {
+            Id = Guid.NewGuid(),
+            AwayPlayers = await updatedMatch.AwayPlayers.SelectAsync(p => AdaptToPlayer(p, token)).ToList(),
+            AwayScore = updatedMatch.AwayScore,
+            HomePlayers = await updatedMatch.HomePlayers.SelectAsync(p => AdaptToPlayer(p, token)).ToList(),
+            HomeScore = updatedMatch.HomeScore,
+            Sayg = updatedMatch.Sayg != null && permitted
+                ? await _scoreAsYouGoAdapter.Adapt(updatedMatch.Sayg, token)
+                : null,
+        };
+
+        await _auditingHelper.SetUpdated(match, token);
+        return match;
+    }
+
+    public async Task<GameMatch> UpdateMatch(GameMatch currentMatch, RecordScoresDto.RecordScoresGameMatchDto updatedMatch, CancellationToken token)
+    {
+        var user = await _userService.GetUser(token);
+        var permitted = user?.Access?.RecordScoresAsYouGo == true;
+        if (!updatedMatch.HomePlayers.Any() || !updatedMatch.AwayPlayers.Any())
+        {
+            updatedMatch.Sayg = null;
+            currentMatch.Sayg = null; // remove the current sayg data, there are no players for it to apply to.
+        }
+
+        var match = new GameMatch
+        {
+            Author = currentMatch.Author,
+            Created = currentMatch.Created,
+            Deleted = currentMatch.Deleted,
+            Id = currentMatch.Id,
+            Remover = currentMatch.Remover,
+            Version = currentMatch.Version,
+            AwayPlayers = await updatedMatch.AwayPlayers.SelectAsync(p => AdaptToPlayer(p, token)).ToList(),
+            AwayScore = updatedMatch.AwayScore,
+            HomePlayers = await updatedMatch.HomePlayers.SelectAsync(p => AdaptToPlayer(p, token)).ToList(),
+            HomeScore = updatedMatch.HomeScore,
+            Sayg = updatedMatch.Sayg != null && permitted
+                ? await _scoreAsYouGoAdapter.Adapt(updatedMatch.Sayg, token)
+                : currentMatch.Sayg,
+        };
+        await _auditingHelper.SetUpdated(match, token);
+        return match;
+    }
+}

--- a/CourageScores/Models/Cosmos/Game/Game.cs
+++ b/CourageScores/Models/Cosmos/Game/Game.cs
@@ -145,7 +145,7 @@ public class Game : AuditedEntity, IPermissionedEntity, IGameVisitable
     [ExcludeFromCodeCoverage]
     public bool CanEdit(UserDto? user)
     {
-        return user?.Access?.ManageGames == true;
+        return user?.Access?.ManageGames == true || user?.Access?.InputResults == true;
     }
 
     [ExcludeFromCodeCoverage]

--- a/CourageScores/Models/Dtos/ActionResultDto.cs
+++ b/CourageScores/Models/Dtos/ActionResultDto.cs
@@ -38,4 +38,54 @@ public class ActionResultDto<TDto>
     /// Any warnings from the action
     /// </summary>
     public List<string> Warnings { get; set; } = new();
+
+    public ActionResultDto<TDto> Merge(IActionResult<TDto> from)
+    {
+        return new ActionResultDto<TDto>
+        {
+            Success = Success && from.Success,
+            Messages = Messages.Concat(from.Messages).ToList(),
+            Warnings = Warnings.Concat(from.Warnings).ToList(),
+            Errors = Errors.Concat(from.Errors).ToList(),
+
+            Result = from.Result ?? Result,
+        };
+    }
+
+    public ActionResultDto<TDto> Merge(ActionResultDto<TDto> from)
+    {
+        return new ActionResultDto<TDto>
+        {
+            Success = Success && from.Success,
+            Messages = Messages.Concat(from.Messages).ToList(),
+            Warnings = Warnings.Concat(from.Warnings).ToList(),
+            Errors = Errors.Concat(from.Errors).ToList(),
+
+            Result = from.Result ?? Result,
+        };
+    }
+
+    public ActionResultDto<TOther> As<TOther>(TOther? result = default)
+    {
+        return new ActionResultDto<TOther>
+        {
+            Success = Success,
+            Messages = Messages,
+            Warnings = Warnings,
+            Errors = Errors,
+            Result = result,
+        };
+    }
+
+    public ActionResult<TDto> ToActionResult()
+    {
+        return new ActionResult<TDto>
+        {
+            Success = Success,
+            Messages = Messages,
+            Warnings = Warnings,
+            Errors = Errors,
+            Result = Result,
+        };
+    }
 }

--- a/CourageScores/Services/AsyncEnumerableExtensions.cs
+++ b/CourageScores/Services/AsyncEnumerableExtensions.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CourageScores.Services;
 
+[ExcludeFromCodeCoverage]
 public static class AsyncEnumerableExtensions
 {
     [DebuggerStepThrough]

--- a/CourageScores/Services/Command/AddOrUpdateCommand.cs
+++ b/CourageScores/Services/Command/AddOrUpdateCommand.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using CourageScores.Models;
 using CourageScores.Models.Cosmos;
 using CourageScores.Models.Dtos;
@@ -62,6 +63,7 @@ public abstract class AddOrUpdateCommand<TModel, TDto> : IUpdateCommand<TModel, 
             });
     }
 
+    [ExcludeFromCodeCoverage]
     public virtual bool RequiresLogin => true;
 
     protected abstract Task<ActionResult<TModel>> ApplyUpdates(TModel model, TDto update, CancellationToken token);

--- a/CourageScores/Services/Command/AddOrUpdateCommand.cs
+++ b/CourageScores/Services/Command/AddOrUpdateCommand.cs
@@ -51,19 +51,18 @@ public abstract class AddOrUpdateCommand<TModel, TDto> : IUpdateCommand<TModel, 
 
         var result = await ApplyUpdates(model, _update!, token);
 
-        return new ActionResult<TModel>
-        {
-            Success = result.Success,
-            Errors = result.Errors,
-            Warnings = result.Warnings,
-            Messages = result.Messages.Any()
-                ? result.Messages
-                : new List<string>
-                {
-                    $"{typeof(TModel).Name} {(create ? "created" : "updated")}",
-                },
-            Result = model,
-        };
+        return result
+            .As(model)
+            .Merge(new ActionResult<TModel>
+            {
+                Success = result.Success,
+                Messages = result.Messages.Any()
+                    ? new List<string>()
+                    : new List<string>
+                    {
+                        $"{typeof(TModel).Name} {(create ? "created" : "updated")}",
+                    },
+            });
     }
 
     public virtual bool RequiresLogin => true;

--- a/CourageScores/Services/Command/AddOrUpdateCommand.cs
+++ b/CourageScores/Services/Command/AddOrUpdateCommand.cs
@@ -13,10 +13,7 @@ public abstract class AddOrUpdateCommand<TModel, TDto> : IUpdateCommand<TModel, 
     public async Task<ActionResult<TModel>> ApplyUpdate(TModel model, CancellationToken token)
     {
         var create = false;
-        if (_update == null)
-        {
-            throw new InvalidOperationException($"{nameof(WithData)} must be called first");
-        }
+        _update.ThrowIfNull($"{nameof(WithData)} must be called first");
 
         if (model.Deleted != null)
         {

--- a/CourageScores/Services/Command/AddOrUpdateTeamCommand.cs
+++ b/CourageScores/Services/Command/AddOrUpdateTeamCommand.cs
@@ -124,13 +124,12 @@ public class AddOrUpdateTeamCommand : AddOrUpdateCommand<Models.Cosmos.Team.Team
 
             if (!result.Success || result.Result == null)
             {
-                return new ActionResult<Models.Cosmos.Team.Team>
-                {
-                    Success = false,
-                    Messages = result.Messages,
-                    Warnings = result.Warnings,
-                    Errors = result.Errors,
-                };
+                return result
+                    .As<Models.Cosmos.Team.Team>()
+                    .Merge(new ActionResult<Models.Cosmos.Team.Team>
+                    {
+                        Success = false,
+                    });
             }
 
             teamSeason = result.Result;

--- a/CourageScores/Services/Command/AddOrUpdateTournamentGameCommand.cs
+++ b/CourageScores/Services/Command/AddOrUpdateTournamentGameCommand.cs
@@ -96,13 +96,8 @@ public class AddOrUpdateTournamentGameCommand : AddOrUpdateCommand<TournamentGam
 
         _cacheFlags.EvictDivisionDataCacheForSeasonId = game.SeasonId;
         _cacheFlags.EvictDivisionDataCacheForDivisionId = divisionIdToEvictFromCache;
-        return new ActionResult<TournamentGame>
-        {
-            Success = context.Success,
-            Errors = context.Errors,
-            Warnings = context.Warnings,
-            Messages = context.Messages,
-        };
+
+        return context.As<TournamentGame>();
     }
 
     private async Task UpdateRoundRecursively(TournamentRound? round, IReadOnlyCollection<TournamentSide> sides, IActionResult<TournamentGame> context, CancellationToken token)

--- a/CourageScores/Services/Command/AddPlayerToTeamSeasonCommand.cs
+++ b/CourageScores/Services/Command/AddPlayerToTeamSeasonCommand.cs
@@ -148,16 +148,15 @@ public class AddPlayerToTeamSeasonCommand : IUpdateCommand<Models.Cosmos.Team.Te
             var result = await addSeasonCommand.ApplyUpdate(model, token);
             if (!result.Success || result.Result == null)
             {
-                return new ActionResult<TeamPlayer>
-                {
-                    Success = false,
-                    Warnings = result.Warnings.Concat(new[]
+                return result.As<TeamPlayer>()
+                    .Merge(new ActionResult<TeamPlayer>
                     {
-                        $"Could not add the {season.Name} season to team {model.Name}",
-                    }).ToList(),
-                    Messages = result.Messages,
-                    Errors = result.Errors,
-                };
+                        Success = false,
+                        Warnings =
+                        {
+                            $"Could not add the {season.Name} season to team {model.Name}",
+                        },
+                    });
             }
 
             _cacheFlags.EvictDivisionDataCacheForSeasonId = season.Id;

--- a/CourageScores/Services/Command/AddPlayerToTeamSeasonCommand.cs
+++ b/CourageScores/Services/Command/AddPlayerToTeamSeasonCommand.cs
@@ -59,20 +59,9 @@ public class AddPlayerToTeamSeasonCommand : IUpdateCommand<Models.Cosmos.Team.Te
 
     public virtual async Task<ActionResult<TeamPlayer>> ApplyUpdate(Models.Cosmos.Team.Team model, CancellationToken token)
     {
-        if (_player == null)
-        {
-            throw new InvalidOperationException($"Player hasn't been set, ensure {nameof(ForPlayer)} is called");
-        }
-
-        if (_seasonId == null)
-        {
-            throw new InvalidOperationException($"SeasonId hasn't been set, ensure {nameof(ToSeason)} is called");
-        }
-
-        if (_divisionId == null)
-        {
-            throw new InvalidOperationException($"DivisionId hasn't been set, ensure {nameof(ToDivision)} is called");
-        }
+        _player.ThrowIfNull($"Player hasn't been set, ensure {nameof(ForPlayer)} is called");
+        _seasonId.ThrowIfNull($"SeasonId hasn't been set, ensure {nameof(ToSeason)} is called");
+        _divisionId.ThrowIfNull($"DivisionId hasn't been set, ensure {nameof(ToDivision)} is called");
 
         if (model.Deleted != null)
         {
@@ -113,7 +102,7 @@ public class AddPlayerToTeamSeasonCommand : IUpdateCommand<Models.Cosmos.Team.Te
             };
         }
 
-        var season = await _seasonService.Get(_seasonId.Value, token);
+        var season = await _seasonService.Get(_seasonId!.Value, token);
         if (season == null)
         {
             return new ActionResult<TeamPlayer>
@@ -143,7 +132,7 @@ public class AddPlayerToTeamSeasonCommand : IUpdateCommand<Models.Cosmos.Team.Te
 
             var addSeasonCommand = _commandFactory.GetCommand<AddSeasonToTeamCommand>()
                 .ForSeason(season.Id)
-                .ForDivision(_divisionId.Value);
+                .ForDivision(_divisionId!.Value);
 
             var result = await addSeasonCommand.ApplyUpdate(model, token);
             if (!result.Success || result.Result == null)
@@ -165,7 +154,7 @@ public class AddPlayerToTeamSeasonCommand : IUpdateCommand<Models.Cosmos.Team.Te
 
         var players = teamSeason.Players;
 
-        var existingPlayer = players.SingleOrDefault(p => p.Name == _player.Name);
+        var existingPlayer = players.SingleOrDefault(p => p.Name == _player!.Name);
         if (existingPlayer != null)
         {
             if (existingPlayer.Deleted == null)
@@ -182,7 +171,7 @@ public class AddPlayerToTeamSeasonCommand : IUpdateCommand<Models.Cosmos.Team.Te
             }
 
             await _auditingHelper.SetUpdated(existingPlayer, token);
-            existingPlayer.Captain = _player.Captain;
+            existingPlayer.Captain = _player!.Captain;
             existingPlayer.EmailAddress = _player.EmailAddress ?? existingPlayer.EmailAddress;
             _cacheFlags.EvictDivisionDataCacheForSeasonId = season.Id;
             return new ActionResult<TeamPlayer>
@@ -198,7 +187,7 @@ public class AddPlayerToTeamSeasonCommand : IUpdateCommand<Models.Cosmos.Team.Te
 
         var newPlayer = new TeamPlayer
         {
-            Name = _player.Name,
+            Name = _player!.Name,
             Captain = _player.Captain,
             EmailAddress = _player.EmailAddress,
             Id = Guid.NewGuid(),

--- a/CourageScores/Services/Command/AddSeasonToTeamCommand.cs
+++ b/CourageScores/Services/Command/AddSeasonToTeamCommand.cs
@@ -51,15 +51,8 @@ public class AddSeasonToTeamCommand : IUpdateCommand<Models.Cosmos.Team.Team, Te
 
     public virtual async Task<ActionResult<TeamSeason>> ApplyUpdate(Models.Cosmos.Team.Team model, CancellationToken token)
     {
-        if (_seasonId == null)
-        {
-            throw new InvalidOperationException($"SeasonId hasn't been set, ensure {nameof(ForSeason)} is called");
-        }
-
-        if (_divisionId == null)
-        {
-            throw new InvalidOperationException($"DivisionId hasn't been set, ensure {nameof(ForDivision)} is called");
-        }
+        _seasonId.ThrowIfNull($"SeasonId hasn't been set, ensure {nameof(ForSeason)} is called");
+        _divisionId.ThrowIfNull($"DivisionId hasn't been set, ensure {nameof(ForDivision)} is called");
 
         if (model.Deleted != null)
         {
@@ -73,7 +66,7 @@ public class AddSeasonToTeamCommand : IUpdateCommand<Models.Cosmos.Team.Team, Te
             };
         }
 
-        if (_skipSeasonExistenceCheck == false && await _seasonService.Get(_seasonId.Value, token) == null)
+        if (_skipSeasonExistenceCheck == false && await _seasonService.Get(_seasonId!.Value, token) == null)
         {
             return new ActionResult<TeamSeason>
             {
@@ -121,8 +114,8 @@ public class AddSeasonToTeamCommand : IUpdateCommand<Models.Cosmos.Team.Team, Te
         teamSeason = new TeamSeason
         {
             Id = Guid.NewGuid(),
-            SeasonId = _seasonId.Value,
-            DivisionId = _divisionId.Value,
+            SeasonId = _seasonId!.Value,
+            DivisionId = _divisionId!.Value,
             Players = _copyPlayersFromOtherSeasonId.HasValue
                 ? GetPlayersFromOtherSeason(model, _copyPlayersFromOtherSeasonId.Value)
                 : new List<TeamPlayer>(),

--- a/CourageScores/Services/Command/CommandExtensions.cs
+++ b/CourageScores/Services/Command/CommandExtensions.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace CourageScores.Services.Command;
+
+public static class CommandExtensions
+{
+    [ExcludeFromCodeCoverage]
+    public static void ThrowIfNull<T>(this T? value, string message)
+    {
+        if (value == null)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+}

--- a/CourageScores/Services/Command/CreateTournamentMatchSaygCommand.cs
+++ b/CourageScores/Services/Command/CreateTournamentMatchSaygCommand.cs
@@ -34,12 +34,9 @@ public class CreateTournamentMatchSaygCommand : IUpdateCommand<TournamentGame, T
 
     public async Task<ActionResult<TournamentGame>> ApplyUpdate(TournamentGame model, CancellationToken token)
     {
-        if (_request == null)
-        {
-            throw new InvalidOperationException("WithRequest must be called first");
-        }
+        _request.ThrowIfNull($"{nameof(WithRequest)} must be called first");
 
-        var match = FindMatchVisitor.FindMatch(model, _request.MatchId);
+        var match = FindMatchVisitor.FindMatch(model, _request!.MatchId);
         if (match == null)
         {
             return new ActionResult<TournamentGame>

--- a/CourageScores/Services/Command/CreateTournamentMatchSaygCommand.cs
+++ b/CourageScores/Services/Command/CreateTournamentMatchSaygCommand.cs
@@ -81,26 +81,16 @@ public class CreateTournamentMatchSaygCommand : IUpdateCommand<TournamentGame, T
         if (result.Success)
         {
             match.SaygId = result.Result!.Id;
-            return new ActionResult<TournamentGame>
+            return result.ToActionResult().As(model).Merge(new ActionResult<TournamentGame>
             {
                 Success = true,
-                Messages = result.Messages.Concat(new[]
+                Messages =
                 {
                     "Sayg added to match",
-                }).ToList(),
-                Warnings = result.Warnings,
-                Errors = result.Errors,
-                Result = model,
-            };
+                },
+            });
         }
 
-        return new ActionResult<TournamentGame>
-        {
-            Success = false,
-            Errors = result.Errors,
-            Warnings = result.Warnings,
-            Messages = result.Messages,
-            Result = model,
-        };
+        return result.ToActionResult().As(model);
     }
 }

--- a/CourageScores/Services/Command/DeleteTeamCommand.cs
+++ b/CourageScores/Services/Command/DeleteTeamCommand.cs
@@ -21,10 +21,7 @@ public class DeleteTeamCommand : IUpdateCommand<Models.Cosmos.Team.Team, Models.
 
     public async Task<ActionResult<Models.Cosmos.Team.Team>> ApplyUpdate(Models.Cosmos.Team.Team model, CancellationToken token)
     {
-        if (_seasonId == null)
-        {
-            throw new InvalidOperationException($"SeasonId hasn't been set, ensure {nameof(FromSeason)} is called");
-        }
+        _seasonId.ThrowIfNull($"SeasonId hasn't been set, ensure {nameof(FromSeason)} is called");
 
         if (model.Deleted != null)
         {
@@ -54,7 +51,7 @@ public class DeleteTeamCommand : IUpdateCommand<Models.Cosmos.Team.Team, Models.
             };
         }
 
-        var matchingSeasons = model.Seasons.Where(s => s.SeasonId == _seasonId.Value && s.Deleted == null).ToList();
+        var matchingSeasons = model.Seasons.Where(s => s.SeasonId == _seasonId!.Value && s.Deleted == null).ToList();
         foreach (var matchingSeason in matchingSeasons)
         {
             await _auditingHelper.SetDeleted(matchingSeason, token);
@@ -75,7 +72,7 @@ public class DeleteTeamCommand : IUpdateCommand<Models.Cosmos.Team.Team, Models.
                 };
             }
 
-            _cacheFlags.EvictDivisionDataCacheForSeasonId = _seasonId.Value;
+            _cacheFlags.EvictDivisionDataCacheForSeasonId = _seasonId!.Value;
             return new ActionResult<Models.Cosmos.Team.Team>
             {
                 Success = true,
@@ -91,7 +88,7 @@ public class DeleteTeamCommand : IUpdateCommand<Models.Cosmos.Team.Team, Models.
         {
             if (!matchingSeasons.Any())
             {
-                _cacheFlags.EvictDivisionDataCacheForSeasonId = _seasonId.Value;
+                _cacheFlags.EvictDivisionDataCacheForSeasonId = _seasonId!.Value;
                 return new ActionResult<Models.Cosmos.Team.Team>
                 {
                     Success = true,
@@ -104,7 +101,7 @@ public class DeleteTeamCommand : IUpdateCommand<Models.Cosmos.Team.Team, Models.
                 };
             }
 
-            _cacheFlags.EvictDivisionDataCacheForSeasonId = _seasonId.Value;
+            _cacheFlags.EvictDivisionDataCacheForSeasonId = _seasonId!.Value;
             return new ActionResult<Models.Cosmos.Team.Team>
             {
                 Success = true,
@@ -117,7 +114,7 @@ public class DeleteTeamCommand : IUpdateCommand<Models.Cosmos.Team.Team, Models.
             };
         }
 
-        _cacheFlags.EvictDivisionDataCacheForSeasonId = _seasonId.Value;
+        _cacheFlags.EvictDivisionDataCacheForSeasonId = _seasonId!.Value;
 
         return new ActionResult<Models.Cosmos.Team.Team>
         {

--- a/CourageScores/Services/Command/DeleteTournamentMatchSaygCommand.cs
+++ b/CourageScores/Services/Command/DeleteTournamentMatchSaygCommand.cs
@@ -24,12 +24,9 @@ public class DeleteTournamentMatchSaygCommand : IUpdateCommand<TournamentGame, T
 
     public async Task<ActionResult<TournamentGame>> ApplyUpdate(TournamentGame model, CancellationToken token)
     {
-        if (_matchId == null)
-        {
-            throw new InvalidOperationException("FromMatch must be called first");
-        }
+        _matchId.ThrowIfNull($"{nameof(FromMatch)} must be called first");
 
-        var match = FindMatchVisitor.FindMatch(model, _matchId.Value);
+        var match = FindMatchVisitor.FindMatch(model, _matchId!.Value);
         if (match == null)
         {
             return new ActionResult<TournamentGame>

--- a/CourageScores/Services/Command/DeleteTournamentMatchSaygCommand.cs
+++ b/CourageScores/Services/Command/DeleteTournamentMatchSaygCommand.cs
@@ -62,27 +62,14 @@ public class DeleteTournamentMatchSaygCommand : IUpdateCommand<TournamentGame, T
         {
             match.SaygId = null;
 
-            return new ActionResult<TournamentGame>
+            return result.ToActionResult().As(model).Merge(new ActionResult<TournamentGame>
             {
                 Success = true,
-                Messages = result.Messages.Concat(new[]
-                {
-                    "Sayg deleted and removed from match",
-                }).ToList(),
-                Warnings = result.Warnings,
-                Errors = result.Errors,
-                Result = model,
-            };
+                Messages = { "Sayg deleted and removed from match" },
+            });
         }
 
-        return new ActionResult<TournamentGame>
-        {
-            Success = false,
-            Errors = result.Errors,
-            Warnings = result.Warnings,
-            Messages = result.Messages,
-            Result = model,
-        };
+        return result.ToActionResult().As(model);
     }
 
 }

--- a/CourageScores/Services/Command/PatchTournamentCommand.cs
+++ b/CourageScores/Services/Command/PatchTournamentCommand.cs
@@ -27,17 +27,14 @@ public class PatchTournamentCommand : IUpdateCommand<TournamentGame, TournamentG
 
     public async Task<ActionResult<TournamentGame>> ApplyUpdate(TournamentGame model, CancellationToken token)
     {
-        if (_patch == null)
-        {
-            throw new InvalidOperationException("WithPatch must be called first");
-        }
+        _patch.ThrowIfNull($"{nameof(WithPatch)} must be called first");
 
         var updates = new ActionResult<object>
         {
             Success = true,
         };
         var updatesApplied = false;
-        if (_patch.Round != null)
+        if (_patch!.Round != null)
         {
             updates = updates.Merge(await PatchRound(model.Round, _patch.Round));
             updatesApplied = true;

--- a/CourageScores/Services/Command/RemovePlayerCommand.cs
+++ b/CourageScores/Services/Command/RemovePlayerCommand.cs
@@ -37,15 +37,8 @@ public class RemovePlayerCommand : IUpdateCommand<Models.Cosmos.Team.Team, TeamP
 
     public async Task<ActionResult<TeamPlayer>> ApplyUpdate(Models.Cosmos.Team.Team model, CancellationToken token)
     {
-        if (_playerId == null)
-        {
-            throw new InvalidOperationException($"PlayerId hasn't been set, ensure {nameof(ForPlayer)} is called");
-        }
-
-        if (_seasonId == null)
-        {
-            throw new InvalidOperationException($"SeasonId hasn't been set, ensure {nameof(FromSeason)} is called");
-        }
+        _playerId.ThrowIfNull($"PlayerId hasn't been set, ensure {nameof(ForPlayer)} is called");
+        _seasonId.ThrowIfNull($"SeasonId hasn't been set, ensure {nameof(FromSeason)} is called");
 
         if (model.Deleted != null)
         {
@@ -86,7 +79,7 @@ public class RemovePlayerCommand : IUpdateCommand<Models.Cosmos.Team.Team, TeamP
             };
         }
 
-        var season = await _seasonService.Get(_seasonId.Value, token);
+        var season = await _seasonService.Get(_seasonId!.Value, token);
         if (season == null)
         {
             return new ActionResult<TeamPlayer>

--- a/CourageScores/Services/Command/UpdatePlayerCommand.cs
+++ b/CourageScores/Services/Command/UpdatePlayerCommand.cs
@@ -57,20 +57,9 @@ public class UpdatePlayerCommand : IUpdateCommand<Models.Cosmos.Team.Team, TeamP
 
     public async Task<ActionResult<TeamPlayer>> ApplyUpdate(Models.Cosmos.Team.Team model, CancellationToken token)
     {
-        if (_playerId == null)
-        {
-            throw new InvalidOperationException($"PlayerId hasn't been set, ensure {nameof(ForPlayer)} is called");
-        }
-
-        if (_player == null)
-        {
-            throw new InvalidOperationException($"Player hasn't been set, ensure {nameof(WithData)} is called");
-        }
-
-        if (_seasonId == null)
-        {
-            throw new InvalidOperationException($"SeasonId hasn't been set, ensure {nameof(InSeason)} is called");
-        }
+        _playerId.ThrowIfNull($"PlayerId hasn't been set, ensure {nameof(ForPlayer)} is called");
+        _player.ThrowIfNull($"Player hasn't been set, ensure {nameof(WithData)} is called");
+        _seasonId.ThrowIfNull($"SeasonId hasn't been set, ensure {nameof(InSeason)} is called");
 
         if (model.Deleted != null)
         {
@@ -111,7 +100,7 @@ public class UpdatePlayerCommand : IUpdateCommand<Models.Cosmos.Team.Team, TeamP
             };
         }
 
-        var season = await _seasonService.Get(_seasonId.Value, token);
+        var season = await _seasonService.Get(_seasonId!.Value, token);
         if (season == null)
         {
             return new ActionResult<TeamPlayer>
@@ -150,7 +139,7 @@ public class UpdatePlayerCommand : IUpdateCommand<Models.Cosmos.Team.Team, TeamP
             };
         }
 
-        if (player.Updated != _player.LastUpdated)
+        if (player.Updated != _player!.LastUpdated)
         {
             return new ActionResult<TeamPlayer>
             {

--- a/CourageScores/Services/Command/UpdateScoresCommand.cs
+++ b/CourageScores/Services/Command/UpdateScoresCommand.cs
@@ -247,13 +247,13 @@ public class UpdateScoresCommand : IUpdateCommand<CosmosGame, GameDto>
             {
                 game.Matches[index] = await _updateScoresAdapter.UpdateMatch(currentMatch, updatedMatch, token);
             }
-
-            game.OneEighties = await _scores.OneEighties.SelectAsync(p => _updateScoresAdapter.AdaptToPlayer(p, token)).ToList();
-            game.Over100Checkouts = await _scores.Over100Checkouts.SelectAsync(p => _updateScoresAdapter.AdaptToHiCheckPlayer(p, token)).ToList();
-            game.Home.ManOfTheMatch = _scores.Home?.ManOfTheMatch;
-            game.Away.ManOfTheMatch = _scores.Away?.ManOfTheMatch;
-            game.Version = CosmosGame.CurrentVersion;
         }
+
+        game.OneEighties = await _scores.OneEighties.SelectAsync(p => _updateScoresAdapter.AdaptToPlayer(p, token)).ToList();
+        game.Over100Checkouts = await _scores.Over100Checkouts.SelectAsync(p => _updateScoresAdapter.AdaptToHiCheckPlayer(p, token)).ToList();
+        game.Home.ManOfTheMatch = _scores.Home?.ManOfTheMatch;
+        game.Away.ManOfTheMatch = _scores.Away?.ManOfTheMatch;
+        game.Version = CosmosGame.CurrentVersion;
 
         return Success("Game updated");
     }

--- a/CourageScores/Services/Command/UpdateScoresCommand.cs
+++ b/CourageScores/Services/Command/UpdateScoresCommand.cs
@@ -288,8 +288,8 @@ public class UpdateScoresCommand : IUpdateCommand<CosmosGame, GameDto>
     private static CosmosGame MergeDetails(CosmosGame game, CosmosGame submission)
     {
         submission.Id = game.Id;
-        submission.Away = game.Away;
-        submission.Home = game.Home;
+        submission.Away = Copy(game.Away);
+        submission.Home = Copy(game.Home);
         submission.Address = game.Address;
         submission.Date = game.Date;
         submission.Postponed = game.Postponed;
@@ -298,6 +298,16 @@ public class UpdateScoresCommand : IUpdateCommand<CosmosGame, GameDto>
         submission.AccoladesCount = game.AccoladesCount;
         submission.SeasonId = game.SeasonId;
         return submission;
+    }
+
+    private static GameTeam Copy(GameTeam team)
+    {
+        return new GameTeam
+        {
+            Id = team.Id,
+            Name = team.Name,
+            ManOfTheMatch = team.ManOfTheMatch,
+        };
     }
 
     private static ActionResult<GameDto> Success(string message, GameDto? result = null)

--- a/CourageScores/Services/Command/UpdateScoresCommand.cs
+++ b/CourageScores/Services/Command/UpdateScoresCommand.cs
@@ -1,10 +1,10 @@
 ﻿using CourageScores.Filters;
 using CourageScores.Models;
 using CourageScores.Models.Adapters;
+using CourageScores.Models.Adapters.Season;
+using CourageScores.Models.Cosmos;
 using CourageScores.Models.Cosmos.Game;
-using CourageScores.Models.Cosmos.Game.Sayg;
 using CourageScores.Models.Dtos.Game;
-using CourageScores.Models.Dtos.Game.Sayg;
 using CourageScores.Models.Dtos.Identity;
 using CourageScores.Services.Identity;
 using CourageScores.Services.Season;
@@ -16,10 +16,10 @@ public class UpdateScoresCommand : IUpdateCommand<Models.Cosmos.Game.Game, GameD
 {
     private readonly IAuditingHelper _auditingHelper;
     private readonly ScopedCacheManagementFlags _cacheFlags;
+    private readonly IUpdateScoresAdapter _updateScoresAdapter;
     private readonly ICommandFactory _commandFactory;
     private readonly IAdapter<Models.Cosmos.Game.Game, GameDto> _gameAdapter;
     private readonly ISimpleAdapter<GameMatchOption?, GameMatchOptionDto?> _matchOptionsAdapter;
-    private readonly ISimpleAdapter<ScoreAsYouGo, ScoreAsYouGoDto> _scoreAsYouGoAdapter;
     private readonly ICachingSeasonService _seasonService;
     private readonly ITeamService _teamService;
     private readonly IUserService _userService;
@@ -28,22 +28,22 @@ public class UpdateScoresCommand : IUpdateCommand<Models.Cosmos.Game.Game, GameD
     public UpdateScoresCommand(IUserService userService,
         IAdapter<Models.Cosmos.Game.Game, GameDto> gameAdapter,
         ISimpleAdapter<GameMatchOption?, GameMatchOptionDto?> matchOptionsAdapter,
-        ISimpleAdapter<ScoreAsYouGo, ScoreAsYouGoDto> scoreAsYouGoAdapter,
         IAuditingHelper auditingHelper,
         ICachingSeasonService seasonService,
         ICommandFactory commandFactory,
         ITeamService teamService,
-        ScopedCacheManagementFlags cacheFlags)
+        ScopedCacheManagementFlags cacheFlags,
+        IUpdateScoresAdapter updateScoresAdapter)
     {
         _userService = userService;
         _gameAdapter = gameAdapter;
         _matchOptionsAdapter = matchOptionsAdapter;
-        _scoreAsYouGoAdapter = scoreAsYouGoAdapter;
         _auditingHelper = auditingHelper;
         _seasonService = seasonService;
         _commandFactory = commandFactory;
         _teamService = teamService;
         _cacheFlags = cacheFlags;
+        _updateScoresAdapter = updateScoresAdapter;
     }
 
     public UpdateScoresCommand WithData(RecordScoresDto scores)
@@ -123,42 +123,50 @@ public class UpdateScoresCommand : IUpdateCommand<Models.Cosmos.Game.Game, GameD
         var dateChanged = _scores.Date != game.Date;
         game.Date = _scores.Date;
 
-        if (dateChanged)
+        var dateChangedResult = dateChanged
+            ? await MoveGameToAlternativeSeason(game, token)
+            : null;
+
+        return dateChangedResult ?? Success("Game details updated");
+    }
+
+    private async Task<ActionResult<GameDto>?> MoveGameToAlternativeSeason(Models.Cosmos.Game.Game game, CancellationToken token)
+    {
+        var newSeasonId = await GetAppropriateSeasonId(game.Date, token);
+        if (newSeasonId == null || newSeasonId == game.SeasonId)
         {
-            var newSeasonId = await GetAppropriateSeasonId(game.Date, token);
-            if (newSeasonId != null && (newSeasonId != game.SeasonId || dateChanged))
-            {
-                var command = _commandFactory.GetCommand<AddSeasonToTeamCommand>()
-                    .ForSeason(newSeasonId.Value)
-                    .ForDivision(game.DivisionId)
-                    .CopyPlayersFromSeasonId(game.SeasonId);
-
-                game.SeasonId = newSeasonId.Value;
-
-                // register both teams with this season.
-                var homeResult = await _teamService.Upsert(game.Home.Id, command, token);
-                var awayResult = await _teamService.Upsert(game.Away.Id, command, token);
-
-                var success = homeResult.Success && awayResult.Success;
-                if (!success)
-                {
-                    return new ActionResult<GameDto>
-                    {
-                        Success = false,
-                        Errors = homeResult.Errors.Concat(awayResult.Errors).ToList(),
-                        Warnings = homeResult.Warnings.Concat(awayResult.Warnings).ToList(),
-                        Messages = homeResult.Messages.Concat(awayResult.Messages)
-                            .Concat(new[]
-                            {
-                                "Could not add season to home and/or away teams",
-                            }).ToList(),
-                        Result = await _gameAdapter.Adapt(game, token),
-                    };
-                }
-            }
+            return null;
         }
 
-        return Success("Game details updated");
+        var command = _commandFactory.GetCommand<AddSeasonToTeamCommand>()
+            .ForSeason(newSeasonId.Value)
+            .ForDivision(game.DivisionId)
+            .CopyPlayersFromSeasonId(game.SeasonId);
+
+        game.SeasonId = newSeasonId.Value;
+
+        // register both teams with this season.
+        var homeResult = await _teamService.Upsert(game.Home.Id, command, token);
+        var awayResult = await _teamService.Upsert(game.Away.Id, command, token);
+
+        var success = homeResult.Success && awayResult.Success;
+        if (success)
+        {
+            return null;
+        }
+
+        return new ActionResult<GameDto>
+        {
+            Success = false,
+            Errors = homeResult.Errors.Concat(awayResult.Errors).ToList(),
+            Warnings = homeResult.Warnings.Concat(awayResult.Warnings).ToList(),
+            Messages = homeResult.Messages.Concat(awayResult.Messages)
+                .Concat(new[]
+                {
+                    "Could not add season to home and/or away teams",
+                }).ToList(),
+            Result = await _gameAdapter.Adapt(game, token),
+        };
     }
 
     private async Task<ActionResult<GameDto>> UpdateSubmission(Models.Cosmos.Game.Game game, UserDto user, CancellationToken token)
@@ -194,7 +202,50 @@ public class UpdateScoresCommand : IUpdateCommand<Models.Cosmos.Game.Game, GameD
         return Success("Submission updated");
     }
 
-    private static Models.Cosmos.Game.Game NewSubmission(Models.Cosmos.Game.Game game)
+    private async Task<ActionResult<GameDto>> UpdateResults(Models.Cosmos.Game.Game game, CancellationToken token)
+    {
+        if (game.Updated != _scores!.LastUpdated)
+        {
+            return Warning(_scores.LastUpdated == null
+                ? $"Unable to update {nameof(Game)}, data integrity token is missing"
+                : $"Unable to update {nameof(Game)}, {game.Editor} updated it before you at {game.Updated:d MMM yyyy HH:mm:ss}");
+        }
+
+        for (var index = 0; index < Math.Max(_scores.Matches.Count, game.Matches.Count); index++)
+        {
+            var updatedMatch = _scores.Matches.ElementAtOrDefault(index);
+            var currentMatch = game.Matches.ElementAtOrDefault(index);
+
+            if (currentMatch == null && updatedMatch != null)
+            {
+                game.Matches.Add(await _updateScoresAdapter.AdaptToMatch(updatedMatch, token));
+            }
+            else if (updatedMatch == null && currentMatch != null)
+            {
+                game.Matches.RemoveAt(index);
+            }
+            else if (currentMatch != null && updatedMatch != null)
+            {
+                game.Matches[index] = await _updateScoresAdapter.UpdateMatch(currentMatch, updatedMatch, token);
+            }
+
+            game.OneEighties = await _scores.OneEighties.SelectAsync(p => _updateScoresAdapter.AdaptToPlayer(p, token)).ToList();
+            game.Over100Checkouts = await _scores.Over100Checkouts.SelectAsync(p => _updateScoresAdapter.AdaptToHiCheckPlayer(p, token)).ToList();
+            game.Home.ManOfTheMatch = _scores.Home?.ManOfTheMatch;
+            game.Away.ManOfTheMatch = _scores.Away?.ManOfTheMatch;
+            game.Version = Models.Cosmos.Game.Game.CurrentVersion;
+        }
+
+        return Success("Game updated");
+    }
+
+    private async Task<Guid?> GetAppropriateSeasonId(DateTime gameDate, CancellationToken token)
+    {
+        var season = await _seasonService.GetForDate(gameDate, token);
+        return season?.Id;
+    }
+
+    private static Models.Cosmos.Game.Game NewSubmission(AuditedEntity game)
     {
         return new Models.Cosmos.Game.Game
         {
@@ -216,137 +267,6 @@ public class UpdateScoresCommand : IUpdateCommand<Models.Cosmos.Game.Game, GameD
         submission.AccoladesCount = game.AccoladesCount;
         submission.SeasonId = game.SeasonId;
         return submission;
-    }
-
-    private async Task<ActionResult<GameDto>> UpdateResults(Models.Cosmos.Game.Game game, CancellationToken token)
-    {
-        if (game.Updated != _scores!.LastUpdated)
-        {
-            return Warning(_scores.LastUpdated == null
-                ? $"Unable to update {nameof(Game)}, data integrity token is missing"
-                : $"Unable to update {nameof(Game)}, {game.Editor} updated it before you at {game.Updated:d MMM yyyy HH:mm:ss}");
-        }
-
-        for (var index = 0; index < Math.Max(_scores.Matches.Count, game.Matches.Count); index++)
-        {
-            var updatedMatch = _scores.Matches.ElementAtOrDefault(index);
-            var currentMatch = game.Matches.ElementAtOrDefault(index);
-
-            if (currentMatch == null && updatedMatch != null)
-            {
-                game.Matches.Add(await AdaptToMatch(updatedMatch, token));
-            }
-            else if (updatedMatch == null && currentMatch != null)
-            {
-                game.Matches.RemoveAt(index);
-            }
-            else if (currentMatch != null && updatedMatch != null)
-            {
-                game.Matches[index] = await UpdateMatch(currentMatch, updatedMatch, token);
-            }
-
-            game.OneEighties = await _scores.OneEighties.SelectAsync(p => AdaptToPlayer(p, token)).ToList();
-            game.Over100Checkouts = await _scores.Over100Checkouts.SelectAsync(p => AdaptToHiCheckPlayer(p, token)).ToList();
-            game.Home.ManOfTheMatch = _scores.Home?.ManOfTheMatch;
-            game.Away.ManOfTheMatch = _scores.Away?.ManOfTheMatch;
-            game.Version = Models.Cosmos.Game.Game.CurrentVersion;
-        }
-
-        return Success("Game updated");
-    }
-
-    private async Task<Guid?> GetAppropriateSeasonId(DateTime gameDate, CancellationToken token)
-    {
-        var seasons = await _seasonService.GetAll(token)
-            .WhereAsync(s => s.StartDate <= gameDate && s.EndDate >= gameDate)
-            .ToList();
-
-        switch (seasons.Count)
-        {
-            case 0:
-                // no seasons found for this date
-                return null;
-            case 1:
-                // only one season found, return its id
-                return seasons.Single().Id;
-            default:
-                // multiple seasons found, cannot unambiguously determine which one to use
-                return null;
-        }
-    }
-
-    private async Task<GameMatch> AdaptToMatch(RecordScoresDto.RecordScoresGameMatchDto updatedMatch, CancellationToken token)
-    {
-        var user = await _userService.GetUser(token);
-        var permitted = user?.Access?.RecordScoresAsYouGo == true;
-
-        var match = new GameMatch
-        {
-            Id = Guid.NewGuid(),
-            AwayPlayers = await updatedMatch.AwayPlayers.SelectAsync(p => AdaptToPlayer(p, token)).ToList(),
-            AwayScore = updatedMatch.AwayScore,
-            HomePlayers = await updatedMatch.HomePlayers.SelectAsync(p => AdaptToPlayer(p, token)).ToList(),
-            HomeScore = updatedMatch.HomeScore,
-            Sayg = updatedMatch.Sayg != null && permitted
-                ? await _scoreAsYouGoAdapter.Adapt(updatedMatch.Sayg, token)
-                : null,
-        };
-
-        await _auditingHelper.SetUpdated(match, token);
-        return match;
-    }
-
-    private async Task<GameMatch> UpdateMatch(GameMatch currentMatch, RecordScoresDto.RecordScoresGameMatchDto updatedMatch, CancellationToken token)
-    {
-        var user = await _userService.GetUser(token);
-        var permitted = user?.Access?.RecordScoresAsYouGo == true;
-        if (!updatedMatch.HomePlayers.Any() || !updatedMatch.AwayPlayers.Any())
-        {
-            updatedMatch.Sayg = null;
-            currentMatch.Sayg = null; // remove the current sayg data, there are no players for it to apply to.
-        }
-
-        var match = new GameMatch
-        {
-            Author = currentMatch.Author,
-            Created = currentMatch.Created,
-            Deleted = currentMatch.Deleted,
-            Id = currentMatch.Id,
-            Remover = currentMatch.Remover,
-            Version = currentMatch.Version,
-            AwayPlayers = await updatedMatch.AwayPlayers.SelectAsync(p => AdaptToPlayer(p, token)).ToList(),
-            AwayScore = updatedMatch.AwayScore,
-            HomePlayers = await updatedMatch.HomePlayers.SelectAsync(p => AdaptToPlayer(p, token)).ToList(),
-            HomeScore = updatedMatch.HomeScore,
-            Sayg = updatedMatch.Sayg != null && permitted
-                ? await _scoreAsYouGoAdapter.Adapt(updatedMatch.Sayg, token)
-                : currentMatch.Sayg,
-        };
-        await _auditingHelper.SetUpdated(match, token);
-        return match;
-    }
-
-    private async Task<GamePlayer> AdaptToPlayer(RecordScoresDto.RecordScoresGamePlayerDto player, CancellationToken token)
-    {
-        var gamePlayer = new GamePlayer
-        {
-            Id = player.Id,
-            Name = player.Name,
-        };
-        await _auditingHelper.SetUpdated(gamePlayer, token);
-        return gamePlayer;
-    }
-
-    private async Task<NotablePlayer> AdaptToHiCheckPlayer(RecordScoresDto.GameOver100CheckoutDto player, CancellationToken token)
-    {
-        var gamePlayer = new NotablePlayer
-        {
-            Id = player.Id,
-            Name = player.Name,
-            Notes = player.Notes,
-        };
-        await _auditingHelper.SetUpdated(gamePlayer, token);
-        return gamePlayer;
     }
 
     private static ActionResult<GameDto> Success(string message, GameDto? result = null)

--- a/CourageScores/Services/Command/UpdateScoresCommand.cs
+++ b/CourageScores/Services/Command/UpdateScoresCommand.cs
@@ -59,10 +59,7 @@ public class UpdateScoresCommand : IUpdateCommand<CosmosGame, GameDto>
 
     public async Task<ActionResult<GameDto>> ApplyUpdate(CosmosGame game, CancellationToken token)
     {
-        if (_scores == null)
-        {
-            throw new InvalidOperationException($"Game hasn't been set, ensure {nameof(WithData)} is called");
-        }
+        _scores.ThrowIfNull($"Game hasn't been set, ensure {nameof(WithData)} is called");
 
         if (game.Deleted != null)
         {

--- a/CourageScores/Services/Game/BaseOrderUnimportantComparer.cs
+++ b/CourageScores/Services/Game/BaseOrderUnimportantComparer.cs
@@ -1,0 +1,39 @@
+namespace CourageScores.Services.Game;
+
+public abstract class BaseOrderUnimportantComparer<T> : IEqualityComparer<T>, IEqualityComparer<ICollection<T>>
+{
+    public bool Equals(ICollection<T>? x, ICollection<T>? y)
+    {
+        if (x == null && y == null)
+        {
+            return true;
+        }
+
+        if (x == null || y == null)
+        {
+            return false;
+        }
+
+        var setX = new HashSet<T>(x, this);
+        var setY = new HashSet<T>(y, this);
+        return setX.SetEquals(setY);
+    }
+
+    public int GetHashCode(ICollection<T> obj)
+    {
+        return obj.Count;
+    }
+
+    bool IEqualityComparer<T>.Equals(T? x, T? y)
+    {
+        if (x == null && y == null)
+        {
+            return true;
+        }
+
+        return Equals(x!, y!);
+    }
+
+    public abstract bool Equals(T x, T y);
+    public abstract int GetHashCode(T obj);
+}

--- a/CourageScores/Services/Game/GameComparer.cs
+++ b/CourageScores/Services/Game/GameComparer.cs
@@ -1,0 +1,61 @@
+using CourageScores.Models.Cosmos.Game;
+using CosmosGame = CourageScores.Models.Cosmos.Game.Game;
+
+namespace CourageScores.Services.Game;
+
+public class GameComparer : IEqualityComparer<CosmosGame>
+{
+    private readonly IEqualityComparer<GameTeam> _teamComparer;
+    private readonly IEqualityComparer<GameMatch> _matchComparer;
+    private readonly IEqualityComparer<GameMatchOption?> _matchOptionComparer;
+    private readonly IEqualityComparer<ICollection<GamePlayer>> _oneEightiesComparer;
+    private readonly IEqualityComparer<ICollection<NotablePlayer>> _hiChecksComparer;
+
+    public GameComparer(
+        IEqualityComparer<GameTeam> teamComparer,
+        IEqualityComparer<GameMatch> matchComparer,
+        IEqualityComparer<GameMatchOption?> matchOptionComparer,
+        IEqualityComparer<ICollection<GamePlayer>> oneEightiesComparer,
+        IEqualityComparer<ICollection<NotablePlayer>> hiChecksComparer)
+    {
+        _teamComparer = teamComparer;
+        _matchComparer = matchComparer;
+        _matchOptionComparer = matchOptionComparer;
+        _oneEightiesComparer = oneEightiesComparer;
+        _hiChecksComparer = hiChecksComparer;
+    }
+
+    public bool Equals(CosmosGame? x, CosmosGame? y)
+    {
+        if (x == null && y == null)
+        {
+            return true;
+        }
+
+        if (x == null || y == null)
+        {
+            return false;
+        }
+
+        return x.Id == y.Id
+               && x.Date == y.Date
+               && x.DivisionId == y.DivisionId
+               && x.SeasonId == y.SeasonId
+               && _teamComparer.Equals(x.Home, y.Home)
+               && _teamComparer.Equals(x.Away, y.Away)
+               && x.Matches.SequenceEqual(y.Matches, _matchComparer)
+               && x.MatchOptions.SequenceEqual(y.MatchOptions, _matchOptionComparer)
+               && _oneEightiesComparer.Equals(x.OneEighties, y.OneEighties)
+               && _hiChecksComparer.Equals(x.Over100Checkouts, y.Over100Checkouts);
+    }
+
+    public int GetHashCode(CosmosGame obj)
+    {
+        return obj.Id.GetHashCode()
+               ^ obj.Date.GetHashCode()
+               ^ obj.DivisionId.GetHashCode()
+               ^ obj.SeasonId.GetHashCode()
+               ^ _teamComparer.GetHashCode(obj.Home)
+               ^ _teamComparer.GetHashCode(obj.Away);
+    }
+}

--- a/CourageScores/Services/Game/GameMatchComparer.cs
+++ b/CourageScores/Services/Game/GameMatchComparer.cs
@@ -1,0 +1,36 @@
+using CourageScores.Models.Cosmos.Game;
+
+namespace CourageScores.Services.Game;
+
+public class GameMatchComparer : IEqualityComparer<GameMatch>
+{
+    private readonly IEqualityComparer<ICollection<GamePlayer>> _playerComparer;
+
+    public GameMatchComparer(IEqualityComparer<ICollection<GamePlayer>> playerComparer)
+    {
+        _playerComparer = playerComparer;
+    }
+
+    public bool Equals(GameMatch? x, GameMatch? y)
+    {
+        if (x == null && y == null)
+        {
+            return true;
+        }
+
+        if (x == null || y == null)
+        {
+            return false;
+        }
+
+        return x.HomeScore == y.HomeScore
+               && x.AwayScore == y.AwayScore
+               && _playerComparer.Equals(x.HomePlayers, y.HomePlayers)
+               && _playerComparer.Equals(x.AwayPlayers, y.AwayPlayers);
+    }
+
+    public int GetHashCode(GameMatch obj)
+    {
+        return (obj.HomeScore?.GetHashCode() ^ obj.AwayScore?.GetHashCode()) ?? 0;
+    }
+}

--- a/CourageScores/Services/Game/GameMatchOptionComparer.cs
+++ b/CourageScores/Services/Game/GameMatchOptionComparer.cs
@@ -1,0 +1,33 @@
+using CourageScores.Models.Cosmos.Game;
+
+namespace CourageScores.Services.Game;
+
+public class GameMatchOptionComparer : IEqualityComparer<GameMatchOption?>
+{
+    public bool Equals(GameMatchOption? x, GameMatchOption? y)
+    {
+        if (x == null && y == null)
+        {
+            return true;
+        }
+
+        if (x == null || y == null)
+        {
+            return false;
+        }
+
+        return x.StartingScore == y.StartingScore
+               && x.NumberOfLegs == y.NumberOfLegs
+               && x.PlayerCount == y.PlayerCount;
+    }
+
+    public int GetHashCode(GameMatchOption? obj)
+    {
+        if (obj == null)
+        {
+            return 0;
+        }
+
+        return (obj.NumberOfLegs ^ obj.StartingScore ^ obj.PlayerCount) ?? 0;
+    }
+}

--- a/CourageScores/Services/Game/GamePlayerComparer.cs
+++ b/CourageScores/Services/Game/GamePlayerComparer.cs
@@ -1,0 +1,17 @@
+using CourageScores.Models.Cosmos.Game;
+
+namespace CourageScores.Services.Game;
+
+public class GamePlayerComparer : BaseOrderUnimportantComparer<GamePlayer>
+{
+    public override bool Equals(GamePlayer x, GamePlayer y)
+    {
+        return x.Id == y.Id
+            && StringComparer.OrdinalIgnoreCase.Equals(x.Name.Trim(), y.Name.Trim());
+    }
+
+    public override int GetHashCode(GamePlayer obj)
+    {
+        return obj.Id.GetHashCode();
+    }
+}

--- a/CourageScores/Services/Game/GameService.cs
+++ b/CourageScores/Services/Game/GameService.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Game;
 using CourageScores.Services.Command;
@@ -33,6 +32,26 @@ public class GameService : IGameService
     public IAsyncEnumerable<GameDto> GetWhere(string query, CancellationToken token)
     {
         return _underlyingService.GetWhere(query, token).SelectAsync(g => Adapt(g, token));
+    }
+
+    public async Task<ActionResultDto<GameDto>> Upsert<TOut>(Guid id, IUpdateCommand<Models.Cosmos.Game.Game, TOut> updateCommand, CancellationToken token)
+    {
+        var result = await _underlyingService.Upsert(id, updateCommand, token);
+        if (result.Result != null)
+        {
+            result.Result = await Adapt(result.Result, token);
+        }
+        return result;
+    }
+
+    public async Task<ActionResultDto<GameDto>> Delete(Guid id, CancellationToken token)
+    {
+        var result = await _underlyingService.Delete(id, token);
+        if (result.Result != null)
+        {
+            result.Result = await Adapt(result.Result, token);
+        }
+        return result;
     }
 
     private async Task<GameDto> Adapt(GameDto game, CancellationToken token)
@@ -89,20 +108,4 @@ public class GameService : IGameService
         submission.SeasonId = game.SeasonId;
         return submission;
     }
-
-    #region delegating members
-
-    [ExcludeFromCodeCoverage]
-    public Task<ActionResultDto<GameDto>> Upsert<TOut>(Guid id, IUpdateCommand<Models.Cosmos.Game.Game, TOut> updateCommand, CancellationToken token)
-    {
-        return _underlyingService.Upsert(id, updateCommand, token);
-    }
-
-    [ExcludeFromCodeCoverage]
-    public Task<ActionResultDto<GameDto>> Delete(Guid id, CancellationToken token)
-    {
-        return _underlyingService.Delete(id, token);
-    }
-
-    #endregion
 }

--- a/CourageScores/Services/Game/GameService.cs
+++ b/CourageScores/Services/Game/GameService.cs
@@ -96,10 +96,12 @@ public class GameService : IGameService
 
     private static GameDto MergeDetails(GameDto game, GameDto? submission)
     {
-        submission ??= new GameDto();
+        submission ??= new GameDto
+        {
+            Home = game.Home,
+            Away = game.Away,
+        };
         submission.Id = game.Id;
-        submission.Away = game.Away;
-        submission.Home = game.Home;
         submission.Address = game.Address;
         submission.Date = game.Date;
         submission.Postponed = game.Postponed;

--- a/CourageScores/Services/Game/GameService.cs
+++ b/CourageScores/Services/Game/GameService.cs
@@ -106,6 +106,10 @@ public class GameService : IGameService
         submission.DivisionId = game.DivisionId;
         submission.IsKnockout = game.IsKnockout;
         submission.SeasonId = game.SeasonId;
+        submission.Author ??= game.Author;
+        submission.Created ??= game.Created;
+        submission.Editor ??= game.Editor;
+        submission.Updated ??= game.Updated;
         return submission;
     }
 }

--- a/CourageScores/Services/Game/GameTeamComparer.cs
+++ b/CourageScores/Services/Game/GameTeamComparer.cs
@@ -1,0 +1,27 @@
+using CourageScores.Models.Cosmos.Game;
+
+namespace CourageScores.Services.Game;
+
+public class GameTeamComparer : IEqualityComparer<GameTeam>
+{
+    public bool Equals(GameTeam? x, GameTeam? y)
+    {
+        if (x == null && y == null)
+        {
+            return true;
+        }
+
+        if (x == null || y == null)
+        {
+            return false;
+        }
+
+        return x.Id == y.Id
+            && StringComparer.OrdinalIgnoreCase.Equals(x.Name.Trim(), y.Name.Trim());
+    }
+
+    public int GetHashCode(GameTeam obj)
+    {
+        return obj.Id.GetHashCode();
+    }
+}

--- a/CourageScores/Services/Game/HiChecksComparer.cs
+++ b/CourageScores/Services/Game/HiChecksComparer.cs
@@ -1,0 +1,18 @@
+using CourageScores.Models.Cosmos.Game;
+
+namespace CourageScores.Services.Game;
+
+public class HiChecksComparer : BaseOrderUnimportantComparer<NotablePlayer>
+{
+    public override bool Equals(NotablePlayer x, NotablePlayer y)
+    {
+        return x.Id == y.Id
+               && StringComparer.OrdinalIgnoreCase.Equals(x.Name.Trim(), y.Name.Trim())
+               && x.Notes?.Trim() == y.Notes?.Trim();
+    }
+
+    public override int GetHashCode(NotablePlayer obj)
+    {
+        return obj.Id.GetHashCode();
+    }
+}


### PR DESCRIPTION
- [x] add tests for scores adapter
- [x] add tests for uncovered branches of UpdateScoresCommand
- [x] add tests for auto-merging submissions
- [x] add tests for data-integrity tokens from GameService.Adapt
- [x] add tests for GameService.Delete -> Adapt
- [x] add tests for GameService.Upsert -> Adapt
- [x] fix exception when logged in as an admin
- [x] once published submission should be readonly
- [x] switching between the submissions does not correctly change man of the match
- [x] man of the match option for merge shows as id only
- [x] man of the match for a team submission should not be excluded by adapter
- [x] Add tests for score card heading
- [x] show the name of the submission author when reviewing the submissions (logged in as an admin)
- [x] Update tests for unpublish results
- [x] description of submissions show same author for home and away submissions

Resolves #663