### PR TITLE
#729 simplify tournament data entry

### DIFF
--- a/CourageScores.Tests/Models/Adapters/Identity/AccessAdapterTests.cs
+++ b/CourageScores.Tests/Models/Adapters/Identity/AccessAdapterTests.cs
@@ -36,6 +36,7 @@ public class AccessAdapterTests
             ShowDebugOptions = true,
             ManageSockets = true,
             UseWebSockets = true,
+            EnterTournamentResults = true,
         };
 
         var result = await _adapter.Adapt(model, _token);
@@ -60,6 +61,7 @@ public class AccessAdapterTests
         Assert.That(result.ShowDebugOptions, Is.EqualTo(model.ShowDebugOptions));
         Assert.That(result.ManageSockets, Is.EqualTo(model.ManageSockets));
         Assert.That(result.UseWebSockets, Is.EqualTo(model.UseWebSockets));
+        Assert.That(result.EnterTournamentResults, Is.EqualTo(model.EnterTournamentResults));
     }
 
     [Test]
@@ -87,6 +89,7 @@ public class AccessAdapterTests
             ShowDebugOptions = true,
             ManageSockets = true,
             UseWebSockets = true,
+            EnterTournamentResults = true,
         };
 
         var result = await _adapter.Adapt(dto, _token);
@@ -110,5 +113,6 @@ public class AccessAdapterTests
         Assert.That(result.ShowDebugOptions, Is.EqualTo(dto.ShowDebugOptions));
         Assert.That(result.ManageSockets, Is.EqualTo(dto.ManageSockets));
         Assert.That(result.UseWebSockets, Is.EqualTo(dto.UseWebSockets));
+        Assert.That(result.EnterTournamentResults, Is.EqualTo(dto.EnterTournamentResults));
     }
 }

--- a/CourageScores/ClientApp/package.json
+++ b/CourageScores/ClientApp/package.json
@@ -53,6 +53,7 @@
     "collectCoverageFrom": [
       "!src/tests/**/*.ts",
       "!coverage/**/*.js",
+      "!dist/**/*.*",
       "!src/interfaces/apis/**/*.ts",
       "!src/interfaces/models/**/*.ts"
     ]

--- a/CourageScores/ClientApp/src/api/http.ts
+++ b/CourageScores/ClientApp/src/api/http.ts
@@ -8,6 +8,8 @@ export interface IHttp {
     put(relativeUrl: string, content: any): any;
 }
 
+/* istanbul ignore file */
+
 class Http implements IHttp {
     private settings: ISettings;
     constructor(settings: ISettings) {

--- a/CourageScores/ClientApp/src/api/settings.ts
+++ b/CourageScores/ClientApp/src/api/settings.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 export interface ISettings {
     get apiHost(): string;
     get invalidateCacheOnNextRequest(): boolean;

--- a/CourageScores/ClientApp/src/api/socketFactory.ts
+++ b/CourageScores/ClientApp/src/api/socketFactory.ts
@@ -1,5 +1,7 @@
 import {ISettings} from "./settings";
 
+/* istanbul ignore file */
+
 function socketFactory(settings: ISettings): WebSocket {
     const relativeUrl = `/api/Live/`;
     const apiHost = settings.apiHost.replace('https://', 'wss://');

--- a/CourageScores/ClientApp/src/components/Division.test.tsx
+++ b/CourageScores/ClientApp/src/components/Division.test.tsx
@@ -100,7 +100,7 @@ describe('Division', () => {
                 controls: true,
             }, reportedError), '/division/:divisionId', `/division/${divisionId}`);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const seasonSelection = context.container.querySelector('.btn-group .btn-group:nth-child(1)') as HTMLElement;
             const divisionSelection = context.container.querySelector('.btn-group .btn-group:nth-child(2)') as HTMLElement;
             expect(seasonSelection.textContent).toContain('Select a season');
@@ -115,7 +115,7 @@ describe('Division', () => {
                 controls: false,
             }, reportedError), '/division/:divisionId', `/division/${divisionId}`);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const seasonSelection = context.container.querySelector('.btn-group .btn-group:nth-child(1)') as HTMLElement;
             const divisionSelection = context.container.querySelector('.btn-group .btn-group:nth-child(2)') as HTMLElement;
             expect(seasonSelection.textContent).toContain('Select a season');
@@ -155,7 +155,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
                 const headings = Array.from(table.querySelectorAll('thead tr th')) as HTMLTableCellElement[];
                 expect(headings.map(th => th.textContent)).toEqual(['Venue', 'Played', 'Points', 'Won', 'Lost', 'Drawn', '+/-']);
@@ -167,7 +167,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
                 const headings = Array.from(table.querySelectorAll('thead tr th')) as HTMLTableCellElement[];
                 expect(headings.map(th => th.textContent)).toEqual(['Venue', 'Played', 'Points', 'Won', 'Lost', 'Drawn', '+/-']);
@@ -179,7 +179,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.name}/teams/${season.name}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
                 const headings = Array.from(table.querySelectorAll('thead tr th')) as HTMLTableCellElement[];
                 expect(headings.map(th => th.textContent)).toEqual(['Venue', 'Played', 'Points', 'Won', 'Lost', 'Drawn', '+/-']);
@@ -191,7 +191,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.id}/teams/${season.id}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
                 const headings = Array.from(table.querySelectorAll('thead tr th')) as HTMLTableCellElement[];
                 expect(headings.map(th => th.textContent)).toEqual(['Venue', 'Played', 'Points', 'Won', 'Lost', 'Drawn', '+/-']);
@@ -206,7 +206,7 @@ describe('Division', () => {
                     teams: toMap([team]),
                 }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.id}/team:${team.id}/${season.id}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('.content-background h3') as HTMLHeadingElement;
                 expect(heading.textContent).toEqual('TEAM_NAME 🔗');
             });
@@ -218,7 +218,7 @@ describe('Division', () => {
                     teams: toMap([team]),
                 }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.name}/team:${team.name}/${season.name}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('.content-background h3') as HTMLHeadingElement;
                 expect(heading.textContent).toEqual('TEAM_NAME 🔗');
             });
@@ -230,7 +230,7 @@ describe('Division', () => {
                     teams: toMap([team]),
                 }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.name}/team:/${season.name}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
                 expect(content.textContent).toContain('⚠ Team could not be found');
             });
@@ -242,7 +242,7 @@ describe('Division', () => {
                     teams: toMap([team]),
                 }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.name}/team:UNKNOWN_TEAM/${season.name}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
                 expect(content.textContent).toContain('⚠ Team could not be found');
             });
@@ -255,7 +255,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/fixtures`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
                 expect(content.textContent).toContain('No fixtures, yet');
             });
@@ -266,7 +266,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/fixtures`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
                 expect(content.textContent).toContain('No fixtures, yet');
             });
@@ -277,7 +277,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.name}/fixtures/${season.name}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
                 expect(content.textContent).toContain('No fixtures, yet');
             });
@@ -288,7 +288,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.id}/fixtures/${season.id}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
                 expect(content.textContent).toContain('No fixtures, yet');
             });
@@ -301,7 +301,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/players`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
                 const headings = Array.from(table.querySelectorAll('thead tr th'));
                 expect(headings.map(th => th.textContent)).toEqual(['Rank', 'Player', 'Venue', 'Played', 'Won', 'Lost', 'Points', 'Win %', '180s', 'hi-check']);
@@ -313,7 +313,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/players`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
                 const headings = Array.from(table.querySelectorAll('thead tr th'));
                 expect(headings.map(th => th.textContent)).toEqual(['Rank', 'Player', 'Venue', 'Played', 'Won', 'Lost', 'Points', 'Win %', '180s', 'hi-check']);
@@ -325,7 +325,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.name}/players/${season.name}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
                 const headings = Array.from(table.querySelectorAll('thead tr th'));
                 expect(headings.map(th => th.textContent)).toEqual(['Rank', 'Player', 'Venue', 'Played', 'Won', 'Lost', 'Points', 'Win %', '180s', 'hi-check']);
@@ -337,7 +337,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.name}/players/${season.id}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
                 const headings = Array.from(table.querySelectorAll('thead tr th'));
                 expect(headings.map(th => th.textContent)).toEqual(['Rank', 'Player', 'Venue', 'Played', 'Won', 'Lost', 'Points', 'Win %', '180s', 'hi-check']);
@@ -351,7 +351,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/player:${player.id}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('.content-background h3') as HTMLHeadingElement;
                 expect(heading.textContent).toContain('PLAYER_NAME');
             });
@@ -362,7 +362,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/player:${player.name}@${team.name}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('.content-background h3') as HTMLHeadingElement;
                 expect(heading.textContent).toContain('PLAYER_NAME');
             });
@@ -373,7 +373,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/player:${player.name}@UNKNOWN_TEAM`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('.content-background h5') as HTMLHeadingElement;
                 expect(heading.textContent).toContain('⚠ Player could not be found');
             });
@@ -384,7 +384,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/player:UNKNOWN_PLAYER@${team.name}`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('.content-background h5') as HTMLHeadingElement;
                 expect(heading.textContent).toContain('⚠ Player could not be found');
             });
@@ -395,7 +395,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/player:`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('.content-background h5') as HTMLHeadingElement;
                 expect(heading.textContent).toContain('⚠ Player could not be found');
             });
@@ -406,7 +406,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/player:foo`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('.content-background h5') as HTMLHeadingElement;
                 expect(heading.textContent).toContain('⚠ Player could not be found');
             });
@@ -419,7 +419,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const tabs = Array.from(context.container.querySelectorAll('.nav-tabs .nav-item')) as HTMLElement[];
                 expect(tabs.map(t => t.textContent)).not.toContain('Reports');
             });
@@ -435,7 +435,7 @@ describe('Division', () => {
                     }
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const tabs = Array.from(context.container.querySelectorAll('.nav-tabs .nav-item')) as HTMLElement[];
                 expect(tabs.map(t => t.textContent)).not.toContain('Reports');
             });
@@ -452,7 +452,7 @@ describe('Division', () => {
                     controls: true,
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const tabs = Array.from(context.container.querySelectorAll('.nav-tabs .nav-item'));
                 expect(tabs.map(t => t.textContent)).toContain('Reports');
             });
@@ -468,7 +468,7 @@ describe('Division', () => {
                     }
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/reports`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const button = context.container.querySelector('.btn.btn-primary') as HTMLButtonElement;
                 expect(button).toBeFalsy();
             });
@@ -484,7 +484,7 @@ describe('Division', () => {
                     }
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/reports`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const button = context.container.querySelector('.btn.btn-primary') as HTMLButtonElement;
                 expect(button.textContent).toEqual('📊 Get reports...');
             });
@@ -497,7 +497,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const tabs = Array.from(context.container.querySelectorAll('.nav-tabs .nav-item'));
                 expect(tabs.map(t => t.textContent)).not.toContain('Health');
             });
@@ -513,7 +513,7 @@ describe('Division', () => {
                     }
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const tabs = Array.from(context.container.querySelectorAll('.nav-tabs .nav-item'));
                 expect(tabs.map(t => t.textContent)).not.toContain('Health');
             });
@@ -530,7 +530,7 @@ describe('Division', () => {
                     controls: true,
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const tabs = Array.from(context.container.querySelectorAll('.nav-tabs .nav-item'));
                 expect(tabs.map(t => t.textContent)).toContain('Health');
             });
@@ -546,7 +546,7 @@ describe('Division', () => {
                     }
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/health`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const button = context.container.querySelector('.btn.btn-primary');
                 expect(button).toBeFalsy();
             });
@@ -562,7 +562,7 @@ describe('Division', () => {
                     }
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/health`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const component = context.container.querySelector('div[datatype="health"]') as HTMLElement;
                 expect(component).toBeTruthy();
             });
@@ -588,7 +588,7 @@ describe('Division', () => {
                     account: {},
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('h3') as HTMLHeadingElement;
                 expect(heading.textContent).toEqual('⚠ Errors in division data');
             });
@@ -613,7 +613,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('h3') as HTMLHeadingElement;
                 expect(heading).toBeFalsy();
             });
@@ -667,7 +667,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/unknown/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
                 expect(content.textContent).toEqual('No data found');
             });
@@ -678,7 +678,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.id}/teams/UNKNOWN`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
                 expect(content.textContent).toEqual('No data found');
             });
@@ -689,7 +689,7 @@ describe('Division', () => {
                     seasons: [season],
                 }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/teams`);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
                 expect(content.className).toContain('loading-background');
             });
@@ -751,13 +751,13 @@ describe('Division', () => {
                 expect(dataRequested).toEqual([
                     {divisionId: division.id, seasonId: null},
                 ]); // data loaded once
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const fixtureContainer = (context.container.querySelector('div[data-fixture-date="2023-07-01"]') as HTMLElement).parentElement as HTMLElement;
 
                 await doSelectOption(fixtureContainer.querySelector('.dropdown-menu'), 'AWAY');
                 await doClick(findButton(fixtureContainer, '💾'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(dataRequested).toEqual([
                     {divisionId: division.id, seasonId: null},
                     {divisionId: division.id, seasonId: null},
@@ -788,13 +788,13 @@ describe('Division', () => {
                 expect(dataRequested).toEqual([
                     {divisionId: division.id, seasonId: null},
                 ]); // data loaded once
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const fixtureContainer = (context.container.querySelector('div[data-fixture-date="2023-07-01"]') as HTMLElement).parentElement as HTMLElement;
                 window.confirm = () => true;
 
                 await doClick(findButton(fixtureContainer, '🗑'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(dataRequested).toEqual([
                     {divisionId: division.id, seasonId: null},
                     {divisionId: division.id, seasonId: null},
@@ -827,7 +827,7 @@ describe('Division', () => {
                 controls: true,
             }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('.btn-group')).toBeTruthy();
             expect(context.container.innerHTML).toContain(`${season.name} (${renderDate(season.startDate)} - ${renderDate(season.endDate)})`);
             expect(context.container.innerHTML).toContain(division.name);
@@ -840,7 +840,7 @@ describe('Division', () => {
                 controls: true,
             }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('.nav-tabs')).toBeTruthy();
             expect(context.container.innerHTML).toContain('Teams');
             expect(context.container.innerHTML).toContain('Fixtures');
@@ -854,7 +854,7 @@ describe('Division', () => {
                 controls: false,
             }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('.btn-group')).toBeFalsy();
         });
 
@@ -865,7 +865,7 @@ describe('Division', () => {
                 controls: false,
             }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('.nav-tabs')).toBeFalsy();
         });
     })

--- a/CourageScores/ClientApp/src/components/DivisionControls.test.tsx
+++ b/CourageScores/ClientApp/src/components/DivisionControls.test.tsx
@@ -170,7 +170,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const seasonButton = getShownData(getSeasonButtonGroup());
                 expect(seasonButton.textContent).toContain('Season 1');
                 expect(seasonButton.textContent).toContain(seasonDates(season1));
@@ -183,7 +183,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(getOptions(getSeasonButtonGroup())).toEqual([
                     'Season 2 ' + seasonDates(season2),
                     'Season 1 ' + seasonDates(season1)]);
@@ -196,7 +196,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const divisionButton = getShownData(getDivisionButtonGroup());
                 expect(divisionButton.textContent).toEqual('Division 1');
             });
@@ -208,7 +208,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(getOptions(getDivisionButtonGroup())).toEqual([
                     'Division 1',
                     'Division 2']);
@@ -223,7 +223,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const seasonButton = getShownData(getSeasonButtonGroup());
                 expect(seasonButton.textContent).toEqual('Select a season');
                 assertDropdownOpen(getSeasonButtonGroup(), true);
@@ -236,7 +236,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(getOptions(getSeasonButtonGroup())).toEqual([
                     'Season 2 ' + seasonDates(season2),
                     'Season 1 ' + seasonDates(season1)]);
@@ -249,7 +249,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const divisionButton = getShownData(getDivisionButtonGroup());
                 expect(divisionButton.textContent).toEqual('All divisions');
             });
@@ -261,7 +261,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(getOptions(getDivisionButtonGroup())).toEqual([]);
             });
         });
@@ -301,7 +301,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const seasonButton = getShownData(getSeasonButtonGroup());
                 expect(seasonButton.textContent).toContain('Season 3');
                 expect(seasonButton.textContent).toContain(seasonDates(season3));
@@ -315,7 +315,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(getOptions(getSeasonButtonGroup())).toEqual([
                     'Season 4 ' + seasonDates(season4),
                     'Season 3 ' + seasonDates(season3),
@@ -329,7 +329,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const divisionButton = getShownData(getDivisionButtonGroup());
                 expect(divisionButton.textContent).toEqual('Division 3✏');
             });
@@ -341,7 +341,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(getOptions(getDivisionButtonGroup())).toEqual([
                     'Division 3',
                     'Division 4',
@@ -357,7 +357,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const seasonButton = getShownData(getSeasonButtonGroup());
                 expect(seasonButton.textContent).toEqual('Select a season');
                 assertDropdownOpen(getSeasonButtonGroup(), true);
@@ -370,7 +370,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(getOptions(getSeasonButtonGroup())).toEqual([
                     'Season 4 ' + seasonDates(season4),
                     'Season 3 ' + seasonDates(season3),
@@ -384,7 +384,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const divisionButton = getShownData(getDivisionButtonGroup());
                 expect(divisionButton.textContent).toEqual('All divisions');
             });
@@ -396,7 +396,7 @@ describe('DivisionControls', () => {
                     overrideMode: null,
                 }, account, seasons, divisions);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(getOptions(getDivisionButtonGroup())).toEqual([]);
             });
         });
@@ -428,7 +428,7 @@ describe('DivisionControls', () => {
                     originalDivisionData: division5,
                     overrideMode: null,
                 }, account, seasons, divisions);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const group = getSeasonButtonGroup();
                 assertDropdownOpen(group, false);
 
@@ -443,7 +443,7 @@ describe('DivisionControls', () => {
                     originalDivisionData: division5,
                     overrideMode: null,
                 }, account, seasons, divisions);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const group = getDivisionButtonGroup();
                 assertDropdownOpen(group, false);
 
@@ -458,7 +458,7 @@ describe('DivisionControls', () => {
                     originalDivisionData: division5,
                     overrideMode: null,
                 }, account, seasons, divisions);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const group = getSeasonButtonGroup();
                 assertDropdownOpen(group, false);
 
@@ -479,7 +479,7 @@ describe('DivisionControls', () => {
                 }, account, seasons, divisions, route, currentPath);
 
                 const group = getSeasonButtonGroup();
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const option = getOption(group, 'Season 6');
                 expect(option.href).toContain(`/division/${encodeURI(division5.name)}/OVERRIDE/${encodeURI(season6.name)}`);
 
@@ -499,7 +499,7 @@ describe('DivisionControls', () => {
                 }, account, seasons, divisions, route, currentPath);
 
                 const group = getSeasonButtonGroup();
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const option = getOption(group, 'Season 6');
                 expect(option.href).toContain(`/division/${encodeURI(division5.name)}/team:TEAM_ID/${encodeURI(season6.name)}`);
 
@@ -519,7 +519,7 @@ describe('DivisionControls', () => {
                 }, account, seasons, divisions, route, currentPath);
 
                 const group = getSeasonButtonGroup();
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const option = getOption(group, 'Season 6');
                 expect(option.href).toContain(`/division/${encodeURI(division5.name)}/player:PLAYER_ID/${encodeURI(season6.name)}`);
 
@@ -539,7 +539,7 @@ describe('DivisionControls', () => {
                 }, account, seasons, divisions, route, currentPath);
 
                 const group = getSeasonButtonGroup();
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const option = getOption(group, 'Season 6');
                 expect(option.href).toContain(`/division/${encodeURI(division5.name)}`); // highlighting that division5 will be selected
                 expect(option.href).toContain(`/${encodeURI(season6.name)}`);
@@ -563,7 +563,7 @@ describe('DivisionControls', () => {
                     originalDivisionData: division5,
                     overrideMode: null,
                 }, account, seasons, divisions);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
 
                 await doClick(findButton(getSeasonButtonGroup(), `Season 5 ${seasonDates(season5)}✏`));
 
@@ -578,7 +578,7 @@ describe('DivisionControls', () => {
                     originalDivisionData: division5,
                     overrideMode: null,
                 }, account, seasons, divisions);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
 
                 await doSelectOption(getSeasonButtonGroup().querySelector('.dropdown-menu'), '➕ New season');
 
@@ -593,12 +593,12 @@ describe('DivisionControls', () => {
                     originalDivisionData: division5,
                     overrideMode: null,
                 }, account, seasons, divisions);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 await doClick(findButton(getSeasonButtonGroup(), `Season 5 ${seasonDates(season5)}✏`));
 
                 await doClick(findButton(context.container, 'Update season'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const dialog = context.container.querySelector('.btn-group .modal-dialog');
                 expect(dialog).toBeFalsy();
                 expect(changedDivisionOrSeason).toEqual(true);
@@ -612,7 +612,7 @@ describe('DivisionControls', () => {
                     originalDivisionData: division5,
                     overrideMode: null,
                 }, account, seasons, divisions);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 await doClick(findButton(getSeasonButtonGroup(), `Season 5 ${seasonDates(season5)}✏`));
 
                 await doClick(findButton(context.container, 'Close'));
@@ -627,7 +627,7 @@ describe('DivisionControls', () => {
                     originalDivisionData: division5,
                     overrideMode: null,
                 }, account, seasons, divisions);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
 
                 await doClick(findButton(getDivisionButtonGroup(), 'Division 5✏'));
 
@@ -642,7 +642,7 @@ describe('DivisionControls', () => {
                     originalDivisionData: division5,
                     overrideMode: null,
                 }, account, seasons, divisions);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
 
                 await doSelectOption(getDivisionButtonGroup().querySelector('.dropdown-menu'), '➕ New division');
 
@@ -657,12 +657,12 @@ describe('DivisionControls', () => {
                     originalDivisionData: division5,
                     overrideMode: null,
                 }, account, seasons, divisions);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 await doClick(findButton(getDivisionButtonGroup(), 'Division 5✏'));
 
                 await doClick(findButton(context.container, 'Update division'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const dialog = context.container.querySelector('.btn-group .modal-dialog');
                 expect(dialog).toBeFalsy();
                 expect(changedDivisionOrSeason).toEqual(true);
@@ -676,7 +676,7 @@ describe('DivisionControls', () => {
                     originalDivisionData: division5,
                     overrideMode: null,
                 }, account, seasons, divisions);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 await doClick(findButton(getDivisionButtonGroup(), 'Division 5✏'));
 
                 await doClick(findButton(context.container, 'Close'));

--- a/CourageScores/ClientApp/src/components/EditDivision.test.tsx
+++ b/CourageScores/ClientApp/src/components/EditDivision.test.tsx
@@ -107,11 +107,11 @@ describe('EditDivision', () => {
             onClose,
             setSaveError,
         });
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         await doChange(context.container, 'input[name="name"]', 'NEW DIVISION NAME', context.user);
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(updatedData.id).toEqual(division.id);
         expect(updatedData.name).toEqual('NEW DIVISION NAME');
     });
@@ -141,11 +141,11 @@ describe('EditDivision', () => {
             onClose,
             setSaveError,
         });
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         await doClick(findButton(context.container, 'Update division'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(alert).toBeNull();
         expect(saved).toEqual(true);
         expect(updatedDivision).not.toBeNull();
@@ -160,14 +160,14 @@ describe('EditDivision', () => {
             onClose,
             setSaveError,
         });
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         apiResponse = {
             success: false
         };
 
         await doClick(findButton(context.container, 'Update division'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(saveError).toEqual(apiResponse);
     });
 
@@ -180,7 +180,7 @@ describe('EditDivision', () => {
             onClose,
             setSaveError,
         });
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         await doClick(findButton(context.container, 'Delete division'));
 
@@ -197,12 +197,12 @@ describe('EditDivision', () => {
             onClose,
             setSaveError,
         });
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         confirmResponse = true;
 
         await doClick(findButton(context.container, 'Delete division'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(deletedId).toEqual(division.id);
     });
 
@@ -215,7 +215,7 @@ describe('EditDivision', () => {
             onClose,
             setSaveError,
         });
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         confirmResponse = true;
         apiResponse = {
             success: false
@@ -223,7 +223,7 @@ describe('EditDivision', () => {
 
         await doClick(findButton(context.container, 'Delete division'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(deletedId).toEqual(division.id);
         expect(saveError).toEqual(apiResponse);
     });
@@ -237,7 +237,7 @@ describe('EditDivision', () => {
             onClose,
             setSaveError,
         });
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         confirmResponse = true;
 
         await doClick(findButton(context.container, 'Delete division'));

--- a/CourageScores/ClientApp/src/components/EditSeason.test.tsx
+++ b/CourageScores/ClientApp/src/components/EditSeason.test.tsx
@@ -122,11 +122,11 @@ describe('EditSeason', () => {
             onClose,
             onSave,
         }, [season], divisions);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         await doChange(context.container, 'input[name="name"]', 'NEW SEASON NAME', context.user);
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(updatedData.id).toEqual(season.id);
         expect(updatedData.name).toEqual('NEW SEASON NAME');
     });
@@ -142,15 +142,15 @@ describe('EditSeason', () => {
             onClose,
             onSave,
         }, [season], divisions);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         await doChange(context.container, 'input[name="startDate"]', '2023-06-01', context.user);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(updatedData.id).toEqual(season.id);
         expect(updatedData.startDate).toEqual('2023-06-01');
 
         await doChange(context.container, 'input[name="endDate"]', '2023-09-01', context.user);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(updatedData.id).toEqual(season.id);
         expect(updatedData.endDate).toEqual('2023-09-01');
     });
@@ -166,14 +166,14 @@ describe('EditSeason', () => {
             onClose,
             onSave,
         }, [season], divisions);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         const divisionOptions = Array.from(context.container.querySelectorAll('.list-group-item'));
         const unselectedDivision = divisionOptions.filter(d => d.className.indexOf('active') === -1)[0];
         expect(unselectedDivision.textContent).toEqual(division2.name);
         await doClick(unselectedDivision);
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(updatedData.id).toEqual(season.id);
         expect(updatedData.divisionIds).toEqual([division1.id, division2.id]);
     });
@@ -189,14 +189,14 @@ describe('EditSeason', () => {
             onClose,
             onSave,
         }, [season], divisions);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         const divisionOptions = Array.from(context.container.querySelectorAll('.list-group-item'));
         const selectedDivision = divisionOptions.filter(d => d.className.indexOf('active') !== -1)[0];
         expect(selectedDivision.textContent).toEqual(division1.name);
         await doClick(selectedDivision);
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(updatedData.id).toEqual(season.id);
         expect(updatedData.divisionIds).toEqual([]);
     });
@@ -215,11 +215,11 @@ describe('EditSeason', () => {
             onClose,
             onSave,
         }, [otherSeason], divisions);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         await doSelectOption(context.container.querySelector('.dropdown-menu'), 'OTHER SEASON');
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(updatedData.copyTeamsFromSeasonId).toEqual(otherSeason.id);
     });
 
@@ -248,11 +248,11 @@ describe('EditSeason', () => {
             onSave,
             onUpdateData,
         }, [season], divisions);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         await doClick(findButton(context.container, 'Update season'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(alert).toBeNull();
         expect(saved).toEqual(true);
         expect(updatedSeason).not.toBeNull();
@@ -266,14 +266,14 @@ describe('EditSeason', () => {
             onSave,
             onUpdateData,
         }, [season], divisions);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         apiResponse = {
             success: false
         };
 
         await doClick(findButton(context.container, 'Update season'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(saveError).toEqual(apiResponse);
     });
 
@@ -285,7 +285,7 @@ describe('EditSeason', () => {
             onSave,
             onUpdateData,
         }, [season], divisions);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         await doClick(findButton(context.container, 'Delete season'));
 
@@ -301,12 +301,12 @@ describe('EditSeason', () => {
             onSave,
             onUpdateData,
         }, [season], divisions);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         confirmResponse = true;
 
         await doClick(findButton(context.container, 'Delete season'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(deletedId).toEqual(season.id);
     });
 
@@ -318,7 +318,7 @@ describe('EditSeason', () => {
             onSave,
             onUpdateData,
         }, [season], divisions);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         confirmResponse = true;
         apiResponse = {
             success: false
@@ -326,7 +326,7 @@ describe('EditSeason', () => {
 
         await doClick(findButton(context.container, 'Delete season'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(deletedId).toEqual(season.id);
         expect(saveError).toEqual(apiResponse);
     });
@@ -339,7 +339,7 @@ describe('EditSeason', () => {
             onSave,
             onUpdateData,
         }, [season], divisions);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         confirmResponse = true;
 
         await doClick(findButton(context.container, 'Delete season'));

--- a/CourageScores/ClientApp/src/components/Practice.test.tsx
+++ b/CourageScores/ClientApp/src/components/Practice.test.tsx
@@ -104,7 +104,7 @@ describe('Practice', () => {
         it('renders when app is loading', async () => {
             await renderComponent(account, '', true);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
             expect(context.container.querySelector('.loading-background')).not.toBeNull();
         });
@@ -112,7 +112,7 @@ describe('Practice', () => {
         it('renders given no saved data', async () => {
             await renderComponent(account, '');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
             assertInputValue('yourName', 'you');
             assertInputValue('startingScore', '501');
@@ -124,7 +124,7 @@ describe('Practice', () => {
         it('renders given empty saved data', async () => {
             await renderComponent(account, '#');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
             assertInputValue('yourName', 'you');
             assertInputValue('startingScore', '501');
@@ -138,14 +138,14 @@ describe('Practice', () => {
 
             await renderComponent(account, data);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertDataError('Data not found');
         });
 
         it('can close data error', async () => {
             const data = '#not-found';
             await renderComponent(account, data);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertDataError('Data not found');
 
             await doClick(findButton(context.container.querySelector('div[data-name="data-error"]'), 'Clear'));
@@ -168,7 +168,7 @@ describe('Practice', () => {
 
             await renderComponent(account, '#' + jsonData.id);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
             assertInputValue('yourName', 'Simon');
             assertInputValue('startingScore', '123');
@@ -192,7 +192,7 @@ describe('Practice', () => {
 
             await renderComponent(account, '#' + jsonData.id);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
             assertInputValue('yourName', 'you');
             assertInputValue('startingScore', '123');
@@ -216,7 +216,7 @@ describe('Practice', () => {
                 .addTo(saygData)
                 .build();
             await renderComponent(account, '#' + jsonData.id);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
 
             delete saygData[jsonData.id];
@@ -243,7 +243,7 @@ describe('Practice', () => {
             };
             saygData[jsonData.id] = jsonData;
             await renderComponent(account, '#' + jsonData.id);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
 
             delete saygData[jsonData.id];
@@ -259,7 +259,7 @@ describe('Practice', () => {
 
         it('can change your name', async () => {
             await renderComponent(account, '');
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
 
             await doChange(context.container, 'input[name="yourName"]', 'YOU', context.user);
@@ -271,7 +271,7 @@ describe('Practice', () => {
 
         it('can clear opponent name', async () => {
             await renderComponent(account, '');
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
             await doChange(context.container, 'input[name="opponentName"]', 'THEM', context.user);
             await doClick(findButton(context.container, 'Save '));
@@ -286,7 +286,7 @@ describe('Practice', () => {
 
         it('handles save error correctly', async () => {
             await renderComponent(account, '');
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
             apiResultFunc = () => {
                 throw new Error('some error');
@@ -294,7 +294,10 @@ describe('Practice', () => {
 
             await doClick(findButton(context.container, 'Save '));
 
-            expect(reportedError.hasError()).toEqual(true);
+            reportedError.verifyErrorEquals({
+                message: 'some error',
+                stack: expect.any(String),
+            });
         });
 
         it('can restart practice', async () => {
@@ -310,7 +313,7 @@ describe('Practice', () => {
             };
             saygData[jsonData.id] = jsonData;
             await renderComponent(account, '#' + jsonData.id);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
 
             await doClick(findButton(context.container, 'Restart...'));
@@ -327,7 +330,7 @@ describe('Practice', () => {
 
         it('can record scores as they are entered', async () => {
             await renderComponent(account, '');
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
 
             await doChange(context.container, 'input[data-score-input="true"]', '180', context.user);
@@ -349,7 +352,7 @@ describe('Practice', () => {
 
         it('can complete a leg', async () => {
             await renderComponent(account, '');
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
             await doChange(context.container, 'input[name="startingScore"]', '501', context.user);
             await doChange(context.container, 'input[data-score-input="true"]', '180', context.user);
@@ -379,7 +382,7 @@ describe('Practice', () => {
         it('when no data loaded, sets your name to account givenName', async () => {
             await renderComponent(account, '');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertInputValue('yourName', 'GIVEN NAME');
             assertScoreInputVisible();
         });
@@ -399,7 +402,7 @@ describe('Practice', () => {
 
             await renderComponent(account, '#' + jsonData.id);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
             assertInputValue('yourName', 'Simon');
             assertInputValue('startingScore', '123');
@@ -423,7 +426,7 @@ describe('Practice', () => {
 
             await renderComponent(account, '#' + jsonData.id);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             assertNoDataError();
             assertInputValue('yourName', 'you');
             assertInputValue('startingScore', '123');

--- a/CourageScores/ClientApp/src/components/admin/AdminHome.test.tsx
+++ b/CourageScores/ClientApp/src/components/admin/AdminHome.test.tsx
@@ -66,7 +66,7 @@ describe('AdminHome', () => {
 
         const tab = context.container.querySelector(`.nav-tabs .nav-item a[href="${href}"]`);
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         if (exists) {
             expect(tab).not.toBeNull();
         } else {
@@ -95,7 +95,7 @@ describe('AdminHome', () => {
             address
         );
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const content = context.container.querySelector(`div.content-background`);
         expect(content).not.toBeNull();
         expect(content.innerHTML).toContain(expectContent);

--- a/CourageScores/ClientApp/src/components/admin/Errors.test.tsx
+++ b/CourageScores/ClientApp/src/components/admin/Errors.test.tsx
@@ -150,7 +150,7 @@ describe('Errors', () => {
         await renderComponent();
 
         assertResults(0);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
     });
 
     it('shows empty results when none found', async () => {
@@ -159,7 +159,7 @@ describe('Errors', () => {
         await clickRefresh('2001-02-03', []);
 
         assertResults(0);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
     });
 
     it('shows error dialog on error', async () => {
@@ -169,7 +169,10 @@ describe('Errors', () => {
         await clickRefresh('2001-02-03', []);
 
         assertResults(0);
-        expect(reportedError.hasError()).toEqual(true);
+        reportedError.verifyErrorEquals({
+            message: 'Some error',
+            stack: expect.any(String),
+        });
     });
 
     it('shows results on refresh', async () => {
@@ -194,7 +197,7 @@ describe('Errors', () => {
         const uiItem = results.filter(li => li.innerHTML.indexOf('message2') !== -1)[0];
         assertListItem(apiItem, apiError);
         assertListItem(uiItem, uiError);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
     });
 
     it('shows api details on click', async () => {
@@ -216,7 +219,7 @@ describe('Errors', () => {
         await clickErrorItem(0);
 
         assertDisplayedErrors(data);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
     });
 
     it('shows api details without some details on click', async () => {
@@ -234,7 +237,7 @@ describe('Errors', () => {
         await clickErrorItem(0);
 
         assertDisplayedErrors(data);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
     });
 
     it('shows ui details on click', async () => {
@@ -256,7 +259,7 @@ describe('Errors', () => {
         await clickErrorItem(0);
 
         assertDisplayedErrors(data);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
     });
 
     it('shows ui details without some details on click', async () => {
@@ -274,6 +277,6 @@ describe('Errors', () => {
         await clickErrorItem(0);
 
         assertDisplayedErrors(data);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
     });
 });

--- a/CourageScores/ClientApp/src/components/admin/ExportData.test.tsx
+++ b/CourageScores/ClientApp/src/components/admin/ExportData.test.tsx
@@ -62,14 +62,14 @@ describe('ExportData', () => {
     it('renders tables', async () => {
         await renderComponent(props);
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         expect(tables.map(t => t.textContent)).toEqual(['Table 1', 'Table 2']);
     });
 
     it('can select exportable table', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table1 = tables.filter(t => t.textContent.indexOf('Table 1') !== -1)[0];
         expect(table1).toBeTruthy();
@@ -82,7 +82,7 @@ describe('ExportData', () => {
 
     it('cannot select non-exportable table', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table2 = tables.filter(t => t.textContent.indexOf('Table 2') !== -1)[0];
         expect(table2).toBeTruthy();
@@ -95,7 +95,7 @@ describe('ExportData', () => {
 
     it('cannot export when no tables selected', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         let alert: string;
         window.alert = (msg) => alert = msg;
         const tables = Array.from(context.container.querySelectorAll('ul li'));
@@ -105,19 +105,19 @@ describe('ExportData', () => {
 
         await doClick(findButton(context.container, 'Export data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(exportRequest).toBeNull();
         expect(alert).toEqual('Select some tables to export');
     });
 
     it('can export data with password', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         await doChange(context.container, 'input[name="password"]', 'pass', context.user);
 
         await doClick(findButton(context.container, 'Export data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(exportRequest).toEqual({
             includeDeletedEntries: true,
             password: 'pass',
@@ -127,11 +127,11 @@ describe('ExportData', () => {
 
     it('can export data without password', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         await doClick(findButton(context.container, 'Export data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(exportRequest).toEqual({
             includeDeletedEntries: true,
             password: '',
@@ -141,12 +141,12 @@ describe('ExportData', () => {
 
     it('can export data without deleted entries', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         await doClick(context.container, 'input[name="includeDeletedEntries"]');
 
         await doClick(findButton(context.container, 'Export data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(exportRequest).toEqual({
             includeDeletedEntries: false,
             password: '',
@@ -156,7 +156,7 @@ describe('ExportData', () => {
 
     it('can download zip', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         apiResponse = {
             success: true,
             result: {
@@ -165,26 +165,26 @@ describe('ExportData', () => {
         };
         await doClick(findButton(context.container, 'Export data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const downloadButton = context.container.querySelector('a[download="export.zip"]') as HTMLAnchorElement;
         expect(downloadButton.href).toEqual('data:application/zip;base64,ZIP CONTENT');
     });
 
     it('can handle error during export', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         apiResponse = {success: false};
 
         await doClick(findButton(context.container, 'Export data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(exportRequest).not.toBeNull();
         expect(context.container.textContent).toContain('Could not export data');
     });
 
     it('can close error report from export', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         apiResponse = {success: false};
         await doClick(findButton(context.container, 'Export data'));
         expect(context.container.textContent).toContain('Could not export data');

--- a/CourageScores/ClientApp/src/components/admin/ImportData.test.tsx
+++ b/CourageScores/ClientApp/src/components/admin/ImportData.test.tsx
@@ -75,14 +75,14 @@ describe('ImportData', () => {
     it('renders tables', async () => {
         await renderComponent(props);
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         expect(tables.map(t => t.textContent)).toEqual(['Table 1', 'Table 2']);
     });
 
     it('can select importable table', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table1 = tables.filter(t => t.textContent.indexOf('Table 1') !== -1)[0];
         expect(table1).toBeTruthy();
@@ -95,7 +95,7 @@ describe('ImportData', () => {
 
     it('cannot select non-importable table', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table2 = tables.filter(t => t.textContent.indexOf('Table 2') !== -1)[0];
         expect(table2).toBeTruthy();
@@ -108,20 +108,20 @@ describe('ImportData', () => {
 
     it('cannot import when no file selected', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         let alert: string;
         window.alert = (msg) => alert = msg;
 
         await doClick(findButton(context.container, 'Import data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(importRequest).toBeNull();
         expect(alert).toEqual('Select a file first');
     });
 
     it('cannot import when no tables selected', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         let alert: string;
         window.alert = (msg) => alert = msg;
         const tables = Array.from(context.container.querySelectorAll('ul li'));
@@ -133,14 +133,14 @@ describe('ImportData', () => {
 
         await doClick(findButton(context.container, 'Import data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(importRequest).toBeNull();
         expect(alert).toEqual('Select some tables to import');
     });
 
     it('can import data with password', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table1 = tables.filter(t => t.textContent.indexOf('Table 1') !== -1)[0];
         if (table1.className.indexOf('active') === -1) {
@@ -151,7 +151,7 @@ describe('ImportData', () => {
 
         await doClick(findButton(context.container, 'Import data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(importRequest).toEqual({
             dryRun: true,
             purgeData: false,
@@ -162,7 +162,7 @@ describe('ImportData', () => {
 
     it('can import data without password', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table1 = tables.filter(t => t.textContent.indexOf('Table 1') !== -1)[0];
         if (table1.className.indexOf('active') === -1) {
@@ -172,7 +172,7 @@ describe('ImportData', () => {
 
         await doClick(findButton(context.container, 'Import data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(importRequest).toEqual({
             dryRun: true,
             purgeData: false,
@@ -183,7 +183,7 @@ describe('ImportData', () => {
 
     it('can import data with purge and commit', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table1 = tables.filter(t => t.textContent.indexOf('Table 1') !== -1)[0];
         if (table1.className.indexOf('active') === -1) {
@@ -195,7 +195,7 @@ describe('ImportData', () => {
 
         await doClick(findButton(context.container, 'Import data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(importRequest).toEqual({
             dryRun: false,
             purgeData: true,
@@ -206,7 +206,7 @@ describe('ImportData', () => {
 
     it('renders import results', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table1 = tables.filter(t => t.textContent.indexOf('Table 1') !== -1)[0];
         if (table1.className.indexOf('active') === -1) {
@@ -227,7 +227,7 @@ describe('ImportData', () => {
 
         await doClick(findButton(context.container, 'Import data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(context.container.textContent).toContain('Table 1: 5 row/s imported');
         expect(context.container.textContent).toContain('some_error');
         expect(context.container.textContent).toContain('some_warning');
@@ -236,7 +236,7 @@ describe('ImportData', () => {
 
     it('can handle error during import', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table1 = tables.filter(t => t.textContent.indexOf('Table 1') !== -1)[0];
         if (table1.className.indexOf('active') === -1) {
@@ -247,14 +247,14 @@ describe('ImportData', () => {
 
         await doClick(findButton(context.container, 'Import data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(importRequest).not.toBeNull();
         expect(context.container.textContent).toContain('Could not import data');
     });
 
     it('can handle http 500 error during import', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table1 = tables.filter(t => t.textContent.indexOf('Table 1') !== -1)[0];
         if (table1.className.indexOf('active') === -1) {
@@ -269,14 +269,14 @@ describe('ImportData', () => {
 
         await doClick(findButton(context.container, 'Import data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(importRequest).not.toBeNull();
         expect(context.container.textContent).toContain('Could not import data');
     });
 
     it('can handle http 400 error during import', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table1 = tables.filter(t => t.textContent.indexOf('Table 1') !== -1)[0];
         if (table1.className.indexOf('active') === -1) {
@@ -293,14 +293,14 @@ describe('ImportData', () => {
 
         await doClick(findButton(context.container, 'Import data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(importRequest).not.toBeNull();
         expect(context.container.textContent).toContain('Could not import data');
     });
 
     it('can handle unexpected error during import', async () => {
         await renderComponent(props);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const tables = Array.from(context.container.querySelectorAll('ul li'));
         const table1 = tables.filter(t => t.textContent.indexOf('Table 1') !== -1)[0];
         if (table1.className.indexOf('active') === -1) {
@@ -318,7 +318,7 @@ describe('ImportData', () => {
 
         await doClick(findButton(context.container, 'Import data'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(importRequest).not.toBeNull();
         expect(context.container.textContent).toContain('Could not import data');
     });

--- a/CourageScores/ClientApp/src/components/admin/Templates.test.tsx
+++ b/CourageScores/ClientApp/src/components/admin/Templates.test.tsx
@@ -79,7 +79,7 @@ describe('Templates', () => {
 
             await renderComponent();
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const templateItems = Array.from(context.container.querySelectorAll('ul[datatype="templates"] .list-group-item'));
             expect(templateItems.map(li => li.querySelector('label').textContent)).toEqual(['TEMPLATE']);
             expect(templateItems.map(li => li.querySelector('small').textContent)).toEqual(['DESCRIPTION']);
@@ -100,7 +100,7 @@ describe('Templates', () => {
 
             await renderComponent('?select=' + template.id);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const templateItems = Array.from(context.container.querySelectorAll('ul[datatype="templates"] .list-group-item'));
             expect(templateItems.map(li => li.className.indexOf('active') !== -1)).toEqual([true]);
         });
@@ -117,7 +117,7 @@ describe('Templates', () => {
 
             await renderComponent('?select=' + template.name);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const templateItems = Array.from(context.container.querySelectorAll('ul[datatype="templates"] .list-group-item'));
             expect(templateItems.map(li => li.className.indexOf('active') !== -1)).toEqual([true]);
         });
@@ -131,7 +131,7 @@ describe('Templates', () => {
 
             await renderComponent();
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const templateItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(templateItems.map(li => li.querySelector('label').textContent)).toEqual(['TEMPLATE']);
             expect(templateItems.map(li => li.querySelector('small'))).toEqual([null]);
@@ -153,7 +153,7 @@ describe('Templates', () => {
 
             await renderComponent();
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const templateItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(templateItems.map(li => li.querySelector('label').textContent)).toEqual(['TEMPLATE']);
             expect(templateItems.map(li => Array.from(li.querySelectorAll('span.bg-danger')).map(s => s.textContent))).toEqual([['1']]);
@@ -180,7 +180,7 @@ describe('Templates', () => {
 
             await renderComponent();
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const templateItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(templateItems.map(li => li.querySelector('label').textContent)).toEqual(['TEMPLATE']);
             expect(templateItems.map(li => Array.from(li.querySelectorAll('span.bg-danger')).map(s => s.textContent))).toEqual([['1']]);
@@ -207,7 +207,7 @@ describe('Templates', () => {
 
             await renderComponent();
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const templateItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(templateItems.map(li => li.querySelector('label').textContent)).toEqual(['TEMPLATE']);
             expect(templateItems.map(li => Array.from(li.querySelectorAll('span.bg-danger')).map(s => s.textContent))).toEqual([[]]);
@@ -234,7 +234,7 @@ describe('Templates', () => {
 
             await renderComponent();
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const templateItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(templateItems.map(li => li.querySelector('label').textContent)).toEqual(['TEMPLATE']);
             expect(templateItems.map(li => Array.from(li.querySelectorAll('span.bg-danger')).map(s => s.textContent))).toEqual([[]]);
@@ -253,12 +253,12 @@ describe('Templates', () => {
             };
             templates = [template];
             await renderComponent();
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(context.container, '.list-group .list-group-item:first-child');
             await doClick(context.container, 'input[name="editorFormat"]'); // switch to text editor
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const templateItems = Array.from(context.container.querySelectorAll('ul[datatype="templates"] .list-group-item'));
             expect(templateItems.map(li => li.className)).toEqual(['list-group-item flex-column active']);
         });
@@ -272,12 +272,12 @@ describe('Templates', () => {
             };
             templates = [template];
             await renderComponent();
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(context.container, '.list-group .list-group-item:first-child');
             await doClick(context.container, '.list-group .list-group-item:first-child');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const templateItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(templateItems.map(li => li.className)).toEqual(['list-group-item flex-column']);
             expect(context.container.querySelector('textarea')).toBeFalsy();
@@ -297,7 +297,7 @@ describe('Templates', () => {
 
             await doClick(findButton(context.container, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updated).toEqual({
                 divisions: [],
                 sharedAddresses: [],
@@ -323,7 +323,7 @@ describe('Templates', () => {
 
             await doChange(context.container, 'textarea', '{}', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
         });
 
         it('updates health as template changes', async () => {
@@ -351,7 +351,7 @@ describe('Templates', () => {
 
             await doChange(context.container, 'textarea', '{}', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const healthCheck = context.container.querySelector('div[datatype="view-health-check"]');
             expect(healthCheck.textContent).toContain('UPDATED HEALTH');
         });
@@ -371,7 +371,7 @@ describe('Templates', () => {
 
             await doChange(context.container, 'textarea', 'invalid json', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(findButton(context.container, 'Save').disabled).toEqual(true);
         });
 
@@ -389,7 +389,7 @@ describe('Templates', () => {
 
             await doClick(findButton(context.container, 'Delete'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
         });
 
         it('can delete template', async () => {
@@ -410,7 +410,7 @@ describe('Templates', () => {
 
             await doClick(findButton(context.container, 'Delete'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(confirm).toEqual('Are you sure you want to delete this template?');
             expect(deleted).toEqual(template.id);
         });
@@ -428,7 +428,7 @@ describe('Templates', () => {
             await doClick(findButton(context.container, 'Add'));
             await doClick(context.container, 'input[name="editorFormat"]'); // switch to text editor
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(JSON.parse(context.container.querySelector('textarea').value)).toEqual({ sharedAddresses: [], divisions: [] });
             expect(context.container.querySelector('button.bg-danger')).toBeFalsy();
         });
@@ -439,7 +439,7 @@ describe('Templates', () => {
 
             await doClick(findButton(context.container, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updated).toEqual({
                 name: '',
                 divisions: [],
@@ -462,7 +462,7 @@ describe('Templates', () => {
 
             await doChange(context.container, 'textarea', '', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(findButton(context.container, 'Save')).toBeTruthy();
         });
 
@@ -473,7 +473,7 @@ describe('Templates', () => {
 
             await doClick(findButton(context.container, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).toContain('Could not save template');
             expect(context.container.textContent).toContain('ERROR');
         });
@@ -496,7 +496,7 @@ describe('Templates', () => {
             await doClick(findButton(context.container, 'Delete'));
 
             expect(deleted).toEqual(template.id);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).toContain('Could not save template');
             expect(context.container.textContent).toContain('ERROR');
         });

--- a/CourageScores/ClientApp/src/components/admin/UserAdmin.test.tsx
+++ b/CourageScores/ClientApp/src/components/admin/UserAdmin.test.tsx
@@ -71,7 +71,7 @@ describe('UserAdmin', () => {
 
         await renderComponent([account], account);
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(context.container.textContent).toContain('Manage access');
         expect(getAccess('manageAccess').checked).toEqual(false);
     });
@@ -86,7 +86,7 @@ describe('UserAdmin', () => {
 
         await doClick(context.container, 'input[id="showEmailAddress"]');
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(context.container.textContent).toContain('You a@b.com');
     });
 
@@ -108,7 +108,7 @@ describe('UserAdmin', () => {
 
         await doSelectOption(context.container.querySelector('.dropdown-menu'), 'Test 1');
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(context.container.textContent).toContain('Manage access');
         expect(getAccess('manageAccess').checked).toEqual(false);
     });
@@ -134,7 +134,7 @@ describe('UserAdmin', () => {
 
         await doSelectOption(context.container.querySelector('.dropdown-menu'), 'Other user');
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(context.container.textContent).toContain('Manage access');
         expect(getAccess('manageAccess').checked).toEqual(true);
     });
@@ -162,7 +162,7 @@ describe('UserAdmin', () => {
 
         await doClick(findButton(context.container, 'Set access'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(updatedAccess).toEqual({
             access: {
                 manageAccess: true,
@@ -196,7 +196,7 @@ describe('UserAdmin', () => {
 
         await doClick(findButton(context.container, 'Set access'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(context.container.textContent).toContain('SOME ERROR');
         expect(context.container.textContent).toContain('Could not save access');
     });
@@ -252,7 +252,7 @@ describe('UserAdmin', () => {
 
         await doClick(findButton(context.container, 'Set access'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(updatedAccess).not.toBeNull();
         expect(accountReloaded).toEqual(true);
     });

--- a/CourageScores/ClientApp/src/components/admin/UserAdmin.tsx
+++ b/CourageScores/ClientApp/src/components/admin/UserAdmin.tsx
@@ -172,6 +172,7 @@ export function UserAdmin() {
         {renderAccessOption('showDebugOptions', 'Show debug options')}
         {renderAccessOption('manageSockets', 'Manage web sockets')}
         {renderAccessOption('useWebSockets', 'Show live results')}
+        {renderAccessOption('enterTournamentResults', 'Enter tournament results')}
         <div>
             <button className="btn btn-primary" onClick={saveChanges} disabled={loading}>
                 {saving

--- a/CourageScores/ClientApp/src/components/common/PageError.test.tsx
+++ b/CourageScores/ClientApp/src/components/common/PageError.test.tsx
@@ -44,7 +44,7 @@ describe('PageError', () => {
             (<PageError error={appError}/>));
 
         // don't allow onError to be called - would call infinite-loop/recursion
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
     }
 
     describe('with error details', () => {

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.test.tsx
@@ -124,7 +124,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([team]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['HOME', '', 'vs', '', 'AWAY']);
@@ -150,7 +150,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([team]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['HOME', 'P', 'vs', 'P', 'AWAY']);
@@ -176,7 +176,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([team]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['HOME', '', 'vs', '', 'AWAY']);
@@ -201,7 +201,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([team]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['HOME', '', 'vs', '', 'Bye']);
@@ -247,7 +247,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['HOME', '', 'vs', '', 'AWAYAWAY', '🗑']);
@@ -271,7 +271,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['HOME', 'P', 'vs', 'P', 'AWAYAWAY', '🗑']);
@@ -295,7 +295,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['HOME', '', 'vs', '', 'AWAYAWAY', '🗑']);
@@ -318,7 +318,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['HOME', '', 'vs', '', 'AWAY', '']);
@@ -344,7 +344,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam, anotherTeamAtHomeAddress]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const awayCell = context.container.querySelector('td:nth-child(5)');
             expect(awayCell.textContent).toContain('ANOTHER TEAM');
             expect(awayCell.textContent).not.toContain('🚫');
@@ -368,7 +368,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const awayCell = context.container.querySelector('td:nth-child(5)');
             expect(awayCell.textContent).toContain('🚫 AWAY (Already playing against HOME)');
         });
@@ -391,7 +391,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const awayCell = context.container.querySelector('td:nth-child(5)');
             expect(awayCell.textContent).toContain(`🚫 AWAY (Already playing same leg on ${renderDate(anotherFixture.date)})`);
         });
@@ -415,7 +415,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const awayCell = context.container.querySelector('td:nth-child(5)');
             expect(awayCell.textContent).toEqual(`AWAY`);
         });
@@ -440,7 +440,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam, anotherTeamAtHomeAddress]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const awayCell = context.container.querySelector('td:nth-child(5)');
             expect(awayCell.textContent).toEqual(`AWAYANOTHER TEAM`);
         });
@@ -465,7 +465,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const awayCell = context.container.querySelector('td:nth-child(5)');
             expect(awayCell.textContent).toContain('🚫 AWAY (Already playing against HOME)');
         });
@@ -485,7 +485,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const awayCell = context.container.querySelector('td:nth-child(5)');
             expect(awayCell.textContent).not.toContain('🚫');
         });
@@ -507,7 +507,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const awayCell = context.container.querySelector('td:nth-child(5)');
             expect(awayCell.querySelector('.dropdown-menu')).toBeFalsy();
             expect(awayCell.textContent).toContain('🚫 HOME - SAME ADDRESS vs AWAY using this venue');
@@ -535,7 +535,7 @@ describe('DivisionFixture', () => {
                 account,
                 toMap([homeTeam, awayTeam]));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const awayCell = context.container.querySelector('td:nth-child(5)');
             expect(awayCell.textContent).toEqual('AWAY');
         });
@@ -561,7 +561,7 @@ describe('DivisionFixture', () => {
 
             await doSelectOption(awayCell.querySelector('.dropdown-menu'), 'ANOTHER TEAM');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedFixtures).not.toBeNull();
             expect(updatedFixtures([{date, fixtures: [fixture]}])).toEqual([{
                 date,
@@ -600,7 +600,7 @@ describe('DivisionFixture', () => {
 
             await doSelectOption(awayCell.querySelector('.dropdown-menu'), 'ANOTHER TEAM');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedFixtures).not.toBeNull();
             expect(updatedFixtures([{date, fixtures: [fixture], isKnockout: true}])).toEqual([{
                 date,
@@ -642,7 +642,7 @@ describe('DivisionFixture', () => {
 
             await doClick(findButton(saveCell, '💾'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(savedFixture).not.toBeNull();
             expect(beforeReloadDivisionCalled).toEqual(true);
             expect(divisionReloaded).toEqual(true);
@@ -672,7 +672,7 @@ describe('DivisionFixture', () => {
 
             await doClick(findButton(saveCell, '💾'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(savedFixture).not.toBeNull();
             expect(beforeReloadDivisionCalled).toEqual(true);
             expect(divisionReloaded).toEqual(true);
@@ -703,7 +703,7 @@ describe('DivisionFixture', () => {
 
             await doClick(findButton(saveCell, '💾'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(savedFixture).not.toBeNull();
             expect(beforeReloadDivisionCalled).toEqual(null);
             expect(divisionReloaded).toEqual(false);
@@ -738,7 +738,7 @@ describe('DivisionFixture', () => {
 
             await doClick(findButton(saveCell, '🗑'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(confirm).toEqual('Are you sure you want to delete this fixture?\n\nHOME vs AWAY');
             expect(deletedFixture).toEqual(fixture.id);
             expect(beforeReloadDivisionCalled).toEqual(true);
@@ -796,7 +796,7 @@ describe('DivisionFixture', () => {
 
             await doClick(findButton(saveCell, '🗑'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(deletedFixture).toBeNull();
             expect(beforeReloadDivisionCalled).toEqual(null);
             expect(divisionReloaded).toEqual(false);
@@ -826,7 +826,7 @@ describe('DivisionFixture', () => {
 
             await doClick(findButton(saveCell, '🗑'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(deletedFixture).toEqual(fixture.id);
             expect(beforeReloadDivisionCalled).toEqual(null);
             expect(divisionReloaded).toEqual(false);
@@ -891,7 +891,7 @@ describe('DivisionFixture', () => {
 
             await doClick(findButton(saveCell, '🗑'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(confirm).toEqual('Are you sure you want to delete this fixture?\n\nHOME vs AWAY');
             expect(deletedFixture).toEqual(fixture.id);
             expect(beforeReloadDivisionCalled).toEqual(true);
@@ -966,7 +966,7 @@ describe('DivisionFixture', () => {
 
             await doSelectOption(awayCell.querySelector('.dropdown-menu'), 'ANOTHER TEAM');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedFixtures).toBeNull();
         });
     });

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixtureDate.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixtureDate.test.tsx
@@ -107,7 +107,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('h4');
             expect(heading).toBeTruthy();
             expect(heading.textContent).toContain(renderDate(fixtureDate.date));
@@ -137,7 +137,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('h4');
             expect(heading).toBeTruthy();
             expect(heading.textContent).toContain(renderDate(fixtureDate.date));
@@ -169,7 +169,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table');
             expect(table).toBeTruthy();
             expect(table.querySelectorAll('tr').length).toEqual(1);
@@ -199,7 +199,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('h4');
             expect(heading).toBeTruthy();
             expect(heading.textContent).toContain(renderDate(fixtureDate.date));
@@ -232,7 +232,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('h4');
             expect(heading).toBeTruthy();
             expect(heading.textContent).toContain(renderDate(fixtureDate.date));
@@ -262,7 +262,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('h4');
             expect(heading).toBeTruthy();
             expect(heading.textContent).toContain(renderDate(fixtureDate.date));
@@ -292,7 +292,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const component = context.container.querySelector('div');
             expect(component).toBeTruthy();
             expect(component.className).not.toContain('text-secondary-50');
@@ -317,7 +317,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const component = context.container.querySelector('div');
             expect(component).toBeTruthy();
             expect(component.className).not.toContain('text-secondary-50');
@@ -342,7 +342,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const component = context.container.querySelector('div');
             expect(component).toBeTruthy();
             expect(component.className).toContain('text-secondary-50');
@@ -374,7 +374,7 @@ describe('DivisionFixtureDate', () => {
                     .build(),
                 account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table');
             expect(table).toBeTruthy();
             expect(table.querySelectorAll('tr').length).toEqual(1);
@@ -509,7 +509,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table');
             expect(table).toBeTruthy();
             expect(table.querySelectorAll('tr').length).toEqual(1);
@@ -544,7 +544,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team).withTeam(homeTeam).withTeam(awayTeam)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table');
             expect(table).toBeTruthy();
             expect(table.querySelectorAll('tr').length).toEqual(2);
@@ -575,7 +575,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table');
             expect(table).toBeTruthy();
             expect(table.querySelectorAll('tr').length).toEqual(1);
@@ -613,7 +613,7 @@ describe('DivisionFixtureDate', () => {
 
             await doSelectOption(table.querySelector('.dropdown-menu'), 'ANOTHER TEAM');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(newFixtures).toEqual([expected]);
         });
 
@@ -698,7 +698,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('input[type="checkbox"][id^="isKnockout_"]')).toBeTruthy();
         });
 
@@ -746,7 +746,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account, null, [team, awayTeam]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('h4');
             expect(heading).toBeTruthy();
             expect(heading.textContent).toContain(renderDate(fixtureDate.date));
@@ -779,7 +779,7 @@ describe('DivisionFixtureDate', () => {
                 .withTeam(team)
                 .build(), account, null, [team, awayTeam]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('h4');
             expect(heading).toBeTruthy();
             expect(heading.textContent).toContain(renderDate(fixtureDate.date));

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixtures.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixtures.test.tsx
@@ -168,7 +168,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct');
             const noteElement = fixtureDateElement.querySelector('.alert-warning');
@@ -186,7 +186,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -205,7 +205,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -225,7 +225,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -241,7 +241,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -264,7 +264,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 OctWho\'s playing?');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -286,7 +286,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 OctWho\'s playing?');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -308,7 +308,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account, '/division', '/division#show-who-is-playing');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             expect(fixtureDateElement.textContent).toContain('SIDE PLAYER');
         });
@@ -329,7 +329,7 @@ describe('DivisionFixtures', () => {
 
             await doSelectOption(filterContainer.querySelector('.dropdown-menu'), 'League fixtures');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
         });
 
         it('hides filters when no controls', async () => {
@@ -345,7 +345,7 @@ describe('DivisionFixtures', () => {
                 .build());
             await renderComponent(divisionData, account, null, null, true);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const filterContainer = context.container.querySelector('.content-background > div[datatype="fixture-filters"]');
             expect(filterContainer).toBeFalsy();
         });
@@ -363,7 +363,7 @@ describe('DivisionFixtures', () => {
                 .build());
             await renderComponent(divisionData, account, '/divisions', '/divisions?date=2020-01-01');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).not.toContain('Pairs at another address');
         });
 
@@ -380,7 +380,7 @@ describe('DivisionFixtures', () => {
                 .build());
             await renderComponent(divisionData, account, '/divisions', '/divisions?date=2022-10-13&type=tournaments');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).toContain('Pairs at another address');
         });
 
@@ -397,7 +397,7 @@ describe('DivisionFixtures', () => {
                 .build());
             await renderComponent(divisionData, account, '/divisions', '/divisions?date=2022-10-13&type=league');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).not.toContain('📅');
         });
     });
@@ -423,7 +423,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct📌 Add noteQualifier');
             const noteElement = fixtureDateElement.querySelector('.alert-warning');
@@ -441,7 +441,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct📌 Add note');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -460,7 +460,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct📌 Add note');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -479,7 +479,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct📌 Add note');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -496,7 +496,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct📌 Add noteQualifier');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -519,7 +519,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct📌 Add noteWho\'s playing?');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -541,7 +541,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const fixtureDateElement = getFixtureDateElement(0, account);
             assertFixtureDate(fixtureDateElement, '13 Oct📌 Add noteWho\'s playing?');
             const fixturesForDate = fixtureDateElement.querySelectorAll('table tbody tr');
@@ -570,7 +570,7 @@ describe('DivisionFixtures', () => {
             const fixtureDateElement = getFixtureDateElement(0, account);
             await doClick(findButton(fixtureDateElement, '➕'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(divisionReloaded).toEqual(true);
             expect(newFixtures).not.toBeNull();
         });
@@ -586,7 +586,7 @@ describe('DivisionFixtures', () => {
 
             await doClick(findButton(fixtureDateElement, '📌 Add note'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
             expect(dialog.textContent).toContain('Create note');
@@ -602,7 +602,7 @@ describe('DivisionFixtures', () => {
 
             await doClick(findButton(fixtureDateElement.querySelector('.alert'), 'Edit'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
             expect(dialog.textContent).toContain('Edit note');
@@ -626,7 +626,7 @@ describe('DivisionFixtures', () => {
             await doChange(dialog, 'textarea[name="note"]', 'New note', context.user);
             await doClick(findButton(dialog, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('.modal-dialog')).toBeFalsy();
             expect(divisionReloaded).toEqual(true);
             expect(updatedNote).not.toBeNull();
@@ -644,7 +644,7 @@ describe('DivisionFixtures', () => {
 
             await doClick(findButton(dialog, 'Close'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('.modal-dialog')).toBeFalsy();
         });
 
@@ -654,7 +654,7 @@ describe('DivisionFixtures', () => {
 
             await doClick(findButton(context.container, '➕ Add date'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
             expect(dialog.textContent).toContain('Add date');
@@ -667,7 +667,7 @@ describe('DivisionFixtures', () => {
             await doClick(findButton(context.container, '➕ Add date'));
             await doClick(findButton(context.container.querySelector('.modal-dialog'), 'Close'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeFalsy();
         });
@@ -682,7 +682,7 @@ describe('DivisionFixtures', () => {
 
             await doClick(findButton(dialog, 'Add date'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(newFixtures).toBeNull();
             expect(alert).toEqual('Select a date first');
         });
@@ -704,7 +704,7 @@ describe('DivisionFixtures', () => {
             await doChange(dialog, 'input[type="date"]', '2022-10-13', context.user);
             await doClick(findButton(dialog, 'Add date'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(newFixtures).toBeNull();
         });
 
@@ -724,7 +724,7 @@ describe('DivisionFixtures', () => {
             await doClick(dialog, 'input[name="isKnockout"]');
             await doClick(findButton(dialog, 'Add date'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(newFixtures).not.toBeNull();
             expect(newFixtures.length).toEqual(1);
             expect(newFixtures[0].date).toEqual('2023-05-06T00:00:00');
@@ -753,7 +753,7 @@ describe('DivisionFixtures', () => {
 
             await renderComponent(divisionData, account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
         });
 
         it('can open create new fixtures dialog', async () => {
@@ -762,7 +762,7 @@ describe('DivisionFixtures', () => {
 
             await doClick(findButton(context.container, '🗓️ Create fixtures'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
             expect(dialog.textContent).toContain('Create season fixtures...');
@@ -772,7 +772,7 @@ describe('DivisionFixtures', () => {
             const divisionData = getInSeasonDivisionData();
             await renderComponent(divisionData, account);
             await doClick(findButton(context.container, '🗓️ Create fixtures'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container.querySelector('.modal-dialog'), 'Close'))
 

--- a/CourageScores/ClientApp/src/components/division_fixtures/TournamentFixture.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/TournamentFixture.test.tsx
@@ -140,7 +140,7 @@ describe('TournamentFixture', () => {
                 {id: division.id, season, players: [player], onReloadDivision, name: '', setDivisionData: noop },
                 account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['TYPE at ADDRESS']);
@@ -160,7 +160,7 @@ describe('TournamentFixture', () => {
                 {id: division.id, season, players: [player], onReloadDivision, name: '', setDivisionData: noop},
                 account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['TYPE at ADDRESS', 'Winner: WINNER']);
@@ -182,7 +182,7 @@ describe('TournamentFixture', () => {
                 account,
                 [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['TYPE at ADDRESS', 'Winner: WINNER']);
@@ -208,7 +208,7 @@ describe('TournamentFixture', () => {
                 account,
                 []);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['TYPE at ADDRESS', 'Winner: WINNER']);
@@ -228,7 +228,7 @@ describe('TournamentFixture', () => {
                 {id: division.id, season, players: [player], onReloadDivision, name: '', setDivisionData: noop},
                 account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.innerHTML).toEqual('');
         });
 
@@ -254,7 +254,7 @@ describe('TournamentFixture', () => {
                 },
                 account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playersCell = context.container.querySelector('td:first-child');
             assertPlayerDisplayWithPlayerLinks(playersCell, 1, side3.players);
             assertSinglePlayerDisplay(playersCell, 2, side1.name, side1.players[0]);
@@ -288,7 +288,7 @@ describe('TournamentFixture', () => {
                 {id: division.id, season, players: [player], onReloadDivision, name: '', setDivisionData: noop},
                 account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(td => td.textContent);
             expect(cellText).toEqual(['Tournament at ADDRESS', '➕']);
@@ -310,7 +310,7 @@ describe('TournamentFixture', () => {
 
             await doClick(findButton(adminCell, '➕'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(savedTournament.data).toEqual({
                 date: '2023-05-06T00:00:00',
                 address: 'ADDRESS',
@@ -337,7 +337,7 @@ describe('TournamentFixture', () => {
 
             await doClick(findButton(adminCell, '➕'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(savedTournament).not.toBeNull();
             expect(tournamentChanged).toBeNull();
             expect(context.container.textContent).toContain('SOME ERROR');
@@ -386,7 +386,7 @@ describe('TournamentFixture', () => {
             await doClick(findButton(adminCell, '🗑'));
 
             expect(confirm).toEqual('Are you sure you want to delete this tournament fixture?');
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(deletedId).toEqual(tournament.id);
             expect(tournamentChanged).toEqual(true);
         });
@@ -411,7 +411,7 @@ describe('TournamentFixture', () => {
             await doClick(findButton(adminCell, '🗑'));
 
             expect(confirm).toEqual('Are you sure you want to delete this tournament fixture?');
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(deletedId).toBeNull();
             expect(tournamentChanged).toEqual(null);
         });
@@ -434,7 +434,7 @@ describe('TournamentFixture', () => {
 
             await doClick(findButton(adminCell, '🗑'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(tournamentChanged).toBeNull();
             expect(context.container.textContent).toContain('SOME ERROR');
             expect(context.container.textContent).toContain('Could not delete tournament');

--- a/CourageScores/ClientApp/src/components/division_fixtures/sayg/LiveSayg.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/sayg/LiveSayg.test.tsx
@@ -54,7 +54,7 @@ describe('LiveSayg', () => {
 
         await renderComponent('/live/match/:id', '/live/match/' + saygData.id);
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(requestedSaygId).toEqual(saygData.id);
     })
 });

--- a/CourageScores/ClientApp/src/components/division_fixtures/sayg/MatchStatistics.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/sayg/MatchStatistics.test.tsx
@@ -300,7 +300,7 @@ describe('MatchStatistics', () => {
         expect(context.container.querySelector('.modal-dialog').textContent).toContain('Edit throw');
         await doClick(findButton(legRow, 'Save changes'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(updatedSayg).not.toBeNull();
     });
 
@@ -580,11 +580,11 @@ describe('MatchStatistics', () => {
             account,
         }));
         expect(Object.keys(socketFactory.subscriptions)).toEqual([saygId]);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         await doSelectOption(context.container.querySelector('h4 .dropdown-menu'), '⏸️ Paused');
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(socketFactory.subscriptions).toBeTruthy();
     });
 
@@ -624,11 +624,11 @@ describe('MatchStatistics', () => {
             account,
         }));
         expect(Object.keys(socketFactory.subscriptions)).toEqual([saygId]);
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
 
         await doClick(findButton(context.container.querySelector('h4'), '🖥'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(context.container.innerHTML).toContain('WidescreenMatchStatistics');
     });
 
@@ -691,7 +691,7 @@ describe('MatchStatistics', () => {
             } as MessageEvent<string>);
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const firstRow = context.container.querySelector('table tbody tr:first-child');
         const finishedHeadings = Array.from(firstRow.querySelectorAll('td'));
         expect(finishedHeadings.map(th => th.textContent)).toEqual(['Score', '2', '0']);

--- a/CourageScores/ClientApp/src/components/division_fixtures/sayg/PlayerInput.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/sayg/PlayerInput.test.tsx
@@ -227,7 +227,7 @@ describe('PlayerInput', () => {
         await setScoreInput("50");
         await doClick(findButton(context.container, '📌📌📌'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(changedLegs).toEqual([{
             currentThrow: 'home',
             startingScore: 501,
@@ -266,7 +266,7 @@ describe('PlayerInput', () => {
         await setScoreInput("100");
         await doClick(findButton(context.container, '📌📌'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(changedLegs).toEqual([{
             currentThrow: 'home',
             startingScore: 501,
@@ -306,7 +306,7 @@ describe('PlayerInput', () => {
         await setScoreInput("50");
         await doClick(findButton(context.container, '📌'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(changedLegs).toEqual([{
             currentThrow: 'home',
             startingScore: 501,
@@ -346,7 +346,7 @@ describe('PlayerInput', () => {
         await setScoreInput("180");
         await doClick(findButton(context.container, '💥💥💥'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(changedLegs).toEqual([{
             currentThrow: 'home',
             startingScore: 501,
@@ -385,7 +385,7 @@ describe('PlayerInput', () => {
         await setScoreInput("120");
         await doClick(findButton(context.container, '💥💥'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(changedLegs).toEqual([{
             currentThrow: 'home',
             startingScore: 501,
@@ -424,7 +424,7 @@ describe('PlayerInput', () => {
         await setScoreInput("60");
         await doClick(findButton(context.container, '💥'));
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(changedLegs).toEqual([{
             currentThrow: 'home',
             startingScore: 501,
@@ -463,7 +463,7 @@ describe('PlayerInput', () => {
         await setScoreInput('');
         await context.user.type(context.container.querySelector('input[data-score-input="true"]'), '{Enter}');
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(changedLegs).toEqual([]);
     });
 
@@ -487,7 +487,7 @@ describe('PlayerInput', () => {
         await setScoreInput('.');
         await context.user.type(context.container.querySelector('input[data-score-input="true"]'), '{Enter}');
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(changedLegs).toEqual([]);
     });
 
@@ -511,7 +511,7 @@ describe('PlayerInput', () => {
         await setScoreInput('121');
         await context.user.type(context.container.querySelector('input[data-score-input="true"]'), '{Enter}');
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(changedLegs.length).toEqual(1);
     });
 
@@ -535,7 +535,7 @@ describe('PlayerInput', () => {
         await setScoreInput('50'); // could be bull (1 dart), 10, D20 (2 darts) or a range of 3-dart options
         await context.user.type(context.container.querySelector('input[data-score-input="true"]'), '{Enter}');
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(changedLegs.length).toEqual(0);
     });
 
@@ -559,7 +559,7 @@ describe('PlayerInput', () => {
         await setScoreInput('200');
         await context.user.type(context.container.querySelector('input[data-score-input="true"]'), '{Enter}');
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(changedLegs.length).toEqual(0);
     });
 });

--- a/CourageScores/ClientApp/src/components/division_fixtures/sayg/SaygLoadingContainer.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/sayg/SaygLoadingContainer.test.tsx
@@ -120,7 +120,7 @@ describe('SaygLoadingContainer', () => {
                 liveOptions: {},
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(containerProps).toEqual({
                 subscriptions: {},
                 enableLiveUpdates: expect.any(Function),
@@ -153,7 +153,7 @@ describe('SaygLoadingContainer', () => {
                 liveOptions: {},
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(containerProps).toEqual({
                 subscriptions: {},
                 liveOptions: expect.any(Object),
@@ -189,7 +189,7 @@ describe('SaygLoadingContainer', () => {
                 liveOptions: {},
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(loadError).toEqual('Data not found');
         });
 
@@ -213,7 +213,7 @@ describe('SaygLoadingContainer', () => {
                 liveOptions: {},
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(loadError).toEqual('Data not found');
         });
 
@@ -240,7 +240,7 @@ describe('SaygLoadingContainer', () => {
                 liveOptions: {},
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(sayg.lastUpdated).toEqual('2023-07-21');
         });
 
@@ -277,7 +277,7 @@ describe('SaygLoadingContainer', () => {
                     .build());
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(containerProps.sayg.lastUpdated).toEqual('2023-07-21');
         });
 
@@ -412,7 +412,10 @@ describe('SaygLoadingContainer', () => {
             expect(saved).toBeNull();
             expect(result).toBeNull();
             expect(containerProps.sayg.id).toBeUndefined();
-            expect(reportedError.hasError()).toEqual(true);
+            reportedError.verifyErrorEquals({
+                message: 'Cannot create property \'lastUpdated\' on string \'SOMETHING THAT WILL TRIGGER AN EXCEPTION\'',
+                stack: expect.any(String),
+            });
         });
 
         it('should save data when score changes and auto save enabled', async () => {
@@ -652,7 +655,7 @@ describe('SaygLoadingContainer', () => {
                 } as MessageEvent<string>);
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(renderedData).toEqual(newSaygData);
         });
 

--- a/CourageScores/ClientApp/src/components/division_fixtures/sayg/WidescreenSaygPlayer.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/sayg/WidescreenSaygPlayer.test.tsx
@@ -94,7 +94,7 @@ describe('WidescreenSaygPlayer', () => {
                     changeStatisticsView,
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const scoreElement = context.container.querySelector('div:nth-child(1)');
             expect(scoreElement.querySelector('h1').textContent).toEqual('401');
         });
@@ -110,7 +110,7 @@ describe('WidescreenSaygPlayer', () => {
                     changeStatisticsView: changeStatisticsView,
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const scoreElement = context.container.querySelector('div:nth-child(2)');
             expect(scoreElement.querySelector('h1').textContent).toEqual('401');
         });
@@ -126,7 +126,7 @@ describe('WidescreenSaygPlayer', () => {
                     changeStatisticsView: changeStatisticsView,
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const optionsContainer = context.container.querySelector('div:nth-child(3)');
             expect(optionsContainer).toBeFalsy();
         });
@@ -148,7 +148,7 @@ describe('WidescreenSaygPlayer', () => {
                     liveOptions: {},
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const optionsContainer = context.container.querySelector('div:nth-child(3)');
             expect(optionsContainer).toBeTruthy();
             expect(optionsContainer.textContent).toContain('⏸️ Paused');
@@ -171,7 +171,7 @@ describe('WidescreenSaygPlayer', () => {
                     liveOptions: {},
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const optionsContainer = context.container.querySelector('div:nth-child(3)');
             expect(optionsContainer).toBeTruthy();
             expect(optionsContainer.textContent).not.toContain('⏸️ Paused');
@@ -194,7 +194,7 @@ describe('WidescreenSaygPlayer', () => {
                     liveOptions: {},
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const optionsContainer = context.container.querySelector('div:nth-child(3)');
             expect(optionsContainer).toBeTruthy();
             expect(optionsContainer.textContent).not.toContain('⏸️ Paused');
@@ -211,7 +211,7 @@ describe('WidescreenSaygPlayer', () => {
                     changeStatisticsView: changeStatisticsView,
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const optionsContainer = context.container.querySelector('div:nth-child(3)');
             const changeButton = optionsContainer.querySelector('button');
             expect(changeButton.textContent).toEqual('📊');
@@ -228,7 +228,7 @@ describe('WidescreenSaygPlayer', () => {
                     changeStatisticsView: null,
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const optionsContainer = context.container.querySelector('div:nth-child(3)');
             const changeButton = optionsContainer.querySelector('button');
             expect(changeButton).toBeFalsy();
@@ -247,7 +247,7 @@ describe('WidescreenSaygPlayer', () => {
                     changeStatisticsView: null,
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const scoreElement = context.container.querySelector('h1');
             expect(scoreElement.textContent).toEqual('🎉');
         });
@@ -265,7 +265,7 @@ describe('WidescreenSaygPlayer', () => {
                     changeStatisticsView: null,
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const scoreElement = context.container.querySelector('h1');
             expect(scoreElement.textContent).toEqual('0');
         });
@@ -298,7 +298,7 @@ describe('WidescreenSaygPlayer', () => {
                     changeStatisticsView: null,
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const throwsElement = context.container.querySelector('div[datatype="WidescreenSaygPlayer"] > div:nth-child(1)');
             const throws = Array.from(throwsElement.querySelectorAll('div'));
             expect(throws.map(thr => thr.textContent)).toEqual([ '12', '10', '8', '6', '4' ]);
@@ -342,7 +342,7 @@ describe('WidescreenSaygPlayer', () => {
                     changeStatisticsView: null,
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const throwsElement = context.container.querySelector('div[datatype="WidescreenSaygPlayer"] > div:nth-child(1)');
             const throws = Array.from(throwsElement.querySelectorAll('div'));
             expect(throws.map(thr => thr.textContent)).toEqual([ '112', '110', '18', '16', '14' ]);
@@ -373,7 +373,7 @@ describe('WidescreenSaygPlayer', () => {
                     changeStatisticsView: null,
                 });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const throwsElement = context.container.querySelector('div[datatype="WidescreenSaygPlayer"] > div:nth-child(1)');
             const throws = Array.from(throwsElement.querySelectorAll('div'));
             expect(throws.map(thr => thr.textContent)).toEqual([ '6', '4', '2' ]);
@@ -409,7 +409,7 @@ describe('WidescreenSaygPlayer', () => {
 
             await doClick(findButton(context.container, '📊'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(newStatisticsView).toEqual(false);
         });
     });

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/GameDetails.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/GameDetails.test.tsx
@@ -128,7 +128,7 @@ describe('GameDetails', () => {
                 setFixtureData,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const shareButton = context.container.querySelectorAll('button')[0];
             expect(shareButton).toBeTruthy();
             expect(shareButton.textContent).toEqual('🔗');

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/ManOfTheMatchInput.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/ManOfTheMatchInput.test.tsx
@@ -85,7 +85,7 @@ describe('ManOfTheMatchInput', () => {
 
             await renderComponent(account, { saving, fixtureData, access, setFixtureData });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.innerHTML).toEqual('');
         });
 
@@ -99,7 +99,7 @@ describe('ManOfTheMatchInput', () => {
 
             await renderComponent(account, { saving, fixtureData, access, setFixtureData });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.innerHTML).toEqual('');
         });
 
@@ -114,7 +114,7 @@ describe('ManOfTheMatchInput', () => {
 
             await renderComponent(account, { saving, fixtureData, access, setFixtureData });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.innerHTML).toEqual('');
         });
 
@@ -129,7 +129,7 @@ describe('ManOfTheMatchInput', () => {
 
             await renderComponent(account, { saving, fixtureData, access, setFixtureData });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.innerHTML).toEqual('');
         });
     });
@@ -149,7 +149,7 @@ describe('ManOfTheMatchInput', () => {
 
                 await renderComponent(account, { saving: false, fixtureData, access: 'admin', setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = context.container.querySelectorAll('td');
                 expect(cells.length).toEqual(3);
                 assertPlayers(cells[0], [], ' ', null);
@@ -167,7 +167,7 @@ describe('ManOfTheMatchInput', () => {
 
                 await renderComponent(account, { saving: false, fixtureData, access: 'admin', setFixtureData, disabled: true });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = context.container.querySelectorAll('td');
                 expect(cells.length).toEqual(3);
                 expect(cells[0].querySelector('.dropdown-toggle').textContent).toEqual('AWAY player');
@@ -182,7 +182,7 @@ describe('ManOfTheMatchInput', () => {
 
                 await renderComponent(account, { saving: false, fixtureData, access: 'admin', setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = context.container.querySelectorAll('td');
                 expect(cells.length).toEqual(3);
                 assertPlayers(cells[0], [], ' ', null);
@@ -199,7 +199,7 @@ describe('ManOfTheMatchInput', () => {
 
                 await renderComponent(account, { saving: false, fixtureData, access: 'admin', setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = context.container.querySelectorAll('td');
                 expect(cells.length).toEqual(3);
                 assertPlayers(cells[0], ['AWAY player'], ' ', null);
@@ -217,7 +217,7 @@ describe('ManOfTheMatchInput', () => {
 
                 await renderComponent(account, { saving: false, fixtureData, access: 'admin', setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = context.container.querySelectorAll('td');
                 expect(cells.length).toEqual(3);
                 assertPlayers(cells[0], ['AWAY player'], 'AWAY player', 'AWAY player');
@@ -234,7 +234,7 @@ describe('ManOfTheMatchInput', () => {
 
                 await renderComponent(account, { saving: false, fixtureData, access: 'admin', setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = context.container.querySelectorAll('td');
                 expect(cells.length).toEqual(3);
                 assertPlayers(cells[2], ['HOME player'], 'HOME player', 'HOME player');
@@ -249,7 +249,7 @@ describe('ManOfTheMatchInput', () => {
                     .playing('HOME', 'AWAY')
                     .withMatch((m: IMatchBuilder) => m.withHome(homePlayer).withAway(awayPlayer))
                     .build();
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 await renderComponent(account, { saving: false, fixtureData, access: 'admin', setFixtureData });
                 const homeMOM = context.container.querySelectorAll('td')[0];
 
@@ -268,7 +268,7 @@ describe('ManOfTheMatchInput', () => {
                     .withMatch((m: IMatchBuilder) => m.withHome(homePlayer).withAway(awayPlayer))
                     .build();
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 await renderComponent(account, { saving: false, fixtureData, access: 'admin', setFixtureData });
                 const homeMOM = context.container.querySelectorAll('td')[0];
 
@@ -286,7 +286,7 @@ describe('ManOfTheMatchInput', () => {
                     .withMatch((m: IMatchBuilder) => m.withHome(homePlayer).withAway(awayPlayer))
                     .build();
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 await renderComponent(account, { saving: false, fixtureData, access: 'admin', setFixtureData });
                 const awayMOM = context.container.querySelectorAll('td')[2];
 
@@ -305,7 +305,7 @@ describe('ManOfTheMatchInput', () => {
                     .withMatch((m: IMatchBuilder) => m.withHome(homePlayer).withAway(awayPlayer))
                     .build();
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 await renderComponent(account, { saving: false, fixtureData, access: 'admin', setFixtureData });
                 const awayMOM = context.container.querySelectorAll('td')[2];
 

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MatchPlayerSelection.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MatchPlayerSelection.test.tsx
@@ -153,7 +153,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             assertSelectedPlayer(cells[0], null);
             assertScore(cells[1], '');
@@ -172,7 +172,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             assertScore(cells[1], '');
             assertScore(cells[3], '');
@@ -197,7 +197,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             assertSelectedPlayer(cells[0], 'HOME');
             assertScore(cells[1], '3');
@@ -224,7 +224,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             assertSelectedPlayer(cells[0], 'HOME');
             assertScore(cells[1], '1');
@@ -251,7 +251,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             assertSelectedPlayer(cells[0], 'HOME');
             assertScore(cells[1], '1');
@@ -289,7 +289,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, containerProps, defaultMatchType);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             assertSelectablePlayers(cells[0], ['HOME', 'ANOTHER HOME']);
             assertSelectablePlayers(cells[4], ['AWAY']);
@@ -321,7 +321,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, containerProps, defaultMatchType);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             assertSelectablePlayers(cells[0], ['HOME']);
             assertSelectablePlayers(cells[4], ['AWAY', 'ANOTHER AWAY']);
@@ -366,7 +366,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, containerProps, matchTypeProps);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             assertSelectablePlayers(cells[0], ['HOME']);
             assertSelectablePlayers(cells[4], ['AWAY']);
@@ -411,7 +411,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, containerProps, matchTypeProps);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             assertSelectablePlayers(cells[0], ['HOME']);
             assertSelectablePlayers(cells[4], ['AWAY']);
@@ -440,7 +440,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             expect(cells[0].textContent).toContain('📊');
         });
@@ -468,7 +468,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             expect(cells[0].textContent).not.toContain('📊');
         });
@@ -518,12 +518,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await selectPlayer(cells[0], 'HOME');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).not.toBeNull();
             expect(updatedMatch.homePlayers).toEqual([homePlayer]);
@@ -544,12 +544,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await selectPlayer(cells[0], 'Add a player...');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).not.toBeNull();
             expect(createPlayerFor).toEqual({
                 index: 0,
@@ -570,12 +570,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await selectPlayer(cells[0], ' ');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).not.toBeNull();
             expect(updatedMatch.homePlayers).toEqual([]);
@@ -596,12 +596,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await selectPlayer(cells[4], 'AWAY');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).not.toBeNull();
             expect(updatedMatch.homePlayers).toEqual([]);
@@ -622,12 +622,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await selectPlayer(cells[4], 'Add a player...');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).not.toBeNull();
             expect(createPlayerFor).toEqual({
                 index: 0,
@@ -648,12 +648,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await selectPlayer(cells[4], ' ');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).not.toBeNull();
             expect(updatedMatch.homePlayers).toEqual([]);
@@ -674,12 +674,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await doChange(cells[1], 'input', '3', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).not.toBeNull();
             expect(updatedMatch.homePlayers).toEqual([]);
@@ -700,12 +700,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await doChange(cells[3], 'input', '3', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).not.toBeNull();
             expect(updatedMatch.homePlayers).toEqual([]);
@@ -726,12 +726,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await doChange(cells[1], 'input', '6', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).not.toBeNull();
             expect(updatedMatch.homePlayers).toEqual([]);
@@ -752,12 +752,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await doChange(cells[3], 'input', '6', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).not.toBeNull();
             expect(updatedMatch.homePlayers).toEqual([]);
@@ -779,12 +779,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await doChange(cells[1], 'input', '3', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).not.toBeNull();
             expect(updatedMatch.homePlayers).toEqual([]);
@@ -806,12 +806,12 @@ describe('MatchPlayerSelection', () => {
                 onMatchOptionsChanged,
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await doChange(cells[3], 'input', '3', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).not.toBeNull();
             expect(updatedMatch.homePlayers).toEqual([]);
@@ -840,7 +840,7 @@ describe('MatchPlayerSelection', () => {
                 setCreatePlayerFor: null,
             };
             await renderComponent(account, props, defaultContainerProps, matchTypeProps);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             await doClick(findButton(cells[4], '🛠'));
             const matchOptionsDialog = cells[4].querySelector('div.modal-dialog');
@@ -876,7 +876,7 @@ describe('MatchPlayerSelection', () => {
                 setCreatePlayerFor: null,
             };
             await renderComponent(account, props, defaultContainerProps, matchTypeProps);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             await doClick(findButton(cells[4], '🛠'));
             const matchOptionsDialog = cells[4].querySelector('div.modal-dialog');
@@ -912,7 +912,7 @@ describe('MatchPlayerSelection', () => {
                 setCreatePlayerFor: null,
             };
             await renderComponent(account, props, defaultContainerProps, matchTypeProps);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             await doClick(findButton(cells[4], '🛠'));
             const matchOptionsDialog = cells[4].querySelector('div.modal-dialog');
@@ -948,7 +948,7 @@ describe('MatchPlayerSelection', () => {
                 setCreatePlayerFor: null,
             };
             await renderComponent(account, props, defaultContainerProps, matchTypeProps);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             await doClick(findButton(cells[4], '🛠'));
             const matchOptionsDialog = cells[4].querySelector('div.modal-dialog');
@@ -956,7 +956,7 @@ describe('MatchPlayerSelection', () => {
 
             await doClick(findButton(matchOptionsDialog, 'Close'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(cells[4].querySelector('div.modal-dialog')).toBeFalsy();
         });
 
@@ -982,16 +982,16 @@ describe('MatchPlayerSelection', () => {
                 away: null,
             };
             await renderComponent(account, props, containerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await selectPlayer(cells[0], 'HOME');
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).toBeNull();
 
             await selectPlayer(cells[4], 'AWAY');
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).toBeNull();
         });
@@ -1018,16 +1018,16 @@ describe('MatchPlayerSelection', () => {
                 home: null,
             };
             await renderComponent(account, props, containerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await doChange(cells[1], 'input', '3', context.user);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).toBeNull();
 
             await doChange(cells[3], 'input', '3', context.user);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createPlayerFor).toBeNull();
             expect(updatedMatch).toBeNull();
         });
@@ -1056,7 +1056,7 @@ describe('MatchPlayerSelection', () => {
 
             await renderComponent(account, props, containerProps, defaultMatchType);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const homePlayers = Array.from(cells[0].querySelectorAll('.dropdown-item'));
             const awayPlayers = Array.from(cells[4].querySelectorAll('.dropdown-item'));
@@ -1087,7 +1087,7 @@ describe('MatchPlayerSelection', () => {
             };
 
             await renderComponent(account, props, containerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             const homeScore = cells[1].querySelector('input');
             const awayScore = cells[3].querySelector('input');
@@ -1116,7 +1116,7 @@ describe('MatchPlayerSelection', () => {
                 }
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
 
             await doClick(findButton(cells[0], '📊'));
@@ -1153,7 +1153,7 @@ describe('MatchPlayerSelection', () => {
                 }
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             await doClick(findButton(cells[0], '📊'));
             const saygDialog = cells[0].querySelector('div.modal-dialog');
@@ -1196,7 +1196,7 @@ describe('MatchPlayerSelection', () => {
                 }
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             await doClick(findButton(cells[0], '📊'));
             const saygDialog = cells[0].querySelector('div.modal-dialog');
@@ -1239,7 +1239,7 @@ describe('MatchPlayerSelection', () => {
                 }
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             await doClick(findButton(cells[0], '📊'));
             const saygDialog = cells[0].querySelector('div.modal-dialog');
@@ -1288,7 +1288,7 @@ describe('MatchPlayerSelection', () => {
                 }
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             await doClick(findButton(cells[0], '📊'));
             const saygDialog = cells[0].querySelector('div.modal-dialog');
@@ -1330,7 +1330,7 @@ describe('MatchPlayerSelection', () => {
                 }
             };
             await renderComponent(account, props, defaultContainerProps, defaultMatchType);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             await doClick(findButton(cells[0], '📊'));
             const saygDialog = cells[0].querySelector('div.modal-dialog');
@@ -1338,7 +1338,7 @@ describe('MatchPlayerSelection', () => {
 
             await doClick(findButton(saygDialog, 'Close'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(cells[0].querySelector('div.modal-dialog')).toBeFalsy();
         });
     });

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeHiCheckAnd180s.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeHiCheckAnd180s.test.tsx
@@ -53,7 +53,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent({ data, fixtureData, setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const homeSubmission = context.container.querySelector('div[datatype="home-180s"]');
                 expect(homeSubmission).not.toBeNull();
                 const oneEighties = Array.from(homeSubmission.querySelectorAll('ol > li')).map(li => li.textContent);
@@ -69,7 +69,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent({ data, fixtureData, setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const awaySubmission = context.container.querySelector('div[datatype="away-180s"]');
                 expect(awaySubmission).not.toBeNull();
                 const oneEighties = Array.from(awaySubmission.querySelectorAll('ol > li')).map(li => li.textContent);
@@ -85,7 +85,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent({ data, fixtureData, setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const homeSubmission = context.container.querySelector('div[datatype="home-180s"]');
                 const awaySubmission = context.container.querySelector('div[datatype="away-180s"]');
                 expect(homeSubmission).toBeNull();
@@ -103,7 +103,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent({ data, fixtureData, setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const homeSubmission = context.container.querySelector('div[datatype="home-180s"]');
                 const awaySubmission = context.container.querySelector('div[datatype="away-180s"]');
                 expect(homeSubmission).toBeNull();
@@ -169,7 +169,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await doClick(findButton(homeSubmission, 'Merge'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedData).not.toBeNull();
                 expect(updatedData.oneEighties).toEqual([player]);
             });
@@ -187,7 +187,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await doClick(findButton(awaySubmission, 'Merge'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedData).not.toBeNull();
                 expect(updatedData.oneEighties).toEqual([player]);
             });
@@ -206,7 +206,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent({ data, fixtureData, setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const homeSubmission = context.container.querySelector('div[datatype="home-hichecks"]');
                 expect(homeSubmission).not.toBeNull();
                 const hiChecks = Array.from(homeSubmission.querySelectorAll('ol > li')).map(li => li.textContent);
@@ -223,7 +223,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent({ data, fixtureData, setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const awaySubmission = context.container.querySelector('div[datatype="away-hichecks"]');
                 expect(awaySubmission).not.toBeNull();
                 const hiChecks = Array.from(awaySubmission.querySelectorAll('ol > li')).map(li => li.textContent);
@@ -240,7 +240,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent({ data, fixtureData, setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const homeSubmission = context.container.querySelector('div[datatype="home-hichecks"]');
                 const awaySubmission = context.container.querySelector('div[datatype="away-hichecks"]');
                 expect(homeSubmission).toBeNull();
@@ -258,7 +258,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await renderComponent({ data, fixtureData, setFixtureData });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const homeSubmission = context.container.querySelector('div[datatype="home-hichecks"]');
                 const awaySubmission = context.container.querySelector('div[datatype="away-hichecks"]');
                 expect(homeSubmission).toBeNull();
@@ -324,7 +324,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await doClick(findButton(homeSubmission, 'Merge'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedData).not.toBeNull();
                 expect(updatedData.over100Checkouts).toEqual([player]);
             });
@@ -342,7 +342,7 @@ describe('MergeHiCheckAnd180s', () => {
 
                 await doClick(findButton(awaySubmission, 'Merge'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedData).not.toBeNull();
                 expect(updatedData.over100Checkouts).toEqual([player]);
             });

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeManOfTheMatch.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeManOfTheMatch.test.tsx
@@ -142,7 +142,7 @@ describe('MergeManOfTheMatch', () => {
 
             await doClick(findButton(context.container.querySelector('td:nth-child(1)'), 'Use MOM'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).not.toBeNull();
             expect(updatedData.home.manOfTheMatch).toEqual(player.id);
         });
@@ -157,7 +157,7 @@ describe('MergeManOfTheMatch', () => {
 
             await doClick(findButton(context.container.querySelector('td:nth-child(3)'), 'Use MOM'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).not.toBeNull();
             expect(updatedData.away.manOfTheMatch).toEqual(player.id);
         });

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeMatch.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MergeMatch.test.tsx
@@ -61,7 +61,7 @@ describe('MergeMatch', () => {
                 setFixtureData,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.innerHTML).toEqual('');
         });
 
@@ -85,7 +85,7 @@ describe('MergeMatch', () => {
                 setFixtureData,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const td = context.container.querySelector('td');
             expect(td.colSpan).toEqual(5);
             expect(td.querySelector('button')).toBeTruthy();
@@ -112,7 +112,7 @@ describe('MergeMatch', () => {
                 setFixtureData,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const td = context.container.querySelector('td');
             expect(td.colSpan).toEqual(5);
             expect(td.querySelector('button')).toBeTruthy();
@@ -139,7 +139,7 @@ describe('MergeMatch', () => {
                 setFixtureData,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const td = context.container.querySelector('td:nth-child(3)') as HTMLTableCellElement;
             expect(td.colSpan).toEqual(2);
             expect(td.querySelector('span').textContent).toEqual('No match');
@@ -160,7 +160,7 @@ describe('MergeMatch', () => {
                 setFixtureData,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.innerHTML).toEqual('');
         });
 
@@ -187,7 +187,7 @@ describe('MergeMatch', () => {
                 setFixtureData,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const homeSubmission = context.container.querySelector('td:nth-child(1)') as HTMLTableCellElement;
             expect(homeSubmission.colSpan).toEqual(2);
             expect(homeSubmission.textContent).toContain('from HOME CAPTAIN');
@@ -218,7 +218,7 @@ describe('MergeMatch', () => {
                 setFixtureData,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const homeSubmission = context.container.querySelector('td:nth-child(1)') as HTMLTableCellElement
             expect(homeSubmission.colSpan).toEqual(2);
             expect(homeSubmission.querySelector('button').disabled).toEqual(true);
@@ -247,7 +247,7 @@ describe('MergeMatch', () => {
                 setFixtureData,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const awaySubmission = context.container.querySelector('td:nth-child(3)') as HTMLTableCellElement
             expect(awaySubmission.colSpan).toEqual(2);
             expect(awaySubmission.textContent).toContain('from AWAY CAPTAIN');
@@ -278,7 +278,7 @@ describe('MergeMatch', () => {
                 setFixtureData,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const awaySubmission = context.container.querySelector('td:nth-child(3)') as HTMLTableCellElement;
             expect(awaySubmission.colSpan).toEqual(2);
             expect(awaySubmission.querySelector('button').disabled).toEqual(true);
@@ -316,7 +316,7 @@ describe('MergeMatch', () => {
 
             await doClick(findButton(homeSubmission, 'Accept'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData.matches[0]).toEqual({
                 awayPlayers: [awayPlayer],
                 homePlayers: [homePlayer],
@@ -355,7 +355,7 @@ describe('MergeMatch', () => {
 
             await doClick(findButton(awaySubmission, 'Accept'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData.matches[0]).toEqual({
                 awayPlayers: [awayPlayer],
                 homePlayers: [homePlayer],
@@ -394,7 +394,7 @@ describe('MergeMatch', () => {
 
             await doClick(findButton(homeSubmission, 'Accept'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData.matches[0]).toEqual({
                 awayPlayers: [awayPlayer],
                 homePlayers: [homePlayer],

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/MultiPlayerSelection.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/MultiPlayerSelection.test.tsx
@@ -68,7 +68,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const inputs = Array.from(context.container.querySelectorAll('input'));
             const buttons = Array.from(context.container.querySelectorAll('button'));
             expect(inputs.length).toEqual(0);
@@ -84,7 +84,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const inputs = Array.from(context.container.querySelectorAll('input'));
             const buttons = Array.from(context.container.querySelectorAll('button'));
             expect(inputs.length).toEqual(0);
@@ -101,7 +101,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const inputs = Array.from(context.container.querySelectorAll('input'));
             const buttons = Array.from(context.container.querySelectorAll('button'));
             expect(inputs.length).toEqual(0);
@@ -116,7 +116,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const selectedPlayers = getSelectedPlayers();
             expect(selectedPlayers.length).toEqual(1 + 1);
             const selectedPlayer = selectedPlayers[0];
@@ -139,7 +139,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const selectedPlayers = getSelectedPlayers();
             expect(selectedPlayers.length).toEqual(1 + 1);
             const selectedPlayer = selectedPlayers[0];
@@ -162,7 +162,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dropdownToggle = context.container.querySelector('button.dropdown-toggle');
             expect(dropdownToggle).toBeTruthy();
             expect(dropdownToggle.textContent).toEqual('PLACEHOLDER');
@@ -179,7 +179,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const selectedPlayer = getSelectedPlayers()[0];
             expect(selectedPlayer).toBeTruthy();
             const selectedPlayerButton = selectedPlayer.querySelector('button');
@@ -200,7 +200,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const selectedPlayer = getSelectedPlayers()[0];
             expect(selectedPlayer).toBeTruthy();
             const selectedPlayerButton = selectedPlayer.querySelector('button');
@@ -220,7 +220,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             }, [teamBuilder('TEAM_NAME').forSeason(season, division, [player]).build()]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const selectedPlayer = getSelectedPlayers()[0];
             expect(selectedPlayer).toBeTruthy();
             const linkToPlayer = selectedPlayer.querySelector('a');
@@ -241,7 +241,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const selectedPlayer = getSelectedPlayers()[0];
             expect(selectedPlayer).toBeTruthy();
             const linkToPlayer = selectedPlayer.querySelector('a');
@@ -261,7 +261,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             }, [ teamBuilder().forSeason(season).build() ]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const selectedPlayer = getSelectedPlayers()[0];
             expect(selectedPlayer).toBeTruthy();
             const linkToPlayer = selectedPlayer.querySelector('a');
@@ -282,7 +282,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             }, []);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const selectedPlayer = getSelectedPlayers()[0];
             expect(selectedPlayer).toBeTruthy();
             const linkToPlayer = selectedPlayer.querySelector('a');
@@ -300,7 +300,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dropdown = context.container.querySelector('ol > li:last-child div.btn-group');
             expect(dropdown).toBeTruthy();
             expect(dropdown.className).toContain('DROPDOWN-CLASS-NAME');
@@ -316,7 +316,7 @@ describe('MultiPlayerSelection', () => {
                 onRemovePlayer: onRemovePlayer,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const notesInput = context.container.querySelector('ol > li:last-child > input');
             expect(notesInput).toBeTruthy();
             expect(notesInput.className).toContain('NOTES-CLASS-NAME');
@@ -338,7 +338,7 @@ describe('MultiPlayerSelection', () => {
                 onAddPlayer: onAddPlayer,
                 onRemovePlayer: onRemovePlayer,
             });
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const selectedPlayer = getSelectedPlayers()[0];
             expect(selectedPlayer).toBeTruthy();
 
@@ -354,7 +354,7 @@ describe('MultiPlayerSelection', () => {
                 onAddPlayer: onAddPlayer,
                 onRemovePlayer: onRemovePlayer,
             });
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'PLAYER'));
             await doClick(findButton(context.container, '➕'));
@@ -371,7 +371,7 @@ describe('MultiPlayerSelection', () => {
                 onAddPlayer: onAddPlayer,
                 onRemovePlayer: onRemovePlayer,
             });
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             // no player selected
             await doClick(findButton(context.container, '➕'));
@@ -388,7 +388,7 @@ describe('MultiPlayerSelection', () => {
                 onAddPlayer: onAddPlayer,
                 onRemovePlayer: onRemovePlayer,
             });
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'PLAYER'));
             await doChange(context.container, 'ol > li:last-child > input[type="number"]', '100', context.user);
@@ -407,7 +407,7 @@ describe('MultiPlayerSelection', () => {
                 onAddPlayer: onAddPlayer,
                 onRemovePlayer: onRemovePlayer,
             });
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'PLAYER'));
             // notes not updated
@@ -425,7 +425,7 @@ describe('MultiPlayerSelection', () => {
                 onAddPlayer: onAddPlayer,
                 onRemovePlayer: onRemovePlayer,
             });
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'PLAYER'));
             await doChange(context.container, 'ol > li:last-child > input[type="number"]', '.', context.user);
@@ -443,7 +443,7 @@ describe('MultiPlayerSelection', () => {
                 onAddPlayer: onAddPlayer,
                 onRemovePlayer: onRemovePlayer,
             });
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const selectedPlayer = getSelectedPlayers()[0];
 
             await doClick(findButton(selectedPlayer, 'PLAYER 🗑'));

--- a/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/scores/Score.test.tsx
@@ -263,7 +263,7 @@ describe('Score', () => {
 
             await renderComponent(fixture.id, appData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const container = context.container.querySelector('.content-background');
             expect(container).toBeTruthy();
             const tableBody = container.querySelector('table tbody');
@@ -279,7 +279,7 @@ describe('Score', () => {
 
             await renderComponent(fixture.id, appData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const container = context.container.querySelector('.content-background');
             expect(container).toBeTruthy();
             const tableBody = container.querySelector('table tbody');
@@ -347,7 +347,7 @@ describe('Score', () => {
 
             await renderComponent(fixture.id, appData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const container = context.container.querySelector('.content-background');
             expect(container).toBeTruthy();
             const tableBody = container.querySelector('table tbody');
@@ -376,7 +376,7 @@ describe('Score', () => {
 
             await renderComponent(fixture.id, appData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const container = context.container.querySelector('.content-background');
             expect(container).toBeTruthy();
             const tableBody = container.querySelector('table tbody');
@@ -517,7 +517,7 @@ describe('Score', () => {
                 };
             };
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstSinglesRow = context.container.querySelector('.content-background table tbody tr:nth-child(2)');
             expect(firstSinglesRow).toBeTruthy();
             const playerSelection = firstSinglesRow.querySelector('td:nth-child(1)');
@@ -528,7 +528,7 @@ describe('Score', () => {
             await doChange(addPlayerDialog, 'input[name="name"]', 'NEW PLAYER', context.user);
             await doClick(findButton(addPlayerDialog, 'Add player'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(teamsReloaded).toEqual(true);
             expect(createdPlayer).not.toBeNull();
             expect(context.container.querySelector('.modal-dialog')).toBeFalsy();
@@ -548,7 +548,7 @@ describe('Score', () => {
                 };
             };
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstSinglesRow = context.container.querySelector('.content-background table tbody tr:nth-child(2)');
             expect(firstSinglesRow).toBeTruthy();
             const playerSelection = firstSinglesRow.querySelector('td:nth-child(1)');
@@ -581,7 +581,7 @@ describe('Score', () => {
                 };
             };
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstSinglesRow = context.container.querySelector('.content-background table tbody tr:nth-child(2)');
             expect(firstSinglesRow).toBeTruthy();
             const playerSelection = firstSinglesRow.querySelector('td:nth-child(1)');
@@ -603,7 +603,7 @@ describe('Score', () => {
             const fixture = getPlayedFixtureData(appData);
             await renderComponent(fixture.id, appData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstSinglesRow = context.container.querySelector('.content-background table tbody tr:nth-child(2)');
             expect(firstSinglesRow).toBeTruthy();
             const playerSelection = firstSinglesRow.querySelector('td:nth-child(5)');
@@ -618,7 +618,7 @@ describe('Score', () => {
             const appData = getDefaultAppData(account);
             const fixture = getPlayedFixtureData(appData);
             await renderComponent(fixture.id, appData);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstSinglesRow = context.container.querySelector('.content-background table tbody tr:nth-child(2)');
             expect(firstSinglesRow).toBeTruthy();
             const playerSelection = firstSinglesRow.querySelector('td:nth-child(5)');
@@ -637,7 +637,7 @@ describe('Score', () => {
 
             await doClick(findButton(context.container, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedFixtures[fixture.id]).not.toBeNull();
         });
 
@@ -668,7 +668,7 @@ describe('Score', () => {
             await doClick(findButton(playerSelection, 'Another player'));
             await doClick(findButton(context.container, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedFixtures[fixture.id]).not.toBeNull();
             expect(updatedFixtures[fixture.id].matches[0].homePlayers).toEqual([anotherHomePlayer]);
         });
@@ -688,7 +688,7 @@ describe('Score', () => {
             await doClick(findButton(dialog, 'Close'));
             await doClick(findButton(context.container, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedFixtures[fixture.id]).not.toBeNull();
             expect(updatedFixtures[fixture.id].matchOptions[0].numberOfLegs).toEqual(30);
         });
@@ -700,13 +700,13 @@ describe('Score', () => {
             fixtureData.homeSubmission = getPlayedFixtureData(appData);
             fixtureData.awaySubmission = getPlayedFixtureData(appData);
             await renderComponent(fixtureData.id, appData);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             let alert: string;
             window.alert = (msg) => alert = msg;
 
             await doClick(findButton(context.container, 'Unpublish'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(alert).toEqual('Results have been unpublished, but NOT saved. Re-merge the changes then click save for them to be saved');
             const matches = Array.from(context.container.querySelectorAll('table tbody tr'));
             const allScores = matches.flatMap(match => {
@@ -735,15 +735,15 @@ describe('Score', () => {
                 match.awayScore = 1;
             });
             await renderComponent(fixtureData.id, appData);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             let alert: string;
             window.alert = (msg) => alert = msg;
             await doClick(context.container, 'span[title="See home submission"]');
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'Unpublish'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(alert).toEqual('Results have been unpublished, but NOT saved. Re-merge the changes then click save for them to be saved');
             const matches = Array.from(context.container.querySelectorAll('table tbody tr'));
             const allScores = matches.flatMap(match => {
@@ -764,15 +764,15 @@ describe('Score', () => {
                 match.awayScore = 2;
             });
             await renderComponent(fixtureData.id, appData);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             let alert: string;
             window.alert = (msg) => alert = msg;
             await doClick(context.container, 'span[title="See away submission"]');
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'Unpublish'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(alert).toEqual('Results have been unpublished, but NOT saved. Re-merge the changes then click save for them to be saved');
             const matches = Array.from(context.container.querySelectorAll('table tbody tr'));
             const allScores = matches.flatMap(match => {
@@ -798,7 +798,7 @@ describe('Score', () => {
 
             await renderComponent(fixtureData.id, appData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
         });
 
         it('can show when only away submission present', async () => {
@@ -817,7 +817,7 @@ describe('Score', () => {
 
             await renderComponent(fixtureData.id, appData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
         });
     });
 
@@ -838,7 +838,7 @@ describe('Score', () => {
         it('renders score card without results', async () => {
             await renderComponent(fixture.id, appData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const container = context.container.querySelector('.content-background');
             expect(container).toBeTruthy();
             const tableBody = container.querySelector('table tbody');
@@ -866,7 +866,7 @@ describe('Score', () => {
 
             await renderComponent(fixture.id, appData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const container = context.container.querySelector('.content-background');
             expect(container).toBeTruthy();
             const tableBody = container.querySelector('table tbody');
@@ -905,7 +905,7 @@ describe('Score', () => {
         it('renders score card without results', async () => {
             await renderComponent(fixture.id, appData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const container = context.container.querySelector('.content-background');
             expect(container).toBeTruthy();
             const tableBody = container.querySelector('table tbody');
@@ -933,7 +933,7 @@ describe('Score', () => {
 
             await renderComponent(fixture.id, appData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const container = context.container.querySelector('.content-background');
             expect(container).toBeTruthy();
             const tableBody = container.querySelector('table tbody');

--- a/CourageScores/ClientApp/src/components/division_fixtures/season_creation/CreateSeasonDialog.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/season_creation/CreateSeasonDialog.test.tsx
@@ -223,7 +223,7 @@ describe('CreateSeasonDialog', () => {
                     onClose,
                 });
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), 'TEMPLATE');
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 setApiResponse(true, {
                     divisions: [{
                         id: divisionId,
@@ -249,7 +249,7 @@ describe('CreateSeasonDialog', () => {
                 await doClick(findButton(context.container, 'Next')); // (1) pick -> (2) assign placeholders
                 await doClick(findButton(context.container, 'Next')); // (2) assign placeholders -> (3) review
                 await doClick(findButton(context.container, 'Next')); // (3) review -> (4) review-proposals
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
 
                 await doClick(findButton(context.container.querySelector('div'), 'Save all fixtures')); // (4) review-proposals -> (5) confirm-save
 
@@ -285,11 +285,11 @@ describe('CreateSeasonDialog', () => {
                 let alert: string;
                 window.alert = (msg) => alert = msg;
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '🚫 TEMPLATE');
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
 
                 await doClick(findButton(context.container, 'Next'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(alert).toEqual('This template is not compatible with this season, pick another template');
                 expect(proposalRequest).toBeNull();
             });
@@ -324,12 +324,12 @@ describe('CreateSeasonDialog', () => {
                     onClose,
                 });
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), 'TEMPLATE');
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 setApiResponse(true);
 
                 await doClick(findButton(context.container, 'Next'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const placeholderLists = Array.from(context.container.querySelectorAll('h6 + ul'));
                 expect(placeholderLists.length).toEqual(1);
             });
@@ -450,7 +450,7 @@ describe('CreateSeasonDialog', () => {
                     onClose,
                 });
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), 'TEMPLATE');
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
 
                 setApiResponse(true, {
                     divisions: [{
@@ -469,13 +469,13 @@ describe('CreateSeasonDialog', () => {
             it('can navigate back to (2) assign placeholders', async () => {
                 await doClick(findButton(context.container, 'Back'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
             });
 
             it('can navigate to (4) review-proposals', async () => {
                 await doClick(findButton(context.container, 'Next'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(divisionDataSetTo).toEqual({
                     id: divisionId,
                     name: 'PROPOSED DIVISION',
@@ -520,7 +520,7 @@ describe('CreateSeasonDialog', () => {
                 });
 
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), 'TEMPLATE');
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 setApiResponse(true, {
                     divisions: [{
                         id: divisionId,
@@ -549,7 +549,7 @@ describe('CreateSeasonDialog', () => {
                 await doClick(findButton(context.container, 'Next'));
                 await doClick(findButton(context.container, 'Next'));
                 await doClick(findButton(context.container, 'Next'));
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
             });
 
             it('can navigate back to (3) review', async () => {
@@ -609,7 +609,7 @@ describe('CreateSeasonDialog', () => {
                 });
 
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), 'TEMPLATE');
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 setApiResponse(true, {
                     divisions: [{
                         id: divisionId,
@@ -638,7 +638,7 @@ describe('CreateSeasonDialog', () => {
                 await doClick(findButton(context.container, 'Next'));
                 await doClick(findButton(context.container, 'Next'));
                 await doClick(findButton(context.container, 'Next'));
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 await doClick(findButton(context.container.querySelector('div'), 'Save all fixtures'));
             });
 
@@ -652,7 +652,7 @@ describe('CreateSeasonDialog', () => {
             it('reloads division after all fixtures saved and closes dialog', async () => {
                 await doClick(findButton(context.container, 'Next'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedFixtures.length).toEqual(3);
                 expect(divisionReloaded).toEqual(true);
                 expect(divisionDataSetTo).toBeNull();
@@ -672,7 +672,7 @@ describe('CreateSeasonDialog', () => {
 
                 await doClick(findButton(context.container, 'Next'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedFixtures.length).toEqual(3);
                 expect(divisionReloaded).toEqual(true);
                 expect(divisionDataSetTo).toBeNull();
@@ -688,7 +688,7 @@ describe('CreateSeasonDialog', () => {
 
                 await doClick(findButton(context.container, 'Next'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedFixtures.length).toEqual(3);
                 expect(divisionReloaded).toEqual(true);
                 expect(divisionDataSetTo).toBeNull();
@@ -708,7 +708,7 @@ describe('CreateSeasonDialog', () => {
 
                 await doClick(findButton(context.container, 'Next'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedFixtures.length).toEqual(1);
                 expect(divisionReloaded).toBeFalsy();
                 expect(divisionDataSetTo).toBeFalsy();
@@ -729,13 +729,13 @@ describe('CreateSeasonDialog', () => {
                     return {success: true};
                 };
                 await doClick(findButton(context.container, 'Next'));
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
 
                 // resume
                 abort = false;
                 await doClick(findButton(context.container, 'Next'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedFixtures.length).toEqual(3);
                 expect(divisionReloaded).toEqual(true);
                 expect(divisionDataSetTo).toBeNull();
@@ -766,11 +766,11 @@ describe('CreateSeasonDialog', () => {
                     seasonId: seasonId,
                     onClose,
                 });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
 
                 await doClick(findButton(context.container, 'Close'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(divisionDataResetTo).toEqual(null);
                 expect(closed).toEqual(true);
             });

--- a/CourageScores/ClientApp/src/components/division_fixtures/season_creation/PickTemplate.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/season_creation/PickTemplate.test.tsx
@@ -83,7 +83,7 @@ describe('PickTemplate', () => {
                 setSelectedTemplate,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.innerHTML).toContain('spinner-border spinner-border-sm');
         });
 
@@ -97,7 +97,7 @@ describe('PickTemplate', () => {
                 setSelectedTemplate,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dropdown = context.container.querySelector('.dropdown-menu');
             expect(dropdown).toBeTruthy();
             expect(dropdown.querySelector('.active')).toBeFalsy();
@@ -113,7 +113,7 @@ describe('PickTemplate', () => {
                 setSelectedTemplate,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dropdown = context.container.querySelector('.dropdown-menu');
             expect(dropdown).toBeTruthy();
             expect(dropdown.querySelector('.active').textContent).toEqual('COMPATIBLECOMPATIBLE DESCRIPTION');
@@ -129,7 +129,7 @@ describe('PickTemplate', () => {
                 setSelectedTemplate,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const alert = context.container.querySelector('.alert');
             expect(alert).toBeTruthy();
             expect(alert.className).toContain('alert-success');
@@ -150,7 +150,7 @@ describe('PickTemplate', () => {
                 setSelectedTemplate,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const alert = context.container.querySelector('.alert');
             expect(alert).toBeTruthy();
             expect(alert.className).toContain('alert-warning');
@@ -189,7 +189,7 @@ describe('PickTemplate', () => {
                 setSelectedTemplate,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const alert = context.container.querySelector('.alert');
             expect(alert).toBeTruthy();
             expect(alert.className).toContain('alert-success');
@@ -243,11 +243,11 @@ describe('PickTemplate', () => {
                 setSelectedTemplate,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dropdown = context.container.querySelector('.dropdown-menu');
             await doSelectOption(dropdown, '🚫 INCOMPATIBLE');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(selectedTemplate).toEqual(incompatibleTemplate);
         });
     });

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/EditSide.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/EditSide.test.tsx
@@ -145,7 +145,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {}
             }, { side, onChange, onClose, onApply, onDelete }, null);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const nameInput = context.container.querySelector('input[name="name"]') as HTMLInputElement;
             expect(nameInput.value).toEqual('');
             expect(context.container.querySelector('.dropdown-menu')).not.toBeNull();
@@ -163,7 +163,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {}
             }, { side, onChange, onClose, onApply, onDelete }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const nameInput = context.container.querySelector('input[name="name"]') as HTMLInputElement;
             expect(nameInput.value).toEqual('SIDE NAME');
             expect(context.container.querySelector('.dropdown-menu')).toBeNull();
@@ -220,7 +220,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {}
             }, { side, onChange, onClose, onApply, onDelete }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const nameInput = context.container.querySelector('input[name="name"]') as HTMLInputElement;
             expect(nameInput.value).toEqual('SIDE NAME');
             expect(context.container.querySelector('.dropdown-menu .active')).not.toBeNull();
@@ -240,7 +240,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {}
             }, { side, onChange, onClose, onApply, onDelete }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const noShowInput = context.container.querySelector('input[name="noShow"]') as HTMLInputElement;
             expect(noShowInput.checked).toEqual(true);
         });
@@ -256,7 +256,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {}
             }, { side, onChange, onClose, onApply, onDelete }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const noShowInput = context.container.querySelector('input[name="noShow"]') as HTMLInputElement;
             expect(noShowInput.checked).toEqual(false);
         });
@@ -278,7 +278,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {}
             }, { side, onChange, onClose, onApply, onDelete }, [teamNotInSeason]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).not.toContain('NOT IN SEASON PLAYER');
         });
@@ -298,7 +298,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player),
             }, { side, onChange, onClose, onApply, onDelete }, [otherDivisionTeam, team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).not.toContain('OTHER DIVISION PLAYER');
         });
@@ -319,7 +319,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player),
             }, { side, onChange, onClose, onApply, onDelete }, [otherDivisionTeam, team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).toContain('OTHER DIVISION PLAYER');
         });
@@ -333,7 +333,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player),
             }, { side, onChange, onClose, onApply, onDelete }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).toContain('PLAYER (⚠ Playing in another tournament)');
         });
@@ -347,7 +347,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {},
             }, { side, onChange, onClose, onApply, onDelete }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).toContain('ANOTHER PLAYER (🚫 Selected in another side)');
         });
@@ -359,7 +359,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {},
             }, { side: tournamentData.sides[0], onChange, onClose, onApply, onDelete }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).toContain('ANOTHER PLAYER');
         });
@@ -375,7 +375,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {},
             }, { side, onChange, onClose, onApply, onDelete }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('.btn-danger')).toBeTruthy();
             expect(context.container.querySelector('.btn-danger').textContent).toEqual('Delete side');
         });
@@ -389,7 +389,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {},
             }, { side, onChange, onClose, onApply, onDelete }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('.btn-danger')).toBeFalsy();
         });
 
@@ -410,7 +410,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {},
             }, { side, onChange, onClose, onApply, onDelete }, [team], account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const buttons = Array.from(context.container.querySelectorAll('.btn'));
             const buttonText = buttons.map(btn => btn.textContent);
             expect(buttonText).toContain('Add player/s');
@@ -431,7 +431,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {},
             }, { side, onChange, onClose, onApply, onDelete }, [team], account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const buttons = Array.from(context.container.querySelectorAll('.btn'));
             const buttonText = buttons.map(btn => btn.textContent);
             expect(buttonText).toContain('Add player/s');
@@ -454,7 +454,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {},
             }, { side, onChange, onClose, onApply, onDelete }, [team], account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const buttons = Array.from(context.container.querySelectorAll('.btn'));
             const buttonText = buttons.map(btn => btn.textContent);
             expect(buttonText).not.toContain('Add player');
@@ -477,7 +477,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {},
             }, { side, onChange, onClose, onApply, onDelete }, [team], account);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const buttons = Array.from(context.container.querySelectorAll('.btn'));
             const buttonText = buttons.map(btn => btn.textContent);
             expect(buttonText).not.toContain('Add player');
@@ -507,7 +507,7 @@ describe('EditSide', () => {
 
             await doChange(context.container, 'input[name="name"]', 'NEW NAME', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: expect.any(String),
                 name: 'NEW NAME',
@@ -526,7 +526,7 @@ describe('EditSide', () => {
 
             await doClick(context.container, 'input[name="noShow"]');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: expect.any(String),
                 name: 'SIDE NAME',
@@ -545,7 +545,7 @@ describe('EditSide', () => {
 
             await doSelectOption(context.container.querySelector('.dropdown-menu'), 'TEAM');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: side.id,
                 players: [],
@@ -566,7 +566,7 @@ describe('EditSide', () => {
 
             await doSelectOption(context.container.querySelector('.dropdown-menu'), 'Select team');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: expect.any(String),
                 name: 'TEAM',
@@ -587,7 +587,7 @@ describe('EditSide', () => {
 
             await doClick(players.filter(p => p.textContent === 'PLAYER')[0]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: expect.any(String),
                 name: 'PLAYER',
@@ -610,7 +610,7 @@ describe('EditSide', () => {
 
             await doClick(players.filter(p => p.textContent === 'PLAYER')[0]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: expect.any(String),
                 name: 'PLAYER',
@@ -633,7 +633,7 @@ describe('EditSide', () => {
 
             await doClick(players.filter(p => p.textContent === 'PLAYER')[0]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: expect.any(String),
                 name: 'OTHER NAME',
@@ -660,7 +660,7 @@ describe('EditSide', () => {
 
             await doClick(players.filter(p => p.textContent === 'ANOTHER PLAYER')[0]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: expect.any(String),
                 name: 'ANOTHER PLAYER, PLAYER',
@@ -691,7 +691,7 @@ describe('EditSide', () => {
 
             await doClick(players.filter(p => p.textContent === 'ANOTHER PLAYER')[0]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: expect.any(String),
                 name: 'SIDE NAME',
@@ -723,7 +723,7 @@ describe('EditSide', () => {
 
             await doClick(players.filter(p => p.textContent === 'ANOTHER PLAYER')[0]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: expect.any(String),
                 name: 'PLAYER',
@@ -746,7 +746,7 @@ describe('EditSide', () => {
 
             await doClick(findButton(context.container, 'Delete side'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(confirm).toEqual('Are you sure you want to remove SIDE NAME?');
             expect(deleted).toEqual(true);
         });
@@ -766,7 +766,7 @@ describe('EditSide', () => {
 
             await doClick(findButton(context.container, 'Delete side'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(confirm).toEqual('Are you sure you want to remove SIDE NAME?');
             expect(deleted).toEqual(false);
         });
@@ -787,7 +787,7 @@ describe('EditSide', () => {
 
             await doClick(findButton(context.container, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(alert).toEqual('Please enter a name for this side');
             expect(applied).toEqual(false);
         });
@@ -806,7 +806,7 @@ describe('EditSide', () => {
 
             await doClick(findButton(context.container, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(alert).toEqual('Select a team or some players');
             expect(applied).toEqual(false);
         });
@@ -823,7 +823,7 @@ describe('EditSide', () => {
 
             await doClick(findButton(context.container, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(applied).toEqual(true);
         });
 
@@ -839,7 +839,7 @@ describe('EditSide', () => {
 
             await doClick(findButton(context.container, 'Close'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(closed).toEqual(true);
             expect(applied).toEqual(false);
         });
@@ -852,7 +852,7 @@ describe('EditSide', () => {
                 season,
                 alreadyPlaying: alreadyPlaying(player),
             }, { side, onChange, onClose, onApply, onDelete }, [team]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             const playerItem = playerItems.filter(li => li.textContent === 'PLAYER (⚠ Playing in another tournament)')[0];
             expect(playerItem).toBeTruthy();
@@ -860,7 +860,7 @@ describe('EditSide', () => {
 
             await doClick(playerItem);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: expect.any(String),
                 name: 'SIDE NAME',
@@ -878,7 +878,7 @@ describe('EditSide', () => {
                 season,
                 alreadyPlaying: {},
             }, { side, onChange, onClose, onApply, onDelete }, [team]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             const playerItem = playerItems.filter(li => li.textContent === 'ANOTHER PLAYER (🚫 Selected in another side)')[0];
             expect(playerItem).toBeTruthy();
@@ -886,7 +886,7 @@ describe('EditSide', () => {
 
             await doClick(playerItem);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toBeNull();
         });
 
@@ -987,7 +987,7 @@ describe('EditSide', () => {
             await doClick(findButton(dialog.querySelector('.dropdown-menu'), team.name));
             await doClick(findButton(dialog, 'Add player'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: side.id,
                 name: 'SIDE NAME',

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/EditTournament.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/EditTournament.test.tsx
@@ -309,7 +309,7 @@ describe('EditTournament', () => {
             await doSelectOption(dialog.querySelector('.dropdown-menu'), 'TEAM 1');
             await doClick(findButton(dialog, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData.sides).toEqual([existingSide, {
                 id: expect.any(String),
                 name: 'TEAM 1',
@@ -346,7 +346,7 @@ describe('EditTournament', () => {
             await doChange(dialog, 'input[name="name"]', 'NAME   ', context.user);
             await doClick(findButton(dialog, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData.sides).toEqual([{
                 id: expect.any(String),
                 name: 'NAME',
@@ -380,7 +380,7 @@ describe('EditTournament', () => {
             expect(dialog).toBeTruthy();
             await doClick(findButton(dialog, 'Close'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(sides.querySelector('.modal-dialog')).toBeFalsy();
         });
 
@@ -415,7 +415,7 @@ describe('EditTournament', () => {
             expect(dialog).toBeTruthy();
             await doClick(findButton(dialog, 'Close'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(sides.querySelector('.modal-dialog')).toBeFalsy();
         });
 
@@ -450,7 +450,7 @@ describe('EditTournament', () => {
             expect(dialog).toBeTruthy();
             await doClick(findButton(dialog, 'Delete side'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData.sides).toEqual([]);
         });
 
@@ -486,7 +486,7 @@ describe('EditTournament', () => {
             await doChange(sideElement, 'input[name="name"]', 'NEW SIDE 1', context.user);
             await doClick(findButton(dialog, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData.round.matches[0]).toEqual({
                 id: expect.any(String),
                 sideA: {id: side.id, name: 'NEW SIDE 1', teamId: team1.id, players: []},
@@ -528,7 +528,7 @@ describe('EditTournament', () => {
             await doChange(sideElement, 'input[name="name"]', 'NEW SIDE 1', context.user);
             await doClick(findButton(dialog, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData.round.matches[0]).toEqual({
                 id: expect.any(String),
                 sideA: null,
@@ -570,7 +570,7 @@ describe('EditTournament', () => {
             await doChange(sideElement, 'input[name="name"]', 'NEW SIDE 1   ', context.user);
             await doClick(findButton(dialog, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData.sides[0]).toEqual({
                 id: side.id,
                 name: 'NEW SIDE 1',

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/EditTournament.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/EditTournament.tsx
@@ -31,7 +31,7 @@ export function EditTournament({canSave, disabled, saving, applyPatch}: IEditTou
     const readOnly: boolean = !isAdmin || !canSave || disabled || saving;
     const hasStarted: boolean = tournamentData.round && tournamentData.round.matches && any(tournamentData.round.matches);
     const winningSideId: string = hasStarted ? getWinningSide(tournamentData.round) : null;
-    const [newSide, setNewSide] = useState(null);
+    const [newSide, setNewSide] = useState<TournamentSideDto>(null);
 
     function getWinningSide(round: TournamentRoundDto): string {
         if (round && round.nextRound) {
@@ -119,7 +119,7 @@ export function EditTournament({canSave, disabled, saving, applyPatch}: IEditTou
                     onRemove={() => removeSide(side)}/>);
             })}
             {!readOnly && !hasStarted
-                ? (<button className="btn btn-primary" onClick={() => setNewSide({})}>➕</button>)
+                ? (<button className="btn btn-primary" onClick={() => setNewSide({ id: createTemporaryId() })}>➕</button>)
                 : null}
             {newSide && !readOnly && !hasStarted ? renderEditNewSide() : null}
         </div>

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.test.tsx
@@ -331,7 +331,7 @@ describe('PrintableSheet', () => {
                 matches: [
                     {
                         sideAmnemonic: 'winner(M3)',
-                        sideBmnemonic: 'winner(M4)',
+                        sideBmnemonic: 'winner(M1)',
                         bye: false,
                         saygLink: null,
                     },
@@ -445,7 +445,7 @@ describe('PrintableSheet', () => {
                         saygLink: null,
                     },
                     {
-                        sideAname: 'e',
+                        sideAmnemonic: 'A',
                         bye: true,
                         saygLink: null,
                     },
@@ -466,7 +466,7 @@ describe('PrintableSheet', () => {
                         saygLink: null,
                     },
                     {
-                        sideAname: 'c',
+                        sideAmnemonic: 'A',
                         bye: true,
                         saygLink: null,
                     },
@@ -612,13 +612,9 @@ describe('PrintableSheet', () => {
                         saygLink: null,
                     },
                     {
-                        sideAname: 'j',
-                        bye: true,
-                        saygLink: null,
-                    },
-                    {
-                        sideAname: 'l',
-                        bye: true,
+                        sideAmnemonic: 'A',
+                        sideBmnemonic: 'B',
+                        bye: false,
                         saygLink: null,
                     },
                 ],

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.test.tsx
@@ -220,7 +220,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rounds = getRounds();
             expect(rounds.length).toEqual(1);
             expect(rounds[0]).toEqual({
@@ -252,7 +252,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rounds = getRounds();
             expect(rounds.length).toEqual(1);
             expect(rounds[0]).toEqual({
@@ -287,7 +287,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rounds = getRounds();
             expect(rounds.length).toEqual(3);
             expect(rounds[0]).toEqual({
@@ -369,7 +369,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rounds = getRounds();
             expect(rounds.length).toEqual(2);
             expect(rounds[0]).toEqual({
@@ -433,7 +433,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rounds = getRounds();
             expect(rounds.length).toEqual(3);
             expect(rounds[0]).toEqual({
@@ -539,7 +539,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rounds = getRounds();
             expect(rounds.length).toEqual(4);
             expect(rounds[0]).toEqual({
@@ -699,7 +699,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const winner = getWinner();
             expect(winner).toEqual({
                 link: null,
@@ -742,7 +742,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({teams, divisions}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const winner = getWinner();
             expect(winner).toEqual({
                 link: null,
@@ -772,7 +772,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const winner = getWinner();
             expect(winner.name).toEqual('B');
             expect(winner.link).toEqual(`http://localhost/division/${division.name}/player:${encodeURI(player2.name)}@TEAM/${season.name}`);
@@ -797,7 +797,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const winner = getWinner();
             expect(winner.name).toEqual('B');
             expect(winner.link).toEqual(`http://localhost/division/${division.name}/player:${encodeURI(player2.name)}@TEAM/${season.name}`);
@@ -818,7 +818,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
             expect(getWhoIsPlaying(linkHref)).toEqual([`http://localhost/division/${division.name}/player:${encodeURI('PLAYER 1')}@TEAM/${season.name}`, null]);
         });
@@ -841,7 +841,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
             expect(getWhoIsPlaying(linkHref)).toEqual([
                 `http://localhost/division/${division.name}/team:TEAM/${season.name}`,
@@ -862,7 +862,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b']);
             expect(getWhoIsPlaying(linkHref)).toEqual([null, null]);
         });
@@ -885,7 +885,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b']);
             expect(getWhoIsPlaying(linkHref)).toEqual([null, null]);
         });
@@ -901,7 +901,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b', '-3 - c-']);
             expect(getWhoIsPlaying(linkHref)).toEqual([null, null, null]);
         });
@@ -916,7 +916,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division}, {printOnly: false}, appProps({}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('div[datatype="heading"]');
             expect(heading.textContent).toEqual(`TYPE at ADDRESS on ${renderDate('2023-06-01')} - NOTES🔗🖨️`);
         });
@@ -941,7 +941,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(getAccolades('180s', d => d.textContent)).toEqual(['PLAYER 1 x 3', 'PLAYER 2 x 1']);
             expect(getAccolades('180s', linkHref))
                 .toEqual([`http://localhost/division/${division.name}/player:${encodeURI(player1.name)}@TEAM/${season.name}`, null]);
@@ -967,7 +967,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(getAccolades('180s', d => d.textContent)).toEqual(['PLAYER 1 x 3', 'PLAYER 2 x 1']);
             expect(getAccolades('180s', linkHref)).toEqual([`http://localhost/division/${division.name}/player:${encodeURI(player1.name)}@TEAM/${season.name}`, null]);
         });
@@ -990,7 +990,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(getAccolades('hi-checks', d => d.textContent)).toEqual(['PLAYER 1 (100)', 'PLAYER 2 (120)']);
             expect(getAccolades('hi-checks', linkHref))
                 .toEqual([`http://localhost/division/${division.name}/player:${encodeURI(player1.name)}@TEAM/${season.name}`, null]);
@@ -1014,7 +1014,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(getAccolades('hi-checks', d => d.textContent)).toEqual(['PLAYER 1 (100)', 'PLAYER 2 (120)']);
             expect(getAccolades('hi-checks', linkHref)).toEqual([`http://localhost/division/${division.name}/player:${encodeURI(player1.name)}@TEAM/${season.name}`, null]);
         });
@@ -1032,7 +1032,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
                 .build();
             await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: false}, appProps({}, reportedError));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstSideA = context.container.querySelector('div[datatype="sideA"]');
 
             await doClick(firstSideA);
@@ -1054,7 +1054,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE)
                 .build();
             await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstSideA = context.container.querySelector('div[datatype="sideA"]');
             await doClick(firstSideA);
             const dialog = context.container.querySelector('div.modal-dialog');
@@ -1084,7 +1084,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
                 .build();
             await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstSideA = context.container.querySelector('div[datatype="sideA"]');
             await doClick(firstSideA);
             const dialog = context.container.querySelector('div.modal-dialog');
@@ -1110,7 +1110,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE)
                 .build();
             await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstSideA = context.container.querySelector('div[datatype="sideB"]');
             await doClick(firstSideA);
             const dialog = context.container.querySelector('div.modal-dialog');
@@ -1140,7 +1140,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
                 .build();
             await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstSideA = context.container.querySelector('div[datatype="sideB"]');
             await doClick(firstSideA);
             const dialog = context.container.querySelector('div.modal-dialog');
@@ -1168,7 +1168,7 @@ describe('PrintableSheet', () => {
             const player1 = playerBuilder('PLAYER 1').build();
             const allPlayers: ISelectablePlayer[] = [player1];
             await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers}, {printOnly: false, editable: true}, appProps({}, reportedError));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(context.container.querySelector('div[data-accolades="180s"]'));
             const dialog = context.container.querySelector('div.modal-dialog');
@@ -1197,7 +1197,7 @@ describe('PrintableSheet', () => {
             const player1 = playerBuilder('PLAYER 1').build();
             const allPlayers: ISelectablePlayer[] = [player1];
             await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers}, {printOnly: false, editable: true}, appProps({}, reportedError));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(context.container.querySelector('div[data-accolades="hi-checks"]'));
             const dialog = context.container.querySelector('div.modal-dialog');
@@ -1234,7 +1234,7 @@ describe('PrintableSheet', () => {
                 access: {}
             }
             await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers}, {printOnly: false, editable: true}, appProps({account}, reportedError));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playing = context.container.querySelector('div[datatype="playing"]');
             const firstSide = playing.querySelector('li');
             await doClick(firstSide);
@@ -1267,10 +1267,10 @@ describe('PrintableSheet', () => {
                     .forSeason(season, division, [player1])
                     .build()]);
             await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers, alreadyPlaying: {}}, {printOnly: false, editable: true}, appProps({account, teams}, reportedError));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const addSide = context.container.querySelector('li[datatype="add-side"]');
             await doClick(addSide);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('div.modal-dialog');
             expect(dialog).toBeTruthy();
             await doChange(dialog, 'input[name="name"]', 'NEW SIDE', context.user);
@@ -1296,7 +1296,7 @@ describe('PrintableSheet', () => {
             }
             window.confirm = () => true;
             await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}}, {printOnly: false, editable: true}, appProps({account}, reportedError));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playing = context.container.querySelector('div[datatype="playing"]');
             const firstSide = playing.querySelector('li.list-group-item');
             await doClick(firstSide);
@@ -1327,7 +1327,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rounds = getRounds();
             expect(rounds.length).toEqual(1);
             expect(rounds[0]).toEqual({
@@ -1353,7 +1353,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
         });
 
@@ -1365,7 +1365,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
         });
 
@@ -1379,7 +1379,7 @@ describe('PrintableSheet', () => {
 
             await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('div[datatype="heading"]');
             expect(heading.textContent).toEqual(`TYPE at ADDRESS on ${renderDate('2023-06-01')} - NOTES🔗🖨️`);
         });
@@ -1441,7 +1441,7 @@ describe('PrintableSheet', () => {
             await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers, alreadyPlaying: {}}, {printOnly: false, editable: true}, appProps({teams, account}, reportedError));
             const addSideOption = context.container.querySelector('li[datatype="add-side"]');
             await doClick(addSideOption);
-            expect(reportedError.error).toBeFalsy();
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('div.modal-dialog');
             expect(dialog).toBeTruthy();
 

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.test.tsx
@@ -1,4 +1,13 @@
-import {appProps, brandingProps, cleanUp, ErrorState, iocProps, renderApp, TestContext} from "../../../helpers/tests";
+import {
+    appProps,
+    brandingProps,
+    cleanUp, doChange,
+    doClick, doSelectOption,
+    ErrorState, findButton,
+    iocProps,
+    renderApp,
+    TestContext
+} from "../../../helpers/tests";
 import {ITournamentContainerProps, TournamentContainer} from "./TournamentContainer";
 import {IPrintableSheetProps, PrintableSheet} from "./PrintableSheet";
 import {renderDate} from "../../../helpers/rendering";
@@ -23,6 +32,9 @@ import {seasonBuilder} from "../../../helpers/builders/seasons";
 import {divisionBuilder} from "../../../helpers/builders/divisions";
 import {NotableTournamentPlayerDto} from "../../../interfaces/models/dtos/Game/NotableTournamentPlayerDto";
 import {TournamentPlayerDto} from "../../../interfaces/models/dtos/Game/TournamentPlayerDto";
+import {IAppContainerProps} from "../../../AppContainer";
+import {ISelectablePlayer} from "../../division_players/PlayerSelection";
+import {UserDto} from "../../../interfaces/models/dtos/Identity/UserDto";
 
 interface ISideInfo {
     sideAwinner?: boolean;
@@ -40,6 +52,7 @@ interface ISideInfo {
 describe('PrintableSheet', () => {
     let context: TestContext;
     let reportedError: ErrorState;
+    let updatedTournament: TournamentGameDto;
 
     afterEach(() => {
         cleanUp(context);
@@ -47,16 +60,18 @@ describe('PrintableSheet', () => {
 
     beforeEach(() => {
         reportedError = new ErrorState();
+        updatedTournament = null;
     });
 
-    async function renderComponent(containerProps: ITournamentContainerProps, props: IPrintableSheetProps, teams?: DataMap<TeamDto>, divisions?: DivisionDto[]) {
+    async function setTournamentData(update: TournamentGameDto) {
+        updatedTournament = update;
+    }
+
+    async function renderComponent(containerProps: ITournamentContainerProps, props: IPrintableSheetProps, appProps: IAppContainerProps) {
         context = await renderApp(
             iocProps(),
             brandingProps(),
-            appProps({
-                teams,
-                divisions,
-            }, reportedError),
+            appProps,
             (<TournamentContainer {...containerProps}>
                 <PrintableSheet {...props} />
             </TournamentContainer>));
@@ -203,7 +218,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -235,7 +250,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -270,7 +285,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE).withSide(sideF)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -352,7 +367,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -416,7 +431,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -522,7 +537,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideG).withSide(sideH).withSide(sideI).withSide(sideJ).withSide(sideK).withSide(sideL)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -682,7 +697,7 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const winner = getWinner();
@@ -725,7 +740,7 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({teams, divisions}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const winner = getWinner();
@@ -755,7 +770,7 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const winner = getWinner();
@@ -780,7 +795,7 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const winner = getWinner();
@@ -801,7 +816,7 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -824,7 +839,7 @@ describe('PrintableSheet', () => {
             const teams: DataMap<TeamDto> = toMap<TeamDto>([team]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -845,7 +860,7 @@ describe('PrintableSheet', () => {
             ]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b']);
@@ -868,7 +883,7 @@ describe('PrintableSheet', () => {
             ]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b']);
@@ -884,7 +899,7 @@ describe('PrintableSheet', () => {
             const teams: DataMap<TeamDto> = toMap([]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b', '-3 - c-']);
@@ -899,7 +914,7 @@ describe('PrintableSheet', () => {
                 .date('2023-06-01')
                 .build();
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false});
+            await renderComponent({tournamentData, season, division}, {printOnly: false}, appProps({}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const heading = context.container.querySelector('div[datatype="heading"]');
@@ -924,7 +939,7 @@ describe('PrintableSheet', () => {
             ]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getAccolades('180s', d => d.textContent)).toEqual(['PLAYER 1 x 3', 'PLAYER 2 x 1']);
@@ -950,7 +965,7 @@ describe('PrintableSheet', () => {
             ]);
             const divisions = [division];
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getAccolades('180s', d => d.textContent)).toEqual(['PLAYER 1 x 3', 'PLAYER 2 x 1']);
@@ -973,7 +988,7 @@ describe('PrintableSheet', () => {
             ]);
             const divisions = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getAccolades('hi-checks', d => d.textContent)).toEqual(['PLAYER 1 (100)', 'PLAYER 2 (120)']);
@@ -997,11 +1012,301 @@ describe('PrintableSheet', () => {
             ]);
             const divisions = [division];
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getAccolades('hi-checks', d => d.textContent)).toEqual(['PLAYER 1 (100)', 'PLAYER 2 (120)']);
             expect(getAccolades('hi-checks', linkHref)).toEqual([`http://localhost/division/${division.name}/player:${encodeURI(player1.name)}@TEAM/${season.name}`, null]);
+        });
+
+        it('cannot set match side a when not permitted', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 1).sideB(sideB, 2))
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideC, 2).sideB(sideD, 1))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .round((r: ITournamentRoundBuilder) => r
+                        .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideB, 2).sideB(sideC, 1))
+                        .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
+                .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
+                .build();
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: false}, appProps({}, reportedError));
+            expect(reportedError.hasError()).toEqual(false);
+            const firstSideA = context.container.querySelector('div[datatype="sideA"]');
+
+            await doClick(firstSideA);
+
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeFalsy();
+        });
+
+        it('can edit match side a', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 1).sideB(sideB, 2))
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideC, 2).sideB(sideD, 1))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .round((r: ITournamentRoundBuilder) => r
+                        .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideB, 2).sideB(sideC, 1))
+                        .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
+                .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE)
+                .build();
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            expect(reportedError.hasError()).toEqual(false);
+            const firstSideA = context.container.querySelector('div[datatype="sideA"]');
+            await doClick(firstSideA);
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+            expect(tournamentData.round.matches[0].sideA.id).toEqual(sideA.id);
+            expect(tournamentData.round.matches[0].scoreA).toEqual(1);
+
+            await doSelectOption(dialog.querySelector('div.btn-group:nth-child(2) .dropdown-menu'), sideE.name); // side
+            await doSelectOption(dialog.querySelector('div.btn-group:nth-child(4) .dropdown-menu'), '2'); // score
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.round.matches[0].sideA.id).toEqual(sideE.id);
+            expect(updatedTournament.round.matches[0].scoreA).toEqual(2);
+        });
+
+        it('can remove match side a', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 1).sideB(sideB, 2))
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideC, 2).sideB(sideD, 1))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .round((r: ITournamentRoundBuilder) => r
+                        .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideB, 2).sideB(sideC, 1))
+                        .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
+                .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
+                .build();
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            expect(reportedError.hasError()).toEqual(false);
+            const firstSideA = context.container.querySelector('div[datatype="sideA"]');
+            await doClick(firstSideA);
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+
+            await doClick(findButton(context.container, 'Remove'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.round.matches[0].sideA.id).toBeFalsy();
+            expect(updatedTournament.round.matches[0].scoreA).toBeNull();
+        });
+
+        it('can edit match side b', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 1).sideB(sideB, 2))
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideC, 2).sideB(sideD, 1))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .round((r: ITournamentRoundBuilder) => r
+                        .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideB, 2).sideB(sideC, 1))
+                        .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
+                .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE)
+                .build();
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            expect(reportedError.hasError()).toEqual(false);
+            const firstSideA = context.container.querySelector('div[datatype="sideB"]');
+            await doClick(firstSideA);
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+            expect(tournamentData.round.matches[0].sideB.id).toEqual(sideB.id);
+            expect(tournamentData.round.matches[0].scoreB).toEqual(2);
+
+            await doSelectOption(dialog.querySelector('div.btn-group:nth-child(2) .dropdown-menu'), sideE.name); // side
+            await doSelectOption(dialog.querySelector('div.btn-group:nth-child(4) .dropdown-menu'), '3'); // score
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.round.matches[0].sideB.id).toEqual(sideE.id);
+            expect(updatedTournament.round.matches[0].scoreB).toEqual(3);
+        });
+
+        it('can remove match side b', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 1).sideB(sideB, 2))
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideC, 2).sideB(sideD, 1))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .round((r: ITournamentRoundBuilder) => r
+                        .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideB, 2).sideB(sideC, 1))
+                        .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
+                .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
+                .build();
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            expect(reportedError.hasError()).toEqual(false);
+            const firstSideA = context.container.querySelector('div[datatype="sideB"]');
+            await doClick(firstSideA);
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+
+            await doClick(findButton(context.container, 'Remove'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.round.matches[0].sideB.id).toBeFalsy();
+            expect(updatedTournament.round.matches[0].scoreB).toBeNull();
+        });
+
+        it('can edit 180s', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 1).sideB(sideB, 2))
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideC, 2).sideB(sideD, 1))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .round((r: ITournamentRoundBuilder) => r
+                        .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideB, 2).sideB(sideC, 1))
+                        .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
+                .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
+                .build();
+            const player1 = playerBuilder('PLAYER 1').build();
+            const allPlayers: ISelectablePlayer[] = [player1];
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            expect(reportedError.hasError()).toEqual(false);
+
+            await doClick(context.container.querySelector('div[data-accolades="180s"]'));
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+            await doSelectOption(dialog.querySelector('.dropdown-menu'), player1.name);
+            await doClick(findButton(dialog, '➕'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.oneEighties).toEqual([
+                { id: player1.id, name: player1.name }
+            ]);
+        });
+
+        it('can edit hi checks', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 1).sideB(sideB, 2))
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideC, 2).sideB(sideD, 1))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .round((r: ITournamentRoundBuilder) => r
+                        .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideB, 2).sideB(sideC, 1))
+                        .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
+                .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
+                .build();
+            const player1 = playerBuilder('PLAYER 1').build();
+            const allPlayers: ISelectablePlayer[] = [player1];
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            expect(reportedError.hasError()).toEqual(false);
+
+            await doClick(context.container.querySelector('div[data-accolades="hi-checks"]'));
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+            await doSelectOption(dialog.querySelector('.dropdown-menu'), player1.name);
+            await doChange(dialog, 'input', '123', context.user);
+            await doClick(findButton(dialog, '➕'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.over100Checkouts).toEqual([
+                { id: player1.id, name: player1.name, score: 123 }
+            ]);
+        });
+
+        it('can edit side', async () => {
+            const player1 = playerBuilder('PLAYER 1').build();
+            const allPlayers: ISelectablePlayer[] = [player1];
+            sideA.players = [ player1 ];
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 1).sideB(sideB, 2))
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideC, 2).sideB(sideD, 1))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .round((r: ITournamentRoundBuilder) => r
+                        .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideB, 2).sideB(sideC, 1))
+                        .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
+                .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
+                .build();
+            const account: UserDto = {
+                name: '',
+                givenName: '',
+                emailAddress: '',
+                access: {}
+            }
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers}, {printOnly: false, editable: true}, appProps({account}, reportedError));
+            expect(reportedError.hasError()).toEqual(false);
+            const playing = context.container.querySelector('div[datatype="playing"]');
+            const firstSide = playing.querySelector('li');
+            await doClick(firstSide);
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+            await doChange(dialog, 'input[name="name"]', 'NEW SIDE A', context.user);
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.sides.map((s: TournamentSideDto) => s.name))
+                .toEqual([sideB.name, sideC.name, sideD.name, 'NEW SIDE A']);
+        });
+
+        it('can add a side', async () => {
+            const player1 = playerBuilder('PLAYER 1').build();
+            const allPlayers: ISelectablePlayer[] = [player1];
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 1).sideB(sideB, 2)))
+                .withSide(sideA).withSide(sideB)
+                .build();
+            const account: UserDto = {
+                name: '',
+                givenName: '',
+                emailAddress: '',
+                access: {}
+            }
+            const teams: DataMap<TeamDto> = toMap<TeamDto>([
+                teamBuilder('TEAM')
+                    .forSeason(season, division, [player1])
+                    .build()]);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers, alreadyPlaying: {}}, {printOnly: false, editable: true}, appProps({account, teams}, reportedError));
+            expect(reportedError.hasError()).toEqual(false);
+            const addSide = context.container.querySelector('li[datatype="add-side"]');
+            await doClick(addSide);
+            expect(reportedError.hasError()).toEqual(false);
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+            await doChange(dialog, 'input[name="name"]', 'NEW SIDE', context.user);
+            await doClick(dialog.querySelector('.list-group li.list-group-item')); // select a player
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.sides.map((s: TournamentSideDto) => s.name))
+                .toEqual([sideA.name, sideB.name, 'NEW SIDE']);
+        });
+
+        it('can remove a side', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 1).sideB(sideB, 2)))
+                .withSide(sideA).withSide(sideB)
+                .build();
+            const account: UserDto = {
+                name: '',
+                givenName: '',
+                emailAddress: '',
+                access: {}
+            }
+            window.confirm = () => true;
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}}, {printOnly: false, editable: true}, appProps({account}, reportedError));
+            expect(reportedError.hasError()).toEqual(false);
+            const playing = context.container.querySelector('div[datatype="playing"]');
+            const firstSide = playing.querySelector('li.list-group-item');
+            await doClick(firstSide);
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+            await doClick(findButton(dialog, 'Delete side'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.sides.map((s: TournamentSideDto) => s.name))
+                .toEqual([sideB.name]);
         });
     });
 
@@ -1020,7 +1325,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -1046,7 +1351,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -1058,7 +1363,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false});
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -1072,11 +1377,105 @@ describe('PrintableSheet', () => {
                 .date('2023-06-01')
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
 
             expect(reportedError.hasError()).toEqual(false);
             const heading = context.container.querySelector('div[datatype="heading"]');
             expect(heading.textContent).toEqual(`TYPE at ADDRESS on ${renderDate('2023-06-01')} - NOTES🔗🖨️`);
+        });
+
+        it('can set match side a', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .withSide(sideA)
+                .withSide(sideB)
+                .build();
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            const firstSideA = context.container.querySelector('div[datatype="sideA"]');
+            await doClick(firstSideA);
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+
+            await doSelectOption(dialog.querySelector('div.btn-group:nth-child(2) .dropdown-menu'), sideA.name); // side
+            await doSelectOption(dialog.querySelector('div.btn-group:nth-child(4) .dropdown-menu'), '2'); // score
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.round.matches[0].sideA.id).toEqual(sideA.id);
+            expect(updatedTournament.round.matches[0].scoreA).toEqual(2);
+        });
+
+        it('can set match side b', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .withSide(sideA)
+                .withSide(sideB)
+                .build();
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            const firstSideA = context.container.querySelector('div[datatype="sideB"]');
+            await doClick(firstSideA);
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+
+            await doSelectOption(dialog.querySelector('div.btn-group:nth-child(2) .dropdown-menu'), sideA.name); // side
+            await doSelectOption(dialog.querySelector('div.btn-group:nth-child(4) .dropdown-menu'), '2'); // score
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.round.matches[0].sideB.id).toEqual(sideA.id);
+            expect(updatedTournament.round.matches[0].scoreB).toEqual(2);
+        });
+
+        it('can add a side', async () => {
+            const player1 = playerBuilder('PLAYER 1').build();
+            const allPlayers: ISelectablePlayer[] = [player1];
+            const teams: DataMap<TeamDto> = toMap<TeamDto>([
+                teamBuilder('TEAM')
+                    .forSeason(season, division, [player1])
+                    .build()]);
+            const account: UserDto = {
+                name: '',
+                givenName: '',
+                emailAddress: '',
+                access: {}
+            }
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers, alreadyPlaying: {}}, {printOnly: false, editable: true}, appProps({teams, account}, reportedError));
+            const addSideOption = context.container.querySelector('li[datatype="add-side"]');
+            await doClick(addSideOption);
+            expect(reportedError.error).toBeFalsy();
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+
+            await doChange(dialog, 'input[name="name"]', 'NEW SIDE', context.user);
+            await doClick(dialog.querySelector('.list-group li.list-group-item')); // select a player
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.sides.map((s: TournamentSideDto) => s.name)).toEqual(['NEW SIDE']);
+        });
+
+        it('can remove a side', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .withSide(sideA)
+                .withSide(sideB)
+                .build();
+            const account: UserDto = {
+                name: '',
+                givenName: '',
+                emailAddress: '',
+                access: {}
+            }
+            window.confirm = () => true;
+            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({account}, reportedError));
+            const playing = context.container.querySelector('div[datatype="playing"]');
+            const firstSide = playing.querySelector('li.list-group-item');
+            await doClick(firstSide);
+            const dialog = context.container.querySelector('div.modal-dialog');
+            expect(dialog).toBeTruthy();
+            await doClick(findButton(dialog, 'Delete side'));
+
+            expect(updatedTournament).not.toBeNull();
+            expect(updatedTournament.sides.map((s: TournamentSideDto) => s.name))
+                .toEqual([sideB.name]);
         });
     });
 });

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.test.tsx
@@ -16,13 +16,26 @@ import {
     sideBuilder,
     tournamentBuilder
 } from "../../../helpers/builders/tournaments";
-import {IMatchOptionsBuilder} from "../../../helpers/builders/games";
+import {IMatchOptionsBuilder, matchOptionsBuilder} from "../../../helpers/builders/games";
 import {playerBuilder} from "../../../helpers/builders/players";
 import {teamBuilder} from "../../../helpers/builders/teams";
 import {seasonBuilder} from "../../../helpers/builders/seasons";
 import {divisionBuilder} from "../../../helpers/builders/divisions";
 import {NotableTournamentPlayerDto} from "../../../interfaces/models/dtos/Game/NotableTournamentPlayerDto";
 import {TournamentPlayerDto} from "../../../interfaces/models/dtos/Game/TournamentPlayerDto";
+
+interface ISideInfo {
+    sideAwinner?: boolean;
+    sideBwinner?: boolean;
+    sideAname?: string;
+    sideAmnemonic?: string;
+    sideBname?: string;
+    sideBmnemonic?: string;
+    scoreA?: string;
+    scoreB?: string;
+    bye: boolean;
+    saygLink?: string;
+}
 
 describe('PrintableSheet', () => {
     let context: TestContext;
@@ -74,32 +87,58 @@ describe('PrintableSheet', () => {
                     } : null,
                     heading: round.querySelector('h5[datatype="round-name"]').textContent,
                     matches: Array.from(round.querySelectorAll('div[datatype="match"]'))
-                        .map(match => {
-                            return {
-                                //element: match,
-                                sideAwinner: match.querySelector('div[datatype="sideA"]')
-                                    ? match.querySelector('div[datatype="sideA"]').className.indexOf('bg-winner') !== -1
-                                    : null,
-                                sideBwinner: match.querySelector('div[datatype="sideB"]')
-                                    ? match.querySelector('div[datatype="sideB"]').className.indexOf('bg-winner') !== -1
-                                    : null,
-                                sideAname: match.querySelector('div[datatype="sideAname"]')
-                                    ? match.querySelector('div[datatype="sideAname"]').textContent.trim()
-                                    : null,
-                                sideBname: match.querySelector('div[datatype="sideBname"]')
-                                    ? match.querySelector('div[datatype="sideBname"]').textContent.trim()
-                                    : null,
-                                scoreA: match.querySelector('div[datatype="scoreA"]')
-                                    ? match.querySelector('div[datatype="scoreA"]').textContent.trim()
-                                    : null,
-                                scoreB: match.querySelector('div[datatype="scoreB"]')
-                                    ? match.querySelector('div[datatype="scoreB"]').textContent.trim()
-                                    : null,
+                        .map((match: Element): ISideInfo => {
+                            function setInfo(selector: string, name: string, getter: (element: Element) => any) {
+                                const element = match.querySelector(selector);
+                                if (element) {
+                                    const value = getter(element);
+                                    if (value) {
+                                        info[name] = value;
+                                    }
+                                }
+                            }
+
+                            const info: ISideInfo = {
                                 bye: match.textContent.indexOf('Bye') !== -1,
                                 saygLink: match.querySelector('a')
                                     ? match.querySelector('a').href
                                     : null,
                             };
+
+                            setInfo(
+                                'div[datatype="sideA"]',
+                                'sideAwinner',
+                                (e: Element) => e.className.indexOf('bg-winner') !== -1);
+                            setInfo(
+                                'div[datatype="sideB"]',
+                                'sideBwinner',
+                                (e: Element) => e.className.indexOf('bg-winner') !== -1);
+                            setInfo(
+                                'span[datatype="sideAname"]',
+                                'sideAname',
+                                (e: Element) => e.textContent.trim());
+                            setInfo(
+                                'span[datatype="sideBname"]',
+                                'sideBname',
+                                (e: Element) => e.textContent.trim());
+                            setInfo(
+                                'span[datatype="sideAmnemonic"]',
+                                'sideAmnemonic',
+                                (e: Element) => e.textContent.trim());
+                            setInfo(
+                                'span[datatype="sideBmnemonic"]',
+                                'sideBmnemonic',
+                                (e: Element) => e.textContent.trim());
+                            setInfo(
+                                'div[datatype="scoreA"]',
+                                'scoreA',
+                                (e: Element) => e.textContent.trim());
+                            setInfo(
+                                'div[datatype="scoreB"]',
+                                'scoreB',
+                                (e: Element) => e.textContent.trim());
+
+                            return info;
                         }),
                 }
             });
@@ -138,22 +177,23 @@ describe('PrintableSheet', () => {
     }
 
     describe('played tournament', () => {
-        const sideA: TournamentSideDto = createSide('A');
-        const sideB: TournamentSideDto = createSide('B');
-        const sideC: TournamentSideDto = createSide('C');
-        const sideD: TournamentSideDto = createSide('D');
-        const sideE: TournamentSideDto = createSide('E');
-        const sideF: TournamentSideDto = createSide('F');
-        const sideG: TournamentSideDto = createSide('G');
-        const sideH: TournamentSideDto = createSide('H');
-        const sideI: TournamentSideDto = createSide('I');
-        const sideJ: TournamentSideDto = createSide('J');
-        const sideK: TournamentSideDto = createSide('K');
-        const sideL: TournamentSideDto = createSide('L');
+        const sideA: TournamentSideDto = createSide('a');
+        const sideB: TournamentSideDto = createSide('b');
+        const sideC: TournamentSideDto = createSide('c');
+        const sideD: TournamentSideDto = createSide('d');
+        const sideE: TournamentSideDto = createSide('e');
+        const sideF: TournamentSideDto = createSide('f');
+        const sideG: TournamentSideDto = createSide('g');
+        const sideH: TournamentSideDto = createSide('h');
+        const sideI: TournamentSideDto = createSide('i');
+        const sideJ: TournamentSideDto = createSide('j');
+        const sideK: TournamentSideDto = createSide('k');
+        const sideL: TournamentSideDto = createSide('l');
         const division: DivisionDto = divisionBuilder('DIVISION').build();
         const season: SeasonDto = seasonBuilder('SEASON')
             .withDivision(division)
             .build();
+        const matchOptionDefaults = matchOptionsBuilder().build();
 
         it('renders tournament with one round', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder()
@@ -163,7 +203,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -174,9 +214,8 @@ describe('PrintableSheet', () => {
                 oneEighties: {players: []},
                 matches: [
                     {
-                        sideAname: 'A',
-                        sideBname: 'B',
-                        sideAwinner: false,
+                        sideAname: 'a',
+                        sideBname: 'b',
                         sideBwinner: true,
                         scoreA: '1',
                         scoreB: '2',
@@ -196,7 +235,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -207,9 +246,8 @@ describe('PrintableSheet', () => {
                 oneEighties: {players: []},
                 matches: [
                     {
-                        sideAname: 'A',
-                        sideBname: 'B',
-                        sideAwinner: false,
+                        sideAname: 'a',
+                        sideBname: 'b',
                         sideBwinner: true,
                         scoreA: '1',
                         scoreB: '2',
@@ -232,7 +270,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE).withSide(sideF)
                 .build();
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -243,30 +281,24 @@ describe('PrintableSheet', () => {
                 oneEighties: null,
                 matches: [
                     {
-                        sideAname: 'A',
-                        sideBname: 'B',
-                        sideAwinner: false,
-                        sideBwinner: false,
+                        sideAname: 'a',
+                        sideBname: 'b',
                         scoreA: '0',
                         scoreB: '0',
                         bye: false,
                         saygLink: null,
                     },
                     {
-                        sideAname: 'C',
-                        sideBname: 'D',
-                        sideAwinner: false,
-                        sideBwinner: false,
+                        sideAname: 'c',
+                        sideBname: 'd',
                         scoreA: '0',
                         scoreB: '0',
                         bye: false,
                         saygLink: null,
                     },
                     {
-                        sideAname: 'E',
-                        sideBname: 'F',
-                        sideAwinner: false,
-                        sideBwinner: false,
+                        sideAname: 'e',
+                        sideBname: 'f',
                         scoreA: '0',
                         scoreB: '0',
                         bye: false,
@@ -280,22 +312,13 @@ describe('PrintableSheet', () => {
                 oneEighties: null,
                 matches: [
                     {
-                        sideAname: 'winner(M1)',
-                        sideBname: 'winner(M2)',
-                        sideAwinner: false,
-                        sideBwinner: false,
-                        scoreA: '',
-                        scoreB: '',
+                        sideAmnemonic: 'winner(M1)',
+                        sideBmnemonic: 'winner(M2)',
                         bye: false,
                         saygLink: null,
                     },
                     {
-                        sideAname: 'winner(M3)',
-                        sideBname: null,
-                        sideAwinner: false,
-                        sideBwinner: null,
-                        scoreA: '',
-                        scoreB: null,
+                        sideAmnemonic: 'winner(M3)',
                         bye: true,
                         saygLink: null,
                     },
@@ -307,12 +330,8 @@ describe('PrintableSheet', () => {
                 oneEighties: {players: []},
                 matches: [
                     {
-                        sideAname: 'winner(M3)',
-                        sideBname: 'winner(M4)',
-                        sideAwinner: false,
-                        sideBwinner: false,
-                        scoreA: '',
-                        scoreB: '',
+                        sideAmnemonic: 'winner(M3)',
+                        sideBmnemonic: 'winner(M4)',
                         bye: false,
                         saygLink: null,
                     },
@@ -333,7 +352,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
                 .build();
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -344,9 +363,8 @@ describe('PrintableSheet', () => {
                 oneEighties: null,
                 matches: [
                     {
-                        sideAname: 'A',
-                        sideBname: 'B',
-                        sideAwinner: false,
+                        sideAname: 'a',
+                        sideBname: 'b',
                         sideBwinner: true,
                         scoreA: '1',
                         scoreB: '2',
@@ -354,10 +372,9 @@ describe('PrintableSheet', () => {
                         saygLink: null,
                     },
                     {
-                        sideAname: 'C',
-                        sideBname: 'D',
+                        sideAname: 'c',
+                        sideBname: 'd',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
@@ -371,10 +388,9 @@ describe('PrintableSheet', () => {
                 oneEighties: {players: []},
                 matches: [
                     {
-                        sideAname: 'B',
-                        sideBname: 'C',
+                        sideAname: 'b',
+                        sideBname: 'c',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
@@ -400,7 +416,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE)
                 .build();
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -411,9 +427,8 @@ describe('PrintableSheet', () => {
                 oneEighties: null,
                 matches: [
                     {
-                        sideAname: 'A',
-                        sideBname: 'B',
-                        sideAwinner: false,
+                        sideAname: 'a',
+                        sideBname: 'b',
                         sideBwinner: true,
                         scoreA: '1',
                         scoreB: '2',
@@ -421,22 +436,16 @@ describe('PrintableSheet', () => {
                         saygLink: null,
                     },
                     {
-                        sideAname: 'C',
-                        sideBname: 'D',
+                        sideAname: 'c',
+                        sideBname: 'd',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
                         saygLink: null,
                     },
                     {
-                        sideAname: 'E',
-                        sideBname: null,
-                        sideAwinner: false,
-                        sideBwinner: null,
-                        scoreA: '',
-                        scoreB: null,
+                        sideAname: 'e',
                         bye: true,
                         saygLink: null,
                     },
@@ -448,22 +457,16 @@ describe('PrintableSheet', () => {
                 oneEighties: null,
                 matches: [
                     {
-                        sideAname: 'E',
-                        sideBname: 'B',
+                        sideAname: 'e',
+                        sideBname: 'b',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
                         saygLink: null,
                     },
                     {
-                        sideAname: 'C',
-                        sideBname: null,
-                        sideAwinner: false,
-                        sideBwinner: null,
-                        scoreA: '',
-                        scoreB: null,
+                        sideAname: 'c',
                         bye: true,
                         saygLink: null,
                     },
@@ -475,10 +478,9 @@ describe('PrintableSheet', () => {
                 oneEighties: {players: []},
                 matches: [
                     {
-                        sideAname: 'C',
-                        sideBname: 'E',
+                        sideAname: 'c',
+                        sideBname: 'e',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
@@ -520,7 +522,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideG).withSide(sideH).withSide(sideI).withSide(sideJ).withSide(sideK).withSide(sideL)
                 .build();
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -531,9 +533,8 @@ describe('PrintableSheet', () => {
                 oneEighties: null,
                 matches: [
                     {
-                        sideAname: 'A',
-                        sideBname: 'B',
-                        sideAwinner: false,
+                        sideAname: 'a',
+                        sideBname: 'b',
                         sideBwinner: true,
                         scoreA: '1',
                         scoreB: '2',
@@ -541,29 +542,26 @@ describe('PrintableSheet', () => {
                         saygLink: null,
                     },
                     {
-                        sideAname: 'C',
-                        sideBname: 'D',
+                        sideAname: 'c',
+                        sideBname: 'd',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
                         saygLink: null,
                     },
                     {
-                        sideAname: 'E',
-                        sideBname: 'F',
+                        sideAname: 'e',
+                        sideBname: 'f',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
                         saygLink: null,
                     },
                     {
-                        sideAname: 'G',
-                        sideBname: 'H',
-                        sideAwinner: false,
+                        sideAname: 'g',
+                        sideBname: 'h',
                         sideBwinner: true,
                         scoreA: '1',
                         scoreB: '2',
@@ -571,9 +569,8 @@ describe('PrintableSheet', () => {
                         saygLink: null,
                     },
                     {
-                        sideAname: 'I',
-                        sideBname: 'J',
-                        sideAwinner: false,
+                        sideAname: 'i',
+                        sideBname: 'j',
                         sideBwinner: true,
                         scoreA: '1',
                         scoreB: '2',
@@ -581,9 +578,8 @@ describe('PrintableSheet', () => {
                         saygLink: null,
                     },
                     {
-                        sideAname: 'K',
-                        sideBname: 'L',
-                        sideAwinner: false,
+                        sideAname: 'k',
+                        sideBname: 'l',
                         sideBwinner: true,
                         scoreA: '1',
                         scoreB: '2',
@@ -598,42 +594,30 @@ describe('PrintableSheet', () => {
                 oneEighties: null,
                 matches: [
                     {
-                        sideAname: 'B',
-                        sideBname: 'C',
+                        sideAname: 'b',
+                        sideBname: 'c',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
                         saygLink: null,
                     },
                     {
-                        sideAname: 'E',
-                        sideBname: 'H',
+                        sideAname: 'e',
+                        sideBname: 'h',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
                         saygLink: null,
                     },
                     {
-                        sideAname: 'J',
-                        sideBname: null,
-                        sideAwinner: false,
-                        sideBwinner: null,
-                        scoreA: '',
-                        scoreB: null,
+                        sideAname: 'j',
                         bye: true,
                         saygLink: null,
                     },
                     {
-                        sideAname: 'L',
-                        sideBname: null,
-                        sideAwinner: false,
-                        sideBwinner: null,
-                        scoreA: '',
-                        scoreB: null,
+                        sideAname: 'l',
                         bye: true,
                         saygLink: null,
                     },
@@ -645,20 +629,18 @@ describe('PrintableSheet', () => {
                 oneEighties: null,
                 matches: [
                     {
-                        sideAname: 'B',
-                        sideBname: 'E',
+                        sideAname: 'b',
+                        sideBname: 'e',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
                         saygLink: null,
                     },
                     {
-                        sideAname: 'J',
-                        sideBname: 'L',
+                        sideAname: 'j',
+                        sideBname: 'l',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
@@ -672,10 +654,9 @@ describe('PrintableSheet', () => {
                 oneEighties: {players: []},
                 matches: [
                     {
-                        sideAname: 'B',
-                        sideBname: 'J',
+                        sideAname: 'b',
+                        sideBname: 'j',
                         sideAwinner: true,
-                        sideBwinner: false,
                         scoreA: '2',
                         scoreB: '1',
                         bye: false,
@@ -705,7 +686,7 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
             const winner = getWinner();
@@ -748,7 +729,7 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
             const winner = getWinner();
@@ -778,7 +759,7 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
             const winner = getWinner();
@@ -803,7 +784,7 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division: null}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
             const winner = getWinner();
@@ -824,7 +805,7 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -847,7 +828,7 @@ describe('PrintableSheet', () => {
             const teams: DataMap<TeamDto> = toMap<TeamDto>([team]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -868,18 +849,18 @@ describe('PrintableSheet', () => {
             ]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division: null}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
-            expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
+            expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b']);
             expect(getWhoIsPlaying(linkHref)).toEqual([null, null]);
         });
 
         it('renders who is playing when team not found', async () => {
             const player1: TeamPlayerDto = playerBuilder('PLAYER 1').build();
             const player2: TeamPlayerDto = playerBuilder('PLAYER 2').build();
-            const sideASinglePlayer: TournamentSideDto = createSide('A', [player1]);
-            const sideBSinglePlayer: TournamentSideDto = createSide('B', [player2]);
+            const sideASinglePlayer: TournamentSideDto = createSide('a', [player1]);
+            const sideBSinglePlayer: TournamentSideDto = createSide('b', [player2]);
             const tournamentData: TournamentGameDto = tournamentBuilder()
                 .withSide(sideASinglePlayer)
                 .withSide(sideBSinglePlayer)
@@ -891,10 +872,10 @@ describe('PrintableSheet', () => {
             ]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division: null}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
-            expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
+            expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b']);
             expect(getWhoIsPlaying(linkHref)).toEqual([null, null]);
         });
 
@@ -907,10 +888,10 @@ describe('PrintableSheet', () => {
             const teams: DataMap<TeamDto> = toMap([]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
-            expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B', '-3 - C-']);
+            expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b', '-3 - c-']);
             expect(getWhoIsPlaying(linkHref)).toEqual([null, null, null]);
         });
 
@@ -947,7 +928,7 @@ describe('PrintableSheet', () => {
             ]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getAccolades('180s', d => d.textContent)).toEqual(['PLAYER 1 x 3', 'PLAYER 2 x 1']);
@@ -973,7 +954,7 @@ describe('PrintableSheet', () => {
             ]);
             const divisions = [division];
 
-            await renderComponent({tournamentData, season, division: null}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getAccolades('180s', d => d.textContent)).toEqual(['PLAYER 1 x 3', 'PLAYER 2 x 1']);
@@ -996,7 +977,7 @@ describe('PrintableSheet', () => {
             ]);
             const divisions = [division];
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getAccolades('hi-checks', d => d.textContent)).toEqual(['PLAYER 1 (100)', 'PLAYER 2 (120)']);
@@ -1020,7 +1001,7 @@ describe('PrintableSheet', () => {
             ]);
             const divisions = [division];
 
-            await renderComponent({tournamentData, season, division: null}, {printOnly: false}, teams, divisions);
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, teams, divisions);
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getAccolades('hi-checks', d => d.textContent)).toEqual(['PLAYER 1 (100)', 'PLAYER 2 (120)']);
@@ -1035,6 +1016,7 @@ describe('PrintableSheet', () => {
         const season: SeasonDto = seasonBuilder('SEASON')
             .withDivision(division)
             .build();
+        const matchOptionDefaults = matchOptionsBuilder().build();
 
         it('renders tournament with 2 sides', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder()
@@ -1042,7 +1024,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
 
             expect(reportedError.hasError()).toEqual(false);
             const rounds = getRounds();
@@ -1053,12 +1035,8 @@ describe('PrintableSheet', () => {
                 oneEighties: {players: []},
                 matches: [
                     {
-                        sideAname: 'A',
-                        sideBname: 'B',
-                        sideAwinner: false,
-                        sideBwinner: false,
-                        scoreA: '',
-                        scoreB: '',
+                        sideAmnemonic: 'A',
+                        sideBmnemonic: 'B',
                         bye: false,
                         saygLink: null,
                     },
@@ -1072,7 +1050,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -1084,7 +1062,7 @@ describe('PrintableSheet', () => {
                 .withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division: null}, {printOnly: false});
+            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false});
 
             expect(reportedError.hasError()).toEqual(false);
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -1098,7 +1076,7 @@ describe('PrintableSheet', () => {
                 .date('2023-06-01')
                 .build();
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false});
+            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false});
 
             expect(reportedError.hasError()).toEqual(false);
             const heading = context.container.querySelector('div[datatype="heading"]');

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.tsx
@@ -17,10 +17,11 @@ import {TeamPlayerDto} from "../../../interfaces/models/dtos/Team/TeamPlayerDto"
 import {
     getUnplayedLayoutData, getUnplayedLayoutDataForSides,
     ILayoutDataForMatch,
-    ILayoutDataForRound, ILayoutDataForSide,
+    ILayoutDataForRound,
     setRoundNames
 } from "../../../helpers/tournaments";
 import {NotableTournamentPlayerDto} from "../../../interfaces/models/dtos/Game/NotableTournamentPlayerDto";
+import {PrintableSheetMatch} from "./PrintableSheetMatch";
 
 export interface IPrintableSheetProps {
     printOnly: boolean;
@@ -330,13 +331,6 @@ export function PrintableSheet({printOnly}: IPrintableSheetProps) {
         return null;
     }
 
-    function renderSide(side: ILayoutDataForSide, type: string) {
-        return <div className="no-wrap pe-3" datatype={type + 'name'}>
-            {side.link || (<span>&nbsp;</span>)}
-            {side.mnemonic ? <span className="text-secondary-50 opacity-75 small">{side.mnemonic}</span> : null}
-        </div>
-    }
-
     try {
         return (<div className={printOnly ? 'd-screen-none' : ''} datatype="printable-sheet">
             {winner ? null : (<div className="float-end">
@@ -356,31 +350,10 @@ export function PrintableSheet({printOnly}: IPrintableSheetProps) {
                     <div key={index} datatype={`round-${index}`} className="d-flex flex-column p-3">
                         {index === layoutData.length - 1 ? render180s() : null}
                         <h5 datatype="round-name">{roundData.name}</h5>
-                        {roundData.matches.map((matchData: ILayoutDataForMatch, index: number) => (
-                            <div key={index} datatype="match" className={`p-0 border-solid border-1 m-1 position-relative ${matchData.bye ? 'opacity-50' : ''}`}>
-                                {matchData.mnemonic && roundData.matches.length > 1 && !matchData.hideMnemonic ? (<span className="position-absolute right-0 opacity-75">
-                                    <span className="small rounded-circle bg-secondary opacity-75 text-light p-1 position-absolute" style={{ left: -10, top: -10 }}>{matchData.mnemonic}</span>
-                                </span>) : null}
-                                {matchData.bye ? (<div className="position-absolute-bottom-right">Bye</div>) : null}
-                                <div datatype="sideA"
-                                     className={`d-flex flex-row justify-content-between p-2 min-width-150 ${matchData.winner === 'sideA' ? 'bg-winner fw-bold' : ''}`}>
-                                    {renderSide(matchData.sideA, 'sideA')}
-                                    <div datatype="scoreA">{matchData.scoreA || ''}</div>
-                                </div>
-                                {matchData.bye ? null : (<div className="text-center dotted-line-through">
-                                    <span className="px-3 bg-white position-relative">
-                                        vs
-                                        {matchData.saygId ? (<a href={`/live/match/${matchData.saygId}`} target="_blank" rel="noreferrer" className="margin-left no-underline">👁️</a>) : null}
-                                    </span>
-                                </div>)}
-                                {matchData.bye
-                                    ? null
-                                    : (<div datatype="sideB"
-                                            className={`d-flex flex-row justify-content-between p-2 min-width-150 ${matchData.winner === 'sideB' ? 'bg-winner fw-bold' : ''}`}>
-                                        {renderSide(matchData.sideB, 'sideB')}
-                                        <div datatype="scoreB">{matchData.scoreB || ''}</div>
-                                    </div>)}
-                            </div>))}
+                        {roundData.matches.map((matchData: ILayoutDataForMatch, index: number) => <PrintableSheetMatch
+                            key={index}
+                            matchData={matchData}
+                            noOfMatches={roundData.matches.length} />)}
                         {index === layoutData.length - 1 ? renderHiChecks() : null}
                     </div>))}
                 {any(tournamentData.sides) ? (<div>

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.tsx
@@ -371,7 +371,7 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
                             key={side.id}
                             onClick={editable ? () => setEditSide(side) : null}
                             className={`list-group-item no-wrap${side.noShow ? ' text-decoration-line-through' : ''}`}>
-                            {index + 1} - {getLinkToSide(side)}
+                            {index + 1} - {editable ? side.name : getLinkToSide(side)}
                         </li>)}
                         {editable ? (<li datatype="add-side" className="list-group-item text-secondary opacity-50" onClick={() => setNewSide({ id: createTemporaryId() })}>
                             Add a side

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.tsx
@@ -259,7 +259,6 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
                 players={tournamentData.oneEighties || []}
                 onRemovePlayer={remove180(tournamentData, setTournamentData)}
                 onAddPlayer={add180(tournamentData, setTournamentData)}/>
-
         </Dialog>
     }
 
@@ -366,7 +365,7 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
                         </div>
                     </div>
                 </div>) : null}
-                {any(tournamentData.sides) ? (<div datatype="playing" className="ms-5">
+                {any(tournamentData.sides) || editable ? (<div datatype="playing" className="ms-5">
                     <h4>Playing</h4>
                     <ul className="list-group">
                         {tournamentData.sides.sort(sortBy('name')).map((side: TournamentSideDto, index: number) => <li
@@ -375,7 +374,7 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
                             className={`list-group-item no-wrap${side.noShow ? ' text-decoration-line-through' : ''}`}>
                             {index + 1} - {getLinkToSide(side)}
                         </li>)}
-                        {editable ? (<li className="list-group-item text-secondary opacity-50" onClick={() => setNewSide({ id: createTemporaryId() })}>
+                        {editable ? (<li datatype="add-side" className="list-group-item text-secondary opacity-50" onClick={() => setNewSide({ id: createTemporaryId() })}>
                             Add a side
                         </li>) : null}
                     </ul>

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.tsx
@@ -347,7 +347,6 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
                         {roundData.matches.map((matchData: ILayoutDataForMatch, matchIndex: number) => <PrintableSheetMatch
                             key={matchIndex}
                             matchData={matchData}
-                            noOfMatches={roundData.matches.length}
                             matchIndex={matchIndex}
                             roundIndex={roundIndex}
                             possibleSides={getPossibleSides(matchData, roundData)}

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheet.tsx
@@ -22,6 +22,9 @@ import {
 } from "../../../helpers/tournaments";
 import {NotableTournamentPlayerDto} from "../../../interfaces/models/dtos/Game/NotableTournamentPlayerDto";
 import {PrintableSheetMatch} from "./PrintableSheetMatch";
+import {TeamSeasonDto} from "../../../interfaces/models/dtos/Team/TeamSeasonDto";
+import {DivisionDto} from "../../../interfaces/models/dtos/DivisionDto";
+import {TeamDto} from "../../../interfaces/models/dtos/Team/TeamDto";
 
 export interface IPrintableSheetProps {
     printOnly: boolean;
@@ -138,19 +141,19 @@ export function PrintableSheet({printOnly}: IPrintableSheetProps) {
         return (<span>{(side || {}).name || (<>&nbsp;</>)}</span>);
     }
 
-    function findTeamAndDivisionForPlayer(player: TournamentPlayerDto) {
+    function findTeamAndDivisionForPlayer(player: TournamentPlayerDto): { team?: TeamDto, division?: DivisionDto } {
         const teamAndDivisionMapping = teams.map(t => {
-            const teamSeason = t.seasons.filter(ts => ts.seasonId === season.id)[0];
+            const teamSeason: TeamSeasonDto = t.seasons.filter((ts: TeamSeasonDto) => ts.seasonId === season.id)[0];
             if (!teamSeason) {
                 return null;
             }
 
-            const hasPlayer = any(teamSeason.players, (p: TeamPlayerDto) => p.id === player.id);
+            const hasPlayer: boolean = any(teamSeason.players, (p: TeamPlayerDto) => p.id === player.id);
             return hasPlayer ? {team: t, divisionId: teamSeason.divisionId} : null;
         }).filter(a => a !== null)[0];
 
         if (!teamAndDivisionMapping) {
-            return null;
+            return { };
         }
 
         if (teamAndDivisionMapping.divisionId) {
@@ -249,7 +252,7 @@ export function PrintableSheet({printOnly}: IPrintableSheetProps) {
         const oneEightyMap = {};
         const playerLookup = {};
 
-        tournamentData.oneEighties.forEach(player => {
+        tournamentData.oneEighties.forEach((player: TournamentPlayerDto) => {
             if (oneEightyMap[player.id]) {
                 oneEightyMap[player.id]++;
             } else {
@@ -272,13 +275,13 @@ export function PrintableSheet({printOnly}: IPrintableSheetProps) {
                 }
 
                 return 0;
-            }).map((id, index) => {
+            }).map((id: string, index: number) => {
                 const player = playerLookup[id];
-                const teamAndDivision = findTeamAndDivisionForPlayer(player);
+                const { team, division } = findTeamAndDivisionForPlayer(player);
 
-                if (teamAndDivision && teamAndDivision.division) {
+                if (division && team) {
                     return (<div key={index} className="p-1 no-wrap">
-                        <EmbedAwareLink to={`/division/${teamAndDivision.division.name}/player:${player.name}@${teamAndDivision.team.name}/${season.name}`}>
+                        <EmbedAwareLink to={`/division/${division.name}/player:${player.name}@${team.name}/${season.name}`}>
                             {player.name}
                         </EmbedAwareLink> x {oneEightyMap[id]}
                     </div>);
@@ -295,11 +298,11 @@ export function PrintableSheet({printOnly}: IPrintableSheetProps) {
         return (<div data-accolades="hi-checks" className="border-1 border-solid my-2 min-height-100 p-2 mt-5">
             <h5>Hi-checks</h5>
             {tournamentData.over100Checkouts.map((player: NotableTournamentPlayerDto, index: number) => {
-                const teamAndDivision = findTeamAndDivisionForPlayer(player);
+                const { team, division } = findTeamAndDivisionForPlayer(player);
 
-                if (teamAndDivision && teamAndDivision.division) {
+                if (division && team) {
                     return (<div key={index} className="p-1 no-wrap">
-                        <EmbedAwareLink to={`/division/${teamAndDivision.division.name}/player:${player.name}@${teamAndDivision.team.name}/${season.name}`}>
+                        <EmbedAwareLink to={`/division/${division.name}/player:${player.name}@${team.name}/${season.name}`}>
                             {player.name}
                         </EmbedAwareLink> ({player.score})
                     </div>);

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.test.tsx
@@ -1,0 +1,703 @@
+﻿import {
+    appProps,
+    brandingProps,
+    cleanUp,
+    doClick, doSelectOption,
+    ErrorState, findButton,
+    iocProps,
+    renderApp,
+    TestContext
+} from "../../../helpers/tests";
+import {TournamentGameDto} from "../../../interfaces/models/dtos/Game/TournamentGameDto";
+import {ITournamentContainerProps, TournamentContainer} from "./TournamentContainer";
+import {IAppContainerProps} from "../../../AppContainer";
+import {IPrintableSheetMatchProps, PrintableSheetMatch} from "./PrintableSheetMatch";
+import {
+    ITournamentMatchBuilder,
+    ITournamentRoundBuilder,
+    sideBuilder,
+    tournamentBuilder
+} from "../../../helpers/builders/tournaments";
+import {ILayoutDataForMatch} from "../../../helpers/tournaments";
+import {createTemporaryId} from "../../../helpers/projection";
+import {matchOptionsBuilder} from "../../../helpers/builders/games";
+import {GameMatchOptionDto} from "../../../interfaces/models/dtos/Game/GameMatchOptionDto";
+
+describe('PrintableSheetMatch', () => {
+    let context: TestContext;
+    let reportedError: ErrorState;
+    let updatedTournament: TournamentGameDto;
+
+    afterEach(() => {
+        cleanUp(context);
+    });
+
+    beforeEach(() => {
+        reportedError = new ErrorState();
+        updatedTournament = null;
+    });
+
+    async function setTournamentData(update: TournamentGameDto) {
+        updatedTournament = update;
+    }
+
+    async function renderComponent(containerProps: ITournamentContainerProps, props: IPrintableSheetMatchProps, appProps: IAppContainerProps) {
+        context = await renderApp(
+            iocProps(),
+            brandingProps(),
+            appProps,
+            (<TournamentContainer {...containerProps}>
+                <PrintableSheetMatch {...props} />
+            </TournamentContainer>));
+    }
+
+    describe('renders', () => {
+        const matchOptionDefaults: GameMatchOptionDto = matchOptionsBuilder().build();
+
+        it('match mnemonic', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '',
+                scoreA: '',
+                sideA: { id: createTemporaryId(), link: null, name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: null, name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+            }, appProps({}, reportedError));
+
+            const matchMnemonic = context.container.querySelector('span[datatype="match-mnemonic"]');
+            expect(matchMnemonic).toBeTruthy();
+            expect(matchMnemonic.textContent).toEqual('M1');
+        });
+
+        it('when no match mnemonic', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '',
+                scoreA: '',
+                sideA: { id: createTemporaryId(), link: null, name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: null, name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+            }, appProps({}, reportedError));
+
+            const matchMnemonic = context.container.querySelector('span[datatype="match-mnemonic"]');
+            expect(matchMnemonic).toBeFalsy();
+        });
+
+        it('sideA', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: (<span>SIDE B</span>), name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+            }, appProps({}, reportedError));
+
+            const sideA = context.container.querySelector('div[datatype="sideA"]');
+            expect(sideA).toBeTruthy();
+            expect(sideA.querySelector('span[datatype="sideAname"]').textContent).toEqual('SIDE A');
+            expect(sideA.querySelector('div[datatype="scoreA"]').textContent).toEqual('5');
+        });
+
+        it('sideB', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: (<span>SIDE B</span>), name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+            }, appProps({}, reportedError));
+
+            const sideB = context.container.querySelector('div[datatype="sideB"]');
+            expect(sideB).toBeTruthy();
+            expect(sideB.querySelector('span[datatype="sideBname"]').textContent).toEqual('SIDE B');
+            expect(sideB.querySelector('div[datatype="scoreB"]').textContent).toEqual('7');
+        });
+
+        it('bye', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: null,
+                mnemonic: 'M1',
+                bye: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+            }, appProps({}, reportedError));
+
+            const sideB = context.container.querySelector('div[datatype="sideB"]');
+            expect(sideB).toBeFalsy();
+        });
+    });
+
+    describe('interactivity', () => {
+        const matchOptionDefaults: GameMatchOptionDto = matchOptionsBuilder().build();
+        const sideA = sideBuilder('SIDE A').build();
+        const sideB = sideBuilder('SIDE B').build();
+        const sideC = sideBuilder('SIDE C').build();
+
+        it('can change side and score for sideA', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: null, name: null, link: null },
+                sideB: { id: null, name: null, link: null },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [sideA, sideB, sideC],
+                editable: true,
+            }, appProps({}, reportedError));
+            const side = context.container.querySelector('div[datatype="sideA"]');
+            await doClick(side);
+            const dialog = context.container.querySelector('.modal-dialog');
+            await doSelectOption(dialog.querySelector('.form-group :nth-child(2) div.dropdown-menu'), 'SIDE C');
+            await doSelectOption(dialog.querySelector('.form-group :nth-child(4) div.dropdown-menu'), '1');
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(updatedTournament.round).toEqual({
+                id: expect.any(String),
+                matchOptions: expect.any(Array),
+                matches: [{
+                    id: expect.any(String),
+                    scoreA: 1,
+                    sideA: {
+                        name: 'SIDE C',
+                        id: sideC.id,
+                        players: [],
+                    },
+                    sideB: {
+                        id: null,
+                        name: null,
+                    },
+                }]
+            });
+        });
+
+        it('can change side and score for sideB', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: null, name: null, link: null },
+                sideB: { id: null, name: null, link: null },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [sideA, sideB, sideC],
+                editable: true,
+            }, appProps({}, reportedError));
+            const side = context.container.querySelector('div[datatype="sideB"]');
+            await doClick(side);
+            const dialog = context.container.querySelector('.modal-dialog');
+            await doSelectOption(dialog.querySelector('.form-group :nth-child(2) div.dropdown-menu'), 'SIDE C');
+            await doSelectOption(dialog.querySelector('.form-group :nth-child(4) div.dropdown-menu'), '1');
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(updatedTournament.round).toEqual({
+                id: expect.any(String),
+                matchOptions: expect.any(Array),
+                matches: [{
+                    id: expect.any(String),
+                    scoreB: 1,
+                    sideA: {
+                        id: null,
+                        name: null,
+                    },
+                    sideB: {
+                        name: 'SIDE C',
+                        id: sideC.id,
+                        players: [],
+                    },
+                }]
+            });
+        });
+
+        it('does not open dialog match in subsequent round when first round is not complete', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .round((r: ITournamentRoundBuilder) => r
+                        .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 5).sideB(sideB, 7))))
+                .build();
+            const nestedMatchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: (<span>SIDE B</span>), name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData: nestedMatchData,
+                matchIndex: 0,
+                roundIndex: 1,
+                possibleSides: [],
+                editable: true,
+            }, appProps({}, reportedError));
+            let alert: string;
+            window.alert = (msg) => alert = msg;
+            await doClick(context.container.querySelector('div[datatype="sideB"]'));
+
+            expect(alert).toEqual('Finish entering data for the previous rounds first');
+        });
+
+        it('can change side properties for match in subsequent round', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 5).sideB(sideC, 1))
+                    .round((r: ITournamentRoundBuilder) => r
+                        .withMatch((m: ITournamentMatchBuilder) => m.sideA(sideA, 5).sideB(sideB, 7))))
+                .build();
+            const nestedMatchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: { id: sideB.id, link: (<span>SIDE B</span>), name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData: nestedMatchData,
+                matchIndex: 0,
+                roundIndex: 1,
+                possibleSides: [sideA, sideB],
+                editable: true,
+            }, appProps({}, reportedError));
+            await doClick(context.container.querySelector('div[datatype="sideB"]'));
+            const dialog = context.container.querySelector('.modal-dialog');
+            await doSelectOption(dialog.querySelector('.form-group :nth-child(4) div.dropdown-menu'), '3');
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(updatedTournament.round.nextRound).toEqual({
+                matchOptions: expect.any(Array),
+                matches: [{
+                    id: expect.any(String),
+                    scoreA: 5,
+                    scoreB: 3,
+                    sideA: {
+                        id: sideA.id,
+                        name: sideA.name,
+                        players: [],
+                    },
+                    sideB: {
+                        id: sideB.id,
+                        name: sideB.name,
+                        players: [],
+                    },
+                }],
+                nextRound: null,
+            });
+        });
+
+        it('preselects side to mnemonic', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: null, name: null, link: null, mnemonic: sideC.name },
+                sideB: { id: null, name: null, link: null },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [sideA, sideB, sideC],
+                editable: true,
+            }, appProps({}, reportedError));
+            const side = context.container.querySelector('div[datatype="sideA"]');
+            await doClick(side);
+            const dialog = context.container.querySelector('.modal-dialog');
+            await doSelectOption(dialog.querySelector('.form-group :nth-child(4) div.dropdown-menu'), '1');
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(updatedTournament.round).toEqual({
+                id: expect.any(String),
+                matchOptions: expect.any(Array),
+                matches: [{
+                    id: expect.any(String),
+                    scoreA: 1,
+                    sideA: {
+                        name: 'SIDE C',
+                        id: sideC.id,
+                        players: [],
+                    },
+                    sideB: {
+                        id: null,
+                        name: null,
+                    },
+                }]
+            });
+        });
+
+        it('cannot save side when no side selected', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: null, name: null, link: null },
+                sideB: { id: null, name: null, link: null },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [sideA, sideB, sideC],
+                editable: true,
+            }, appProps({}, reportedError));
+            let alert: string;
+            window.alert = (msg) => alert = msg;
+            const side = context.container.querySelector('div[datatype="sideA"]');
+            await doClick(side);
+            const dialog = context.container.querySelector('.modal-dialog');
+            await doSelectOption(dialog.querySelector('.form-group :nth-child(4) div.dropdown-menu'), '1');
+            await doClick(findButton(dialog, 'Save'));
+
+            expect(alert).toEqual('Select a side first');
+            expect(updatedTournament).toEqual(null);
+        });
+
+        it('does not open edit dialog for sideA when not editable', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: (<span>SIDE B</span>), name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+                editable: false,
+            }, appProps({}, reportedError));
+            const sideB = context.container.querySelector('div[datatype="sideA"]');
+
+            await doClick(sideB);
+
+            const dialog = context.container.querySelector('.modal-dialog');
+            expect(dialog).toBeFalsy();
+        });
+
+        it('opens edit dialog for sideA', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: (<span>SIDE B</span>), name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+                editable: true,
+            }, appProps({}, reportedError));
+            const sideB = context.container.querySelector('div[datatype="sideA"]');
+
+            await doClick(sideB);
+
+            const dialog = context.container.querySelector('.modal-dialog');
+            expect(dialog).toBeTruthy();
+        });
+
+        it('does not open edit dialog for sideB when not editable', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: (<span>SIDE B</span>), name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+                editable: false,
+            }, appProps({}, reportedError));
+            const sideB = context.container.querySelector('div[datatype="sideB"]');
+
+            await doClick(sideB);
+
+            const dialog = context.container.querySelector('.modal-dialog');
+            expect(dialog).toBeFalsy();
+        });
+
+        it('opens edit dialog for sideB', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder().build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: (<span>SIDE B</span>), name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+                editable: true,
+            }, appProps({}, reportedError));
+            const sideB = context.container.querySelector('div[datatype="sideB"]');
+
+            await doClick(sideB);
+
+            const dialog = context.container.querySelector('.modal-dialog');
+            expect(dialog).toBeTruthy();
+        });
+
+        it('can unset side A', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m
+                        .sideA(sideA, 5)
+                        .sideB(sideB, 7)))
+                .build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: (<span>SIDE B</span>), name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+                editable: true,
+            }, appProps({}, reportedError));
+            await doClick(context.container.querySelector('div[datatype="sideA"]'));
+            const dialog = context.container.querySelector('.modal-dialog');
+
+            await doClick(findButton(dialog, 'Remove'));
+
+            expect(updatedTournament.round).toEqual({
+                matchOptions: expect.any(Array),
+                matches: [{
+                    id: expect.any(String),
+                    scoreA: null,
+                    scoreB: 7,
+                    sideA: {
+                        players: [],
+                    },
+                    sideB: {
+                        id: sideB.id,
+                        name: sideB.name,
+                        players: [],
+                    },
+                }],
+                nextRound: null,
+            });
+        });
+
+        it('can unset side B', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m
+                        .sideA(sideA, 5)
+                        .sideB(sideB, 7)))
+                .build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: (<span>SIDE B</span>), name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+                editable: true,
+            }, appProps({}, reportedError));
+            await doClick(context.container.querySelector('div[datatype="sideB"]'));
+            const dialog = context.container.querySelector('.modal-dialog');
+
+            await doClick(findButton(dialog, 'Remove'));
+
+            expect(updatedTournament.round).toEqual({
+                matchOptions: expect.any(Array),
+                matches: [{
+                    id: expect.any(String),
+                    scoreA: 5,
+                    scoreB: null,
+                    sideA: {
+                        id: sideA.id,
+                        name: sideA.name,
+                        players: [],
+                    },
+                    sideB: {
+                        players: [],
+                    },
+                }],
+                nextRound: null,
+            });
+        });
+
+        it('removes match when sideA and sideB unset', async () => {
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m
+                        .sideB(sideB, 7)))
+                .build();
+            const matchData: ILayoutDataForMatch = {
+                scoreB: '7',
+                scoreA: '5',
+                sideA: { id: createTemporaryId(), link: (<span>SIDE A</span>), name: '', mnemonic: 'A' },
+                sideB: { id: createTemporaryId(), link: (<span>SIDE B</span>), name: '', mnemonic: 'B' },
+                mnemonic: 'M1',
+                hideMnemonic: true,
+            };
+            await renderComponent({
+                tournamentData,
+                setTournamentData,
+                matchOptionDefaults,
+            }, {
+                matchData,
+                matchIndex: 0,
+                roundIndex: 0,
+                possibleSides: [],
+                editable: true,
+            }, appProps({}, reportedError));
+            await doClick(context.container.querySelector('div[datatype="sideB"]'));
+            const dialog = context.container.querySelector('.modal-dialog');
+
+            await doClick(findButton(dialog, 'Remove'));
+
+            expect(updatedTournament.round).toEqual({
+                matchOptions: expect.any(Array),
+                matches: [],
+                nextRound: null,
+            });
+        });
+    });
+});

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
@@ -35,12 +35,21 @@ export function PrintableSheetMatch({ matchData, possibleSides, roundIndex, matc
         text: side.name,
     }});
 
-    function changeSide(designation: 'A' | 'B') {
+    function beginEditSide(designation: 'A' | 'B') {
+        const side: ILayoutDataForSide = matchData['side' + designation];
         const editSide: IEditSide = {
-            sideId: designation === 'A' ? matchData.sideA.id : matchData.sideB.id,
+            sideId: side.id,
             score: designation === 'A' ? matchData.scoreA : matchData.scoreB,
             designation: designation,
         };
+
+        if (!editSide.sideId && side.mnemonic) {
+            // find the side with this name
+            const preSelectSide: IBootstrapDropdownItem = possibleSideOptions.filter(o => o.text === side.mnemonic)[0];
+            if (preSelectSide) {
+                editSide.sideId = preSelectSide.value;
+            }
+        }
 
         setEditSide(editSide);
     }
@@ -171,7 +180,7 @@ export function PrintableSheetMatch({ matchData, possibleSides, roundIndex, matc
                 : null}
             {matchData.bye ? (<div className="position-absolute-bottom-right">Bye</div>) : null}
             <div datatype="sideA"
-                 onClick={editable ? () => changeSide('A') : null}
+                 onClick={editable ? () => beginEditSide('A') : null}
                  className={`d-flex flex-row justify-content-between p-2 min-width-150 ${matchData.winner === 'sideA' ? 'bg-winner fw-bold' : ''}`}>
                 {renderSide(matchData.sideA, 'A')}
                 <div datatype="scoreA">{matchData.scoreA || ''}</div>
@@ -187,7 +196,7 @@ export function PrintableSheetMatch({ matchData, possibleSides, roundIndex, matc
             {matchData.bye
                 ? null
                 : (<div datatype="sideB"
-                        onClick={editable ? () => changeSide('B') : null}
+                        onClick={editable ? () => beginEditSide('B') : null}
                         className={`d-flex flex-row justify-content-between p-2 min-width-150 ${matchData.winner === 'sideB' ? 'bg-winner fw-bold' : ''}`}>
                     {renderSide(matchData.sideB, 'B')}
                     <div datatype="scoreB">{matchData.scoreB || ''}</div>

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
@@ -13,7 +13,6 @@ import {createTemporaryId, repeat} from "../../../helpers/projection";
 
 export interface IPrintableSheetMatchProps {
     matchData: ILayoutDataForMatch;
-    noOfMatches: number;
     roundIndex: number;
     matchIndex: number;
     possibleSides: TournamentSideDto[];
@@ -209,7 +208,7 @@ export function PrintableSheetMatch({ matchData, possibleSides, roundIndex, matc
         <div datatype="match"
                      className={`p-0 border-solid border-1 m-1 position-relative ${matchData.bye ? 'opacity-50' : ''}`}>
             {matchData.mnemonic && !matchData.hideMnemonic
-                ? (<span className="position-absolute right-0 opacity-75">
+                ? (<span datatype="match-mnemonic" className="position-absolute right-0 opacity-75">
                         <span className="small rounded-circle bg-secondary opacity-75 text-light p-1 position-absolute" style={{left: -10, top: -10}}>
                             {matchData.mnemonic}
                         </span>

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
@@ -61,7 +61,7 @@ export function PrintableSheetMatch({ matchData, possibleSides, roundIndex, matc
         const side: ILayoutDataForSide = matchData['side' + designation];
         const editSide: IEditSide = {
             sideId: side.id,
-            score: designation === 'A' ? matchData.scoreA : matchData.scoreB,
+            score: (designation === 'A' ? matchData.scoreA : matchData.scoreB) || '0',
             designation: designation,
         };
 
@@ -78,7 +78,7 @@ export function PrintableSheetMatch({ matchData, possibleSides, roundIndex, matc
 
     function renderSide(side: ILayoutDataForSide, type: 'A' | 'B') {
         return <div className="no-wrap pe-3">
-            {side.link ? (<span datatype={`side${type}name`}>{side.link}</span>) : (<span datatype={`side${type}name`}>&nbsp;</span>)}
+            {side.link && !editable ? (<span datatype={`side${type}name`}>{side.link}</span>) : (<span datatype={`side${type}name`}>{side.name}</span>)}
             {side.mnemonic ? <span className="text-secondary-50 opacity-75 small" datatype={`side${type}mnemonic`}>{side.mnemonic}</span> : null}
         </div>
     }

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
@@ -8,8 +8,8 @@ export interface IPrintableSheetMatchProps {
 export function PrintableSheetMatch({ matchData, noOfMatches } : IPrintableSheetMatchProps) {
     function renderSide(side: ILayoutDataForSide, type: string) {
         return <div className="no-wrap pe-3" datatype={type + 'name'}>
-            {side.link || (<span>&nbsp;</span>)}
-            {side.mnemonic ? <span className="text-secondary-50 opacity-75 small">{side.mnemonic}</span> : null}
+            {side.link ? (<span datatype={`side${type}name`}>{side.link}</span>) : (<span datatype={`side${type}name`}>&nbsp;</span>)}
+            {side.mnemonic ? <span className="text-secondary-50 opacity-75 small" datatype={`side${type}mnemonic`}>{side.mnemonic}</span> : null}
         </div>
     }
 
@@ -23,7 +23,7 @@ export function PrintableSheetMatch({ matchData, noOfMatches } : IPrintableSheet
         {matchData.bye ? (<div className="position-absolute-bottom-right">Bye</div>) : null}
         <div datatype="sideA"
              className={`d-flex flex-row justify-content-between p-2 min-width-150 ${matchData.winner === 'sideA' ? 'bg-winner fw-bold' : ''}`}>
-            {renderSide(matchData.sideA, 'sideA')}
+            {renderSide(matchData.sideA, 'A')}
             <div datatype="scoreA">{matchData.scoreA || ''}</div>
         </div>
         {matchData.bye ? null : (<div className="text-center dotted-line-through">
@@ -38,7 +38,7 @@ export function PrintableSheetMatch({ matchData, noOfMatches } : IPrintableSheet
             ? null
             : (<div datatype="sideB"
                     className={`d-flex flex-row justify-content-between p-2 min-width-150 ${matchData.winner === 'sideB' ? 'bg-winner fw-bold' : ''}`}>
-                {renderSide(matchData.sideB, 'sideB')}
+                {renderSide(matchData.sideB, 'B')}
                 <div datatype="scoreB">{matchData.scoreB || ''}</div>
             </div>)}
     </div>);

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
@@ -1,0 +1,45 @@
+import {ILayoutDataForMatch, ILayoutDataForSide} from "../../../helpers/tournaments";
+
+export interface IPrintableSheetMatchProps {
+    matchData: ILayoutDataForMatch;
+    noOfMatches: number;
+}
+
+export function PrintableSheetMatch({ matchData, noOfMatches } : IPrintableSheetMatchProps) {
+    function renderSide(side: ILayoutDataForSide, type: string) {
+        return <div className="no-wrap pe-3" datatype={type + 'name'}>
+            {side.link || (<span>&nbsp;</span>)}
+            {side.mnemonic ? <span className="text-secondary-50 opacity-75 small">{side.mnemonic}</span> : null}
+        </div>
+    }
+
+    return (<div datatype="match" className={`p-0 border-solid border-1 m-1 position-relative ${matchData.bye ? 'opacity-50' : ''}`}>
+        {matchData.mnemonic && noOfMatches > 1 && !matchData.hideMnemonic ? (
+            <span className="position-absolute right-0 opacity-75">
+                                    <span
+                                        className="small rounded-circle bg-secondary opacity-75 text-light p-1 position-absolute"
+                                        style={{left: -10, top: -10}}>{matchData.mnemonic}</span>
+                                </span>) : null}
+        {matchData.bye ? (<div className="position-absolute-bottom-right">Bye</div>) : null}
+        <div datatype="sideA"
+             className={`d-flex flex-row justify-content-between p-2 min-width-150 ${matchData.winner === 'sideA' ? 'bg-winner fw-bold' : ''}`}>
+            {renderSide(matchData.sideA, 'sideA')}
+            <div datatype="scoreA">{matchData.scoreA || ''}</div>
+        </div>
+        {matchData.bye ? null : (<div className="text-center dotted-line-through">
+                                    <span className="px-3 bg-white position-relative">
+                                        vs
+                                        {matchData.saygId ? (
+                                            <a href={`/live/match/${matchData.saygId}`} target="_blank" rel="noreferrer"
+                                               className="margin-left no-underline">👁️</a>) : null}
+                                    </span>
+        </div>)}
+        {matchData.bye
+            ? null
+            : (<div datatype="sideB"
+                    className={`d-flex flex-row justify-content-between p-2 min-width-150 ${matchData.winner === 'sideB' ? 'bg-winner fw-bold' : ''}`}>
+                {renderSide(matchData.sideB, 'sideB')}
+                <div datatype="scoreB">{matchData.scoreB || ''}</div>
+            </div>)}
+    </div>);
+}

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
@@ -2,14 +2,14 @@ import {ILayoutDataForMatch, ILayoutDataForSide} from "../../../helpers/tourname
 import {useState} from "react";
 import {Dialog} from "../../common/Dialog";
 import {BootstrapDropdown, IBootstrapDropdownItem} from "../../common/BootstrapDropdown";
-import {propChanged, valueChanged} from "../../../helpers/events";
+import {propChanged} from "../../../helpers/events";
 import {TournamentSideDto} from "../../../interfaces/models/dtos/Game/TournamentSideDto";
 import {useTournament} from "./TournamentContainer";
 import {sortBy} from "../../../helpers/collections";
 import {TournamentGameDto} from "../../../interfaces/models/dtos/Game/TournamentGameDto";
 import {TournamentRoundDto} from "../../../interfaces/models/dtos/Game/TournamentRoundDto";
 import {TournamentMatchDto} from "../../../interfaces/models/dtos/Game/TournamentMatchDto";
-import {createTemporaryId} from "../../../helpers/projection";
+import {createTemporaryId, repeat} from "../../../helpers/projection";
 
 export interface IPrintableSheetMatchProps {
     matchData: ILayoutDataForMatch;
@@ -34,6 +34,12 @@ export function PrintableSheetMatch({ matchData, possibleSides, roundIndex, matc
         value: side.id,
         text: side.name,
     }});
+    const possibleScoreOptions: IBootstrapDropdownItem[] = repeat(Math.ceil(bestOf / 2) + 1, (index: number): IBootstrapDropdownItem => {
+        return {
+            value: index,
+            text: index
+        };
+    })
 
     function beginEditSide(designation: 'A' | 'B') {
         const side: ILayoutDataForSide = matchData['side' + designation];
@@ -150,8 +156,14 @@ export function PrintableSheetMatch({ matchData, possibleSides, roundIndex, matc
                 <div className="input-group-prepend">
                     <span className="input-group-text">Score</span>
                 </div>
-                <input className="form-control" type="number" min="0" max={Math.ceil(bestOf / 2)}
-                       value={editSide.score || ''} name="score" onChange={valueChanged(editSide, setEditSide)}/>
+                <BootstrapDropdown
+                    value={editSide.score}
+                    options={possibleScoreOptions}
+                    slim={true}
+                    onChange={propChanged(editSide, setEditSide, 'score')} />
+            </div>
+            <div>
+                Best of {bestOf} legs
             </div>
             <div className="modal-footer px-0 pb-0 mt-3">
                 <div className="left-aligned mx-0">

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/PrintableSheetMatch.tsx
@@ -110,6 +110,11 @@ export function PrintableSheetMatch({ matchData, possibleSides, roundIndex, matc
     }
 
     async function onSave() {
+        if (!editSide.sideId) {
+            window.alert('Select a side first');
+            return;
+        }
+
         const newTournamentData: TournamentGameDto = Object.assign({}, tournamentData);
         const newRound: TournamentRoundDto = getEditableRound(newTournamentData, true);
 

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/Tournament.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/Tournament.test.tsx
@@ -251,7 +251,7 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, true);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const container = context.container.querySelector('.content-background');
                 expect(container).toBeTruthy();
                 expect(container.className).toContain('loading-background');
@@ -268,8 +268,7 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, false);
 
-                expect(reportedError.hasError()).toEqual(true);
-                expect(reportedError.error).toEqual('Tournament could not be found');
+                reportedError.verifyErrorEquals('Tournament could not be found');
                 expect(context.container.textContent).toContain('Tournament not found');
             });
 
@@ -295,8 +294,10 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, false);
 
-                expect(reportedError.hasError()).toEqual(true);
-                expect(reportedError.error.message).toEqual('Could not find the season for this tournament');
+                reportedError.verifyErrorEquals({
+                    message: 'Could not find the season for this tournament',
+                    stack: expect.any(String),
+                });
             });
 
             it('tournament without any sides', async () => {
@@ -324,7 +325,7 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, false);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('.content-background div[datatype="heading"]');
                 expect(heading).toBeTruthy();
                 expect(heading.textContent).toContain('TYPE at ADDRESS on 2 Jan - NOTES🔗🖨️');
@@ -356,7 +357,7 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, false);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const heading = context.container.querySelector('.content-background div[datatype="heading"]');
                 expect(heading).toBeTruthy();
                 expect(heading.textContent).toContain('TYPE at ADDRESS on 2 Jan - NOTES🔗🖨️');
@@ -391,7 +392,7 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, false);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const printableSheet = context.container.querySelector('div[datatype="printable-sheet"]');
                 expect(printableSheet).toBeTruthy();
             });
@@ -434,8 +435,7 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, false);
 
-                expect(reportedError.hasError()).toEqual(true);
-                expect(reportedError.error).toEqual('No seasons found');
+                reportedError.verifyErrorEquals('No seasons found');
             });
 
             it('loading', async () => {
@@ -459,7 +459,7 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, true);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const container = context.container.querySelector('.content-background');
                 expect(container).toBeTruthy();
                 expect(container.className).toContain('loading-background');
@@ -486,7 +486,7 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, false);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 // address
                 const address = context.container.querySelector('.content-background > div:nth-child(2)');
                 expect(address).toBeTruthy();
@@ -534,7 +534,7 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, false);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const editTournamentComponent = context.container.querySelector('.content-background > div:nth-child(6)');
                 expect(editTournamentComponent).toBeTruthy();
                 expect(editTournamentComponent.textContent).toContain('Playing:');
@@ -567,7 +567,7 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, false);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const superLeagueOptions = context.container.querySelector('div[datatype="tournament-options"]');
                 expect(superLeagueOptions).toBeTruthy();
                 const hostInput = superLeagueOptions.querySelector('input[name="host"]') as HTMLInputElement;
@@ -603,7 +603,7 @@ describe('Tournament', () => {
                     divisions: [division],
                 }, false);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(context.container.querySelector('div[data-options-for="superleague"]')).toBeFalsy();
             });
         });
@@ -692,7 +692,7 @@ describe('Tournament', () => {
             await doSelectOption(addPlayerDialog.querySelector('.dropdown-menu'), 'TEAM');
             await doClick(findButton(addPlayerDialog, 'Add player'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createdPlayer).not.toBeNull();
             expect(createdPlayer.teamId).toEqual(team.id);
             expect(createdPlayer.seasonId).toEqual(tournamentData.seasonId);
@@ -1216,7 +1216,7 @@ describe('Tournament', () => {
                 divisions: [division],
             }, false);
             (window as any).open = noop;
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, '🛒'));
 
@@ -1331,13 +1331,13 @@ describe('Tournament', () => {
                 divisions: [division],
             }, false);
             await doClick(findButton(context.container, '📊'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             apiResponse = {success: true, result: tournamentData};
 
             await doChange(context.container, 'input[data-score-input="true"]', '50', context.user);
             await doClick(findButton(context.container, '📌📌📌'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(patchedTournamentData).toEqual([{
                 data: {
                     round: {
@@ -1394,13 +1394,13 @@ describe('Tournament', () => {
                 divisions: [division],
             }, false);
             await doClick(findButton(context.container, '📊'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             apiResponse = {success: true, result: tournamentData};
 
             await doChange(context.container, 'input[data-score-input="true"]', '180', context.user);
             await doClick(findButton(context.container, '📌📌📌'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(patchedTournamentData).toEqual([{
                 data: {
                     additional180: playerA,
@@ -1451,13 +1451,13 @@ describe('Tournament', () => {
                 divisions: [division],
             }, false);
             await doClick(findButton(context.container, '📊'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             apiResponse = {success: true, result: tournamentData};
 
             await doChange(context.container, 'input[data-score-input="true"]', '100', context.user);
             await doClick(findButton(context.container, '📌📌📌'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(patchedTournamentData).toEqual([{
                 data: {
                     additionalOver100Checkout: {
@@ -1524,13 +1524,13 @@ describe('Tournament', () => {
                 divisions: [division],
             }, false);
             await doClick(findButton(context.container, '📊'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             apiResponse = {success: false, errors: ['SOME ERROR']};
 
             await doChange(context.container, 'input[data-score-input="true"]', '180', context.user);
             await doClick(findButton(context.container, '📌📌📌'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(patchedTournamentData).not.toBeNull();
             expect(context.container.textContent).toContain('Could not save tournament details');
             expect(context.container.textContent).toContain('SOME ERROR');
@@ -1564,7 +1564,7 @@ describe('Tournament', () => {
             const dialog = context.container.querySelector('.modal-dialog');
             await doClick(dialog.querySelector('.list-group-item')); // click on a player
             await doClick(findButton(dialog, 'Save')); // close the dialog
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             const oneEightiesDropdown = context.container.querySelector('td[datatype="180s"] .dropdown-menu');
             const oneEightyPlayers = Array.from(oneEightiesDropdown.querySelectorAll('.dropdown-item'));
@@ -1599,7 +1599,7 @@ describe('Tournament', () => {
             const dialog = context.container.querySelector('.modal-dialog');
             await doClick(dialog.querySelector('.list-group-item')); // click on a player
             await doClick(findButton(dialog, 'Save')); // close the dialog
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             const hiCheckDropdown = context.container.querySelector('td[datatype="hiChecks"] .dropdown-menu');
             const hiCheckPlayers = Array.from(hiCheckDropdown.querySelectorAll('.dropdown-item'));
@@ -1635,7 +1635,7 @@ describe('Tournament', () => {
             await doClick(findButton(context.container.querySelector('div:nth-child(6)'), '✏️')); // open edit side dialog
             const dialog = context.container.querySelector('.modal-dialog');
             await doClick(findButton(dialog, 'Delete side')); // delete the side
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             const oneEightyDropdown = context.container.querySelector('td[datatype="180s"] .dropdown-menu');
             expect(oneEightyDropdown).toBeFalsy();
@@ -1670,7 +1670,7 @@ describe('Tournament', () => {
             await doClick(findButton(context.container.querySelector('div:nth-child(6)'), '✏️')); // open edit side dialog
             const dialog = context.container.querySelector('.modal-dialog');
             await doClick(findButton(dialog, 'Delete side')); // delete the side
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             const hiCheckDropdown = context.container.querySelector('td[datatype="hiChecks"] .dropdown-menu');
             expect(hiCheckDropdown).toBeFalsy();

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/Tournament.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/Tournament.tsx
@@ -50,10 +50,8 @@ export function Tournament() {
     const canManageTournaments: boolean = account && account.access && account.access.manageTournaments;
     const canManagePlayers: boolean = account && account.access && account.access.managePlayers;
     const [loading, setLoading] = useState<string>('init');
-    const [disabled, setDisabled] = useState<boolean>(false);
     const [saving, setSaving] = useState<boolean>(false);
     const [patching, setPatching] = useState<boolean>(false);
-    const [canSave, setCanSave] = useState<boolean>(true);
     const [tournamentData, setTournamentData] = useState<TournamentGameDto | null>(null);
     const [saveError, setSaveError] = useState<IClientActionResultDto<TournamentGameDto> | null>(null);
     const [allPlayers, setAllPlayers] = useState<ISelectablePlayer[]>([]);
@@ -67,12 +65,6 @@ export function Tournament() {
         {text: 'Men', value: 'men'},
         {text: 'Women',value: 'women'}
     ];
-
-    useEffect(() => {
-        const isAdmin = (account && account.access && account.access.manageTournaments);
-        setDisabled(!isAdmin || false);
-        setCanSave(isAdmin || false);
-    }, [account]);
 
     useEffect(() => {
             /* istanbul ignore next */
@@ -217,7 +209,7 @@ export function Tournament() {
     }
 
     async function publishLiveUpdate(data: TournamentGameDto) {
-        if (canSave) {
+        if (canManageTournaments) {
             await webSocket.publish(tournamentId, data);
         }
     }
@@ -316,7 +308,7 @@ export function Tournament() {
         }
 
         const liveOptions: ILiveOptions = {
-            publish: canSave,
+            publish: canManageTournaments,
             canSubscribe: false,
             subscribeAtStartup: [],
         };
@@ -442,12 +434,11 @@ export function Tournament() {
                     setWarnBeforeSave={async (warning: string) => setWarnBeforeSave(warning)}
                     matchOptionDefaults={getMatchOptionDefaults(tournamentData)}
                     liveOptions={liveOptions}>
-                    {canSave ? (<EditTournament disabled={disabled} canSave={canSave} saving={saving}
-                                                applyPatch={applyPatch}/>) : null}
-                    {tournamentData.singleRound && !canSave ? (<SuperLeaguePrintout division={division}/>) : null}
-                    {tournamentData.singleRound && canSave ? (
+                    {canManageTournaments ? (<EditTournament canSave={true} saving={saving} applyPatch={applyPatch}/>) : null}
+                    {tournamentData.singleRound && !canManageTournaments ? (<SuperLeaguePrintout division={division}/>) : null}
+                    {tournamentData.singleRound && canManageTournaments ? (
                         <div className="d-screen-none"><SuperLeaguePrintout division={division}/></div>) : null}
-                    {!tournamentData.singleRound ? (<PrintableSheet printOnly={canSave}/>) : null}
+                    {!tournamentData.singleRound ? (<PrintableSheet printOnly={canManageTournaments}/>) : null}
                 </TournamentContainer>
                 {canManageTournaments ? (
                     <button className="btn btn-primary d-print-none margin-right" onClick={saveTournament}>

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/Tournament.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/Tournament.tsx
@@ -49,6 +49,7 @@ export function Tournament() {
     const {divisionApi, tournamentApi, webSocket} = useDependencies();
     const canManageTournaments: boolean = account && account.access && account.access.manageTournaments;
     const canManagePlayers: boolean = account && account.access && account.access.managePlayers;
+    const canEnterTournamentResults = account && account.access && account.access.enterTournamentResults;
     const [loading, setLoading] = useState<string>('init');
     const [saving, setSaving] = useState<boolean>(false);
     const [patching, setPatching] = useState<boolean>(false);
@@ -436,9 +437,10 @@ export function Tournament() {
                     liveOptions={liveOptions}>
                     {canManageTournaments ? (<EditTournament canSave={true} saving={saving} applyPatch={applyPatch}/>) : null}
                     {tournamentData.singleRound && !canManageTournaments ? (<SuperLeaguePrintout division={division}/>) : null}
-                    {tournamentData.singleRound && canManageTournaments ? (
-                        <div className="d-screen-none"><SuperLeaguePrintout division={division}/></div>) : null}
-                    {!tournamentData.singleRound ? (<PrintableSheet printOnly={canManageTournaments}/>) : null}
+                    {tournamentData.singleRound && canManageTournaments ? (<div className="d-screen-none">
+                        <SuperLeaguePrintout division={division}/>
+                    </div>) : null}
+                    {!tournamentData.singleRound ? (<PrintableSheet printOnly={canManageTournaments} editable={canEnterTournamentResults} />) : null}
                 </TournamentContainer>
                 {canManageTournaments ? (
                     <button className="btn btn-primary d-print-none margin-right" onClick={saveTournament}>

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/TournamentRound.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/TournamentRound.test.tsx
@@ -173,7 +173,7 @@ describe('TournamentRound', () => {
                     onHiCheck,
                 });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(context.container.textContent).toContain('No matches defined');
             });
 
@@ -192,7 +192,7 @@ describe('TournamentRound', () => {
                     onHiCheck,
                 });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(context.container.querySelector('div > strong').textContent).toEqual('Semi-Final');
                 const table = context.container.querySelector('table');
                 assertMatch(table, 1, ['SIDE 1', '', 'vs', '', 'SIDE 2']);
@@ -214,7 +214,7 @@ describe('TournamentRound', () => {
                     onHiCheck,
                 });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(context.container.querySelector('div > strong').textContent).toEqual('Semi-Final');
                 const table = context.container.querySelector('table');
                 assertMatch(table, 1, ['SIDE 1', '1', 'vs', '2', 'SIDE 2']);
@@ -242,7 +242,7 @@ describe('TournamentRound', () => {
                     onHiCheck,
                 });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(context.container.querySelector('div > strong').textContent).toEqual('Semi-Final');
                 const roundTables = context.container.querySelectorAll('table');
                 assertMatch(roundTables[0], 1, ['SIDE 1', '1', 'vs', '2', 'SIDE 2']);
@@ -283,7 +283,7 @@ describe('TournamentRound', () => {
                 onHiCheck,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(Array.from(context.container.querySelectorAll('div > strong')).map(s => s.textContent)).toEqual(['Quarter-Final', 'Semi-Final']);
             const roundTables = context.container.querySelectorAll('table');
             assertMatch(roundTables[0], 1, ['SIDE 1', '1', 'vs', '2', 'SIDE 2']);
@@ -313,7 +313,7 @@ describe('TournamentRound', () => {
                 onHiCheck,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('div > strong').textContent).toEqual('Semi-Final');
             const roundTables = context.container.querySelectorAll('table');
             expect(roundTables.length).toEqual(1);
@@ -331,7 +331,7 @@ describe('TournamentRound', () => {
                 patchData,
                 onHiCheck,
             });
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(context.container.querySelector('strong'));
 
@@ -366,7 +366,7 @@ describe('TournamentRound', () => {
                     onHiCheck,
                 });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(context.container.querySelector('table')).toBeTruthy();
             });
 
@@ -385,7 +385,7 @@ describe('TournamentRound', () => {
                     onHiCheck,
                 });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(context.container.querySelector('div > strong').textContent).toEqual('Semi-Final');
                 const table = context.container.querySelector('table');
                 assertEditableMatch(table, 1, ['SIDE 1', '', 'vs', '', 'SIDE 2', '🗑🛠']);
@@ -413,7 +413,7 @@ describe('TournamentRound', () => {
                         onHiCheck,
                     });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(context.container.querySelector('div > strong').textContent).toEqual('Semi-Final');
                 const table = context.container.querySelector('table');
                 assertEditableMatch(table, 1, ['SIDE 1', '1', 'vs', '2', 'SIDE 2', '🗑🛠']);
@@ -441,7 +441,7 @@ describe('TournamentRound', () => {
                     onHiCheck,
                 });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(context.container.querySelector('div > strong').textContent).toEqual('Semi-Final');
                 const roundTables = context.container.querySelectorAll('table');
                 assertEditableMatch(roundTables[0], 1, ['SIDE 1', '1', 'vs', '2', 'SIDE 2']);
@@ -488,7 +488,7 @@ describe('TournamentRound', () => {
                         onHiCheck,
                     });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(Array.from(context.container.querySelectorAll('div > strong')).map(s => s.textContent)).toEqual(['Quarter-Final', 'Semi-Final', 'Final']);
                 const roundTables = context.container.querySelectorAll('table');
                 assertMatch(roundTables[0], 1, ['SIDE 1', '1', 'vs', '2', 'SIDE 2']);
@@ -519,7 +519,7 @@ describe('TournamentRound', () => {
                     onHiCheck,
                 });
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(context.container.querySelector('div > strong').textContent).toEqual('Semi-Final');
                 const roundTables = context.container.querySelectorAll('table');
                 expect(roundTables.length).toEqual(1);
@@ -547,13 +547,13 @@ describe('TournamentRound', () => {
                         patchData,
                         onHiCheck,
                     });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
                 window.confirm = () => true;
 
                 await doClick(findButton(matchRow, '🗑'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedRound).toEqual({
                     matches: [],
                     matchOptions: [],
@@ -580,13 +580,13 @@ describe('TournamentRound', () => {
                         patchData,
                         onHiCheck,
                     });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
                 const sideAScore = matchRow.querySelector('td:nth-child(2)');
 
                 await doChange(sideAScore, 'input', '2', context.user);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedRound).toEqual({
                     matches: [{
                         id: match.id,
@@ -619,13 +619,13 @@ describe('TournamentRound', () => {
                         patchData,
                         onHiCheck,
                     });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
                 const sideBScore = matchRow.querySelector('td:nth-child(4)');
 
                 await doChange(sideBScore, 'input', '2', context.user);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedRound).toEqual({
                     matches: [{
                         id: match.id,
@@ -658,7 +658,7 @@ describe('TournamentRound', () => {
                         patchData,
                         onHiCheck,
                     });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
 
                 await doClick(findButton(matchRow, '🛠'));
@@ -667,7 +667,7 @@ describe('TournamentRound', () => {
                 await doChange(matchOptionsDialog, 'input[name="startingScore"]', '123', context.user);
                 await doClick(findButton(matchOptionsDialog, 'Close'));
                 expect(context.container.querySelector('.modal-dialog')).toBeFalsy();
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedRound).not.toBeNull();
                 expect(updatedRound.matchOptions).toEqual([{
                     startingScore: 123,
@@ -703,7 +703,7 @@ describe('TournamentRound', () => {
                         onHiCheck,
                     },
                     permittedAccount);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
 
                 expect(matchRow.textContent).not.toContain('📊');
@@ -738,11 +738,11 @@ describe('TournamentRound', () => {
                         onHiCheck,
                     },
                     permittedAccount);
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
 
                 await doClick(findButton(matchRow, '📊'));
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const saygDialog = context.container.querySelector('.modal-dialog');
                 expect(saygDialog).toBeTruthy();
             });
@@ -766,13 +766,13 @@ describe('TournamentRound', () => {
                         patchData,
                         onHiCheck,
                     });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
                 const sideA = matchRow.querySelector('td:nth-child(1)');
 
                 await doSelectOption(sideA.querySelector('.dropdown-menu'), 'SIDE 3');
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedRound).toEqual({
                     matches: [{
                         id: match.id,
@@ -805,13 +805,13 @@ describe('TournamentRound', () => {
                         patchData,
                         onHiCheck,
                     });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
                 const sideB = matchRow.querySelector('td:nth-child(5)');
 
                 await doSelectOption(sideB.querySelector('.dropdown-menu'), 'SIDE 3');
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedRound).toEqual({
                     matches: [{
                         id: match.id,
@@ -836,7 +836,7 @@ describe('TournamentRound', () => {
                     patchData,
                     onHiCheck,
                 });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
                 let message: string;
                 window.alert = (msg) => message = msg;
@@ -859,7 +859,7 @@ describe('TournamentRound', () => {
                     patchData,
                     onHiCheck,
                 });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
                 let message: string;
                 window.alert = (msg) => message = msg;
@@ -889,7 +889,7 @@ describe('TournamentRound', () => {
                         patchData,
                         onHiCheck,
                     });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
 
                 await doSelectOption(matchRow.querySelector('td:nth-child(1) .dropdown-menu'), 'SIDE 1');
@@ -919,7 +919,7 @@ describe('TournamentRound', () => {
                     patchData,
                     onHiCheck,
                 });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
 
                 await doSelectOption(matchRow.querySelector('td:nth-child(1) .dropdown-menu'), 'SIDE 1');
@@ -951,7 +951,7 @@ describe('TournamentRound', () => {
                     patchData,
                     onHiCheck,
                 });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const roundTables = context.container.querySelectorAll('table');
                 const subMatchRow = roundTables[1].querySelector('tr:nth-child(1)');
 
@@ -988,7 +988,7 @@ describe('TournamentRound', () => {
                     patchData,
                     onHiCheck,
                 });
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
 
                 const roundTables = Array.from(context.container.querySelectorAll('table'));
                 expect(roundTables.length).toEqual(2);
@@ -1031,10 +1031,10 @@ describe('TournamentRound', () => {
                     },
                     permittedAccount);
                 saygApiData[saygData.id] = saygData;
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
                 await doClick(findButton(matchRow, '📊'));
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const saygDialog = context.container.querySelector('.modal-dialog');
                 expect(saygDialog.querySelector('[data-name="data-error"]')).toBeFalsy();
                 await doChange(saygDialog, 'input[data-score-input="true"]', '180', context.user);
@@ -1080,10 +1080,10 @@ describe('TournamentRound', () => {
                     },
                     permittedAccount);
                 saygApiData[saygData.id] = saygData;
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
                 await doClick(findButton(matchRow, '📊'));
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const saygDialog = context.container.querySelector('.modal-dialog');
                 expect(saygDialog.querySelector('[data-name="data-error"]')).toBeFalsy();
                 await doChange(saygDialog, 'input[data-score-input="true"]', '150', context.user);
@@ -1134,17 +1134,17 @@ describe('TournamentRound', () => {
                     },
                     permittedAccount);
                 saygApiData[saygData.id] = saygData;
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
                 await doClick(findButton(matchRow, '📊'));
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const saygDialog = context.container.querySelector('.modal-dialog');
                 expect(saygDialog.querySelector('[data-name="data-error"]')).toBeFalsy();
 
                 await doChange(saygDialog, 'input[data-score-input="true"]', '51', context.user);
                 await doClick(findButton(saygDialog, '📌📌📌'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(patchedData).toEqual({
                     nestInRound: true,
                     patch: {
@@ -1215,18 +1215,18 @@ describe('TournamentRound', () => {
                     permittedAccount);
                 saygApiData[saygData.id] = saygData;
                 saygApiData[nestedSaygData.id] = nestedSaygData;
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const secondRoundTable = context.container.querySelectorAll('table')[1];
                 const matchRow = secondRoundTable.querySelector('tr:nth-child(1)');
                 await doClick(findButton(matchRow, '📊'));
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const saygDialog = context.container.querySelector('.modal-dialog');
                 expect(saygDialog.querySelector('[data-name="data-error"]')).toBeFalsy();
 
                 await doChange(saygDialog, 'input[data-score-input="true"]', '41', context.user);
                 await doClick(findButton(saygDialog, '📌📌📌'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(patchedData).toEqual({
                     nestInRound: true,
                     patch: {

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/TournamentRoundMatch.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/TournamentRoundMatch.test.tsx
@@ -218,7 +218,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells.length).toEqual(5);
                 expect(cells[0].textContent).toEqual('SIDE A');
@@ -246,7 +246,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells.length).toEqual(5);
                 expect(cells[0].textContent).toEqual('SIDE A');
@@ -274,7 +274,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells.length).toEqual(5);
                 expect(cells[0].className).toContain('bg-winner');
@@ -301,7 +301,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells.length).toEqual(5);
                 expect(cells[1].textContent).toEqual('3');
@@ -326,7 +326,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells.length).toEqual(5);
                 expect(cells[0].className).not.toContain('bg-winner');
@@ -353,7 +353,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells.length).toEqual(5);
                 expect(cells[1].textContent).toEqual('0');
@@ -378,7 +378,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells.length).toEqual(5);
                 expect(cells[0].textContent).toEqual('SIDE A');
@@ -406,7 +406,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells[0].textContent).not.toContain('📊');
             });
@@ -479,7 +479,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells.length).toEqual(6);
                 assertDropdown(cells[0], 'SIDE A', ['SIDE A', 'SIDE B', 'SIDE E']);
@@ -507,7 +507,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells[5].textContent).toContain('🛠');
             });
@@ -535,7 +535,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells[0].textContent).toContain('📊');
             });
@@ -560,7 +560,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells[0].textContent).toContain('📊');
             });
@@ -591,7 +591,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells[0].textContent).not.toContain('📊');
             });
@@ -616,7 +616,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells[0].textContent).not.toContain('📊');
             });
@@ -639,7 +639,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells.length).toEqual(6);
                 assertScore(cells[1], '3');
@@ -664,7 +664,7 @@ describe('TournamentRoundMatch', () => {
                     onMatchOptionsChanged,
                 }, account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('tr td'));
                 expect(cells.length).toEqual(6);
                 assertScore(cells[1], '0');
@@ -756,7 +756,7 @@ describe('TournamentRoundMatch', () => {
 
             await doClick(findButton(cells[0], '📊'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
             expect(dialog.textContent).toContain('SIDE A vs SIDE B');
@@ -804,7 +804,7 @@ describe('TournamentRoundMatch', () => {
 
             await doClick(findButton(cells[0], '📊'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).toContain('SOME ERROR');
             expect(context.container.textContent).toContain('Could not create sayg session');
         });
@@ -893,7 +893,7 @@ describe('TournamentRoundMatch', () => {
 
             await doClick(findButton(cells[0], '📊'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createdSaygSessions.length).toEqual(0);
             expect(message).toEqual('Save the tournament first');
         });
@@ -938,7 +938,7 @@ describe('TournamentRoundMatch', () => {
 
             await doClick(findButton(cells[0], '📊'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(createdSaygSessions.length).toEqual(0);
             expect(message).toEqual('Game has already been played; cannot score as you go');
         });
@@ -983,7 +983,7 @@ describe('TournamentRoundMatch', () => {
             await doClick(findButton(cells[0], '📊'));
             expect(context.container.querySelector('.modal-dialog')).toBeTruthy();
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             await doClick(findButton(context.container.querySelector('.modal-dialog'), 'Close'));
 
             expect(context.container.querySelector('.modal-dialog')).toBeFalsy();
@@ -1017,7 +1017,7 @@ describe('TournamentRoundMatch', () => {
 
             await doClick(findButton(cells[0], '📊'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
             expect(dialog.textContent).toContain('SIDE A vs SIDE B');
@@ -1067,7 +1067,7 @@ describe('TournamentRoundMatch', () => {
 
             await doClick(findButton(cells[0], 'Delete sayg'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeFalsy();
             expect(deletedSayg).toEqual({
@@ -1121,7 +1121,7 @@ describe('TournamentRoundMatch', () => {
 
             await doClick(findButton(cells[0], 'Delete sayg'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
             expect(deletedSayg).toBeNull();
@@ -1207,12 +1207,12 @@ describe('TournamentRoundMatch', () => {
                 .build();
             const cells = Array.from(context.container.querySelectorAll('tr td'));
             await doClick(findButton(cells[0], '📊'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             const dialog = context.container.querySelector('.modal-dialog');
             await doClick(findButton(dialog, '🎯SIDE A'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedSaygData.legs[0].playerSequence).toEqual([
                 {text: 'SIDE A', value: 'home'},
                 {text: 'SIDE B', value: 'away'},
@@ -1247,12 +1247,12 @@ describe('TournamentRoundMatch', () => {
                 .build();
             const cells = Array.from(context.container.querySelectorAll('tr td'));
             await doClick(findButton(cells[0], '📊'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doChange(context.container.querySelector('.modal-dialog'), 'input[data-score-input="true"]', '180', context.user);
             await doClick(findButton(context.container.querySelector('.modal-dialog'), '📌📌📌'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(oneEighties).toEqual([playerSideA]);
         });
 
@@ -1284,12 +1284,12 @@ describe('TournamentRoundMatch', () => {
                 .build();
             const cells = Array.from(context.container.querySelectorAll('tr td'));
             await doClick(findButton(cells[0], '📊'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doChange(context.container.querySelector('.modal-dialog'), 'input[data-score-input="true"]', '180', context.user);
             await doClick(findButton(context.container.querySelector('.modal-dialog'), '📌📌📌'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(oneEighties).toEqual([]);
         });
 
@@ -1321,12 +1321,12 @@ describe('TournamentRoundMatch', () => {
                 .build();
             const cells = Array.from(context.container.querySelectorAll('tr td'));
             await doClick(findButton(cells[0], '📊'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doChange(context.container.querySelector('.modal-dialog'), 'input[data-score-input="true"]', '180', context.user);
             await doClick(findButton(context.container.querySelector('.modal-dialog'), '📌📌📌'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(oneEighties).toEqual([]);
         });
 
@@ -1358,12 +1358,12 @@ describe('TournamentRoundMatch', () => {
                 .build();
             const cells = Array.from(context.container.querySelectorAll('tr td'));
             await doClick(findButton(cells[0], '📊'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doChange(context.container.querySelector('.modal-dialog'), 'input[data-score-input="true"]', '151', context.user);
             await doClick(findButton(context.container.querySelector('.modal-dialog'), '📌📌📌'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(hiChecks).toEqual([{
                 score: 151,
                 player: playerSideB,
@@ -1398,12 +1398,12 @@ describe('TournamentRoundMatch', () => {
                 .build();
             const cells = Array.from(context.container.querySelectorAll('tr td'));
             await doClick(findButton(cells[0], '📊'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doChange(context.container.querySelector('.modal-dialog'), 'input[data-score-input="true"]', '151', context.user);
             await doClick(findButton(context.container.querySelector('.modal-dialog'), '📌📌📌'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(hiChecks).toEqual([]);
         });
 
@@ -1435,12 +1435,12 @@ describe('TournamentRoundMatch', () => {
                 .build();
             const cells = Array.from(context.container.querySelectorAll('tr td'));
             await doClick(findButton(cells[0], '📊'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doChange(context.container.querySelector('.modal-dialog'), 'input[data-score-input="true"]', '151', context.user);
             await doClick(findButton(context.container.querySelector('.modal-dialog'), '📌📌📌'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(hiChecks).toEqual([]);
         });
 
@@ -1465,7 +1465,7 @@ describe('TournamentRoundMatch', () => {
 
             await doClick(findButton(cells[5], '🛠'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
             expect(dialog.textContent).toContain('Edit match options');
@@ -1520,7 +1520,7 @@ describe('TournamentRoundMatch', () => {
 
             await doChange(cells[1], 'input', '5', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedRound).toEqual({
                 matches: [Object.assign({}, match, {scoreA: 5})],
                 matchOptions: [],
@@ -1551,7 +1551,7 @@ describe('TournamentRoundMatch', () => {
 
             await doChange(cells[1], 'input', '', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedRound).toEqual({
                 matches: [Object.assign({}, match, {scoreA: 0})],
                 matchOptions: [],
@@ -1582,7 +1582,7 @@ describe('TournamentRoundMatch', () => {
 
             await doSelectOption(cells[0].querySelector('.dropdown-menu'), 'SIDE C');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedRound).toEqual({
                 matches: [Object.assign({}, match, {sideA: sideC})],
                 matchOptions: [],
@@ -1613,7 +1613,7 @@ describe('TournamentRoundMatch', () => {
 
             await doChange(cells[3], 'input', '5', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedRound).toEqual({
                 matches: [Object.assign({}, match, {scoreB: 5})],
                 matchOptions: [],
@@ -1644,7 +1644,7 @@ describe('TournamentRoundMatch', () => {
 
             await doChange(cells[3], 'input', '', context.user);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedRound).toEqual({
                 matches: [Object.assign({}, match, {scoreB: 0})],
                 matchOptions: [],
@@ -1675,7 +1675,7 @@ describe('TournamentRoundMatch', () => {
 
             await doSelectOption(cells[4].querySelector('.dropdown-menu'), 'SIDE C');
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedRound).toEqual({
                 matches: [Object.assign({}, match, {sideB: sideC})],
                 matchOptions: [],
@@ -1711,7 +1711,7 @@ describe('TournamentRoundMatch', () => {
 
             await doClick(findButton(cells[5], '🗑'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(confirm).toEqual('Are you sure you want to remove this match?');
             expect(updatedRound).toEqual({
                 matches: [],
@@ -1748,7 +1748,7 @@ describe('TournamentRoundMatch', () => {
 
             await doClick(findButton(cells[5], '🗑'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(confirm).toEqual('Are you sure you want to remove this match?');
             expect(updatedRound).toBeNull();
         });

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/TournamentSide.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/TournamentSide.test.tsx
@@ -77,7 +77,7 @@ describe('TournamentSide', () => {
                 onRemove,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const sideName = context.container.querySelector('strong');
             const sideLink = sideName.querySelector('a');
             expect(sideLink).toBeFalsy();
@@ -99,7 +99,7 @@ describe('TournamentSide', () => {
                 onRemove,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const sideName = context.container.querySelector('strong');
             expect(sideName.textContent).toEqual('SIDE NAME');
             const teamName = context.container.querySelector('div[data-name="team-name"]');
@@ -119,7 +119,7 @@ describe('TournamentSide', () => {
                 onRemove,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const sideName = context.container.querySelector('strong');
             expect(sideName.textContent).toEqual('SIDE NAME');
             const teamName = context.container.querySelector('div[data-name="team-name"]');
@@ -142,7 +142,7 @@ describe('TournamentSide', () => {
                 onRemove,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const sideName = context.container.querySelector('strong');
             expect(sideName.textContent).toEqual('SIDE NAME');
             const teamName = context.container.querySelector('div[data-name="team-name"]');
@@ -166,7 +166,7 @@ describe('TournamentSide', () => {
                 onRemove,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const sideName = context.container.querySelector('strong');
             expect(sideName.textContent).toEqual('SIDE NAME');
             const teamName = context.container.querySelector('div[data-name="team-name"]');
@@ -187,7 +187,7 @@ describe('TournamentSide', () => {
                 onRemove,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const sideName = context.container.querySelector('strong');
             expect(sideName.textContent).toEqual('SIDE NAME');
             const players = context.container.querySelector('ol');
@@ -205,7 +205,7 @@ describe('TournamentSide', () => {
                 onRemove,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const sideName = context.container.querySelector('strong');
             expect(sideName.textContent).toEqual('SIDE NAME');
             const players = context.container.querySelector('ol');
@@ -226,7 +226,7 @@ describe('TournamentSide', () => {
                 onRemove,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const sideName = context.container.querySelector('strong');
             expect(sideName.textContent).toEqual('SIDE NAME');
             expect(sideName.className).toContain('text-decoration-line-through');
@@ -245,7 +245,7 @@ describe('TournamentSide', () => {
                 onRemove,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const sideName = context.container.querySelector('strong');
             expect(sideName.textContent).toEqual(team.name);
             const teamName = context.container.querySelector('div[data-name="team-name"]');
@@ -266,7 +266,7 @@ describe('TournamentSide', () => {
                 onRemove,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const sideName = context.container.querySelector('strong');
             expect(sideName.textContent).toEqual(team.name);
             expect(sideName.className).toContain('text-decoration-line-through');
@@ -288,7 +288,7 @@ describe('TournamentSide', () => {
                 onRemove,
             }, [team]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const sideName = context.container.querySelector('strong');
             const sideLink = sideName.querySelector('a');
             expect(sideLink).toBeFalsy();
@@ -318,7 +318,7 @@ describe('TournamentSide', () => {
 
             await doClick(findButton(context.container, '✏️'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
         });
@@ -355,7 +355,7 @@ describe('TournamentSide', () => {
             await doChange(dialog, 'input[name="name"]', 'NEW NAME', context.user);
             await doClick(findButton(dialog, 'Save'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedData).toEqual({
                 id: sideId,
                 teamId: team.id,
@@ -381,7 +381,7 @@ describe('TournamentSide', () => {
             const dialog = context.container.querySelector('.modal-dialog');
             await doClick(findButton(dialog, 'Close'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('.modal-dialog')).toBeFalsy();
         });
 
@@ -402,7 +402,7 @@ describe('TournamentSide', () => {
             const dialog = context.container.querySelector('.modal-dialog');
             await doClick(findButton(dialog, 'Delete side'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(removed).toEqual(true);
             expect(context.container.querySelector('.modal-dialog')).toBeFalsy();
         });

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/TournamentSide.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/TournamentSide.tsx
@@ -13,7 +13,7 @@ export interface ITournamentSideProps {
 }
 
 export function TournamentSide({side, onChange, winner, readOnly, onRemove}: ITournamentSideProps) {
-    const [editSide, setEditSide] = useState(null);
+    const [editSide, setEditSide] = useState<TournamentSideDto>(null);
 
     function renderPlayers() {
         if (isEmpty(side.players || [])) {

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MasterDraw.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MasterDraw.test.tsx
@@ -46,7 +46,7 @@ describe('MasterDraw', () => {
                 notes: 'NOTES',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table.table');
             const rows = Array.from(table.querySelectorAll('tbody tr'));
             expect(rows.length).toEqual(2);
@@ -64,7 +64,7 @@ describe('MasterDraw', () => {
                 notes: 'NOTES',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const tournamentProperties = context.container.querySelector('div.d-flex > div:nth-child(2)');
             expect(tournamentProperties.textContent).toContain('Gender: GENDER');
             expect(tournamentProperties.textContent).toContain('Date: ' + renderDate('2023-05-06'));
@@ -81,7 +81,7 @@ describe('MasterDraw', () => {
                 notes: '',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const tournamentProperties = context.container.querySelector('div.d-flex > div:nth-child(2)');
             expect(tournamentProperties.textContent).toContain('Gender: GENDER');
             expect(tournamentProperties.textContent).not.toContain('Notes:');

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MatchLog.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MatchLog.test.tsx
@@ -79,7 +79,7 @@ describe('MatchLog', () => {
                 saygMatches: [saygMatch]
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).toContain('⚠ No data available for the match between A and B');
         });
 
@@ -97,7 +97,7 @@ describe('MatchLog', () => {
                 saygMatches: [saygMatch]
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).toContain('⚠ No data available for the match between A and B');
         });
 
@@ -117,7 +117,7 @@ describe('MatchLog', () => {
                 saygMatches: [saygMatch]
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = Array.from(context.container.querySelectorAll('table.table'))[0];
             const rows = Array.from(table.querySelectorAll('tbody tr')) as HTMLTableRowElement[];
             /* 2 heading rows, 3 data rows - repeated for home and away */
@@ -145,7 +145,7 @@ describe('MatchLog', () => {
                 saygMatches: [saygMatch]
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = Array.from(context.container.querySelectorAll('table.table'))[0];
             const rows = Array.from(table.querySelectorAll('tbody tr')) as HTMLTableRowElement[];
             /* 2 heading rows, 3 data rows - repeated for home and away */
@@ -175,7 +175,7 @@ describe('MatchLog', () => {
                 saygMatches: [saygMatch]
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table.table');
             const rows = Array.from(table.querySelectorAll('tbody tr')) as HTMLTableRowElement[];
             /* 2 heading rows, 3 data rows - repeated for home and away */
@@ -209,7 +209,7 @@ describe('MatchLog', () => {
                 saygMatches: [saygMatch1, saygMatch2]
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstMatchTable = Array.from(context.container.querySelectorAll('table.table'))[0];
             const secondMatchTable = Array.from(context.container.querySelectorAll('table.table'))[1];
             const firstMatchRows = Array.from(firstMatchTable.querySelectorAll('tbody tr')) as HTMLTableRowElement[];
@@ -247,7 +247,7 @@ describe('MatchLog', () => {
                 saygMatches: [saygMatch1, saygMatch2]
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstMatchTable = Array.from(context.container.querySelectorAll('table.table'))[0];
             const secondMatchTable = Array.from(context.container.querySelectorAll('table.table'))[1];
             const firstMatchRows = Array.from(firstMatchTable.querySelectorAll('tbody tr')) as HTMLTableRowElement[];

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MatchLogRow.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MatchLogRow.test.tsx
@@ -63,7 +63,7 @@ describe('MatchLogRow', () => {
                 teamAverage: 23.45,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('tr')).toBeFalsy();
         });
 
@@ -80,7 +80,7 @@ describe('MatchLogRow', () => {
                 teamAverage: 23.45,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             expect(cells.map(td => td.textContent)).toEqual(['PLAYER', '1', '14', '101', '', '1', '1', '1', '4', '12.34', '23.45', '2', '140', '60', '180', '20', '101', '']);
             expect(context.container.querySelector('tr').className).toEqual('bg-winner');
@@ -99,7 +99,7 @@ describe('MatchLogRow', () => {
                 teamAverage: 23.45,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             expect(cells.map(td => td.textContent)).toEqual(['2', '14', '101', '', '1', '1', '1', '4', '2', '140', '60', '180', '20', '101', '']);
             expect(context.container.querySelector('tr').className).toEqual('');
@@ -118,7 +118,7 @@ describe('MatchLogRow', () => {
                 teamAverage: 23.45,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             expect(cells.map(td => td.textContent)).toEqual(['PLAYER', '1', '0', '', '', '0', '0', '0', '0', '12.34', '23.45', '', '', '', '', '', '', '']);
             expect(context.container.querySelector('tr').className).toEqual('');
@@ -137,7 +137,7 @@ describe('MatchLogRow', () => {
                 teamAverage: 23.45,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const cells = Array.from(context.container.querySelectorAll('td'));
             expect(cells.map(td => td.textContent)).toEqual(['2', '0', '', '', '0', '0', '0', '0', '', '', '', '', '', '', '']);
             expect(context.container.querySelector('tr').className).toEqual('');

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MatchLogTableHeading.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MatchLogTableHeading.test.tsx
@@ -43,7 +43,7 @@ describe('MatchLogTableHeading', () => {
                 noOfThrows: 3,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr')) as HTMLTableRowElement[];
             expect(rows.length).toEqual(2);
             expect(getRowContent(rows[0])).toEqual(['TEAM', 'Dart average', '', '']);
@@ -56,7 +56,7 @@ describe('MatchLogTableHeading', () => {
                 noOfThrows: 3,
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr')) as HTMLTableRowElement[];
             expect(rows.length).toEqual(2);
             const cells = Array.from(rows[0].querySelectorAll('th'));

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MatchReport.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MatchReport.test.tsx
@@ -76,7 +76,7 @@ describe('MatchReport', () => {
                 saygMatches: []
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('h2').textContent).toEqual('SOMERSET DARTS ORGANISATION');
             expect(context.container.querySelector('h3').textContent).toEqual('DIVISION (GENDER)');
         });
@@ -93,7 +93,7 @@ describe('MatchReport', () => {
                 saygMatches: []
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('thead tr')) as HTMLTableRowElement[];
             expect(rows.length).toEqual(3);
             expect(getRowContent(rows[0], 'th')).toEqual(['HOSTvOPPONENT']);
@@ -128,7 +128,7 @@ describe('MatchReport', () => {
                 saygMatches: [saygMatch],
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tbody tr')) as HTMLTableRowElement[];
             expect(rows.length).toEqual(3);
             expect(getRowContent(rows[0], 'td')).toEqual([
@@ -157,7 +157,7 @@ describe('MatchReport', () => {
                 saygMatches: [saygMatch],
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const legsWonContainer = context.container.querySelector('table.table + div');
             expect(legsWonContainer).toBeTruthy();
             const legsWon = Array.from(legsWonContainer.querySelectorAll('div'));

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MatchReportRow.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/MatchReportRow.test.tsx
@@ -79,7 +79,7 @@ describe('MatchReportRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr'));
             expect(rows.length).toEqual(0);
         });
@@ -95,7 +95,7 @@ describe('MatchReportRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr'));
             expect(rows.length).toEqual(0);
         });
@@ -117,7 +117,7 @@ describe('MatchReportRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr'));
             expect(rows.length).toEqual(3);
         });
@@ -137,7 +137,7 @@ describe('MatchReportRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr'));
             expect(getRowContent(rows[0])).toEqual([
                 'M1',
@@ -162,7 +162,7 @@ describe('MatchReportRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr'));
             expect(getRowContent(rows[1])).toEqual([
                 '2', '90', '90', '90', '90', '15', '', '51', '0',
@@ -187,7 +187,7 @@ describe('MatchReportRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr'));
             expect(getRowContent(rows[0])).toEqual([
                 'M1',
@@ -213,7 +213,7 @@ describe('MatchReportRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr'));
             const hostScoreCells = Array.from(rows[0].querySelectorAll('td')).filter((_, index) => index >= 4 && index < 8);
             const opponentScoreCells = Array.from(rows[0].querySelectorAll('td')).filter((_, index) => index >= 14 && index < 18);
@@ -238,7 +238,7 @@ describe('MatchReportRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr'));
             const hostScoreCells = Array.from(rows[0].querySelectorAll('td')).filter((_, index) => index >= 4 && index < 8);
             const opponentScoreCells = Array.from(rows[0].querySelectorAll('td')).filter((_, index) => index >= 14 && index < 18);
@@ -263,7 +263,7 @@ describe('MatchReportRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr'));
             const hostTons = Array.from(rows[0].querySelectorAll('td'))[11];
             const opponentTons = Array.from(rows[0].querySelectorAll('td'))[21];
@@ -288,7 +288,7 @@ describe('MatchReportRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('tr'));
             const hostTons = Array.from(rows[0].querySelectorAll('td'))[11];
             const opponentTons = Array.from(rows[0].querySelectorAll('td'))[21];

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/Summary.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/Summary.test.tsx
@@ -72,7 +72,7 @@ describe('Summary', () => {
                 opponent: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).toContain('No matches');
         });
 
@@ -93,7 +93,7 @@ describe('Summary', () => {
                 opponent: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('table thead tr')) as HTMLTableRowElement[];
             expect(rows.length).toEqual(1);
             expect(getRowContent(rows[0], 'th')).toEqual([
@@ -120,7 +120,7 @@ describe('Summary', () => {
                 opponent: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('table.table tbody tr')) as HTMLTableRowElement[];
             expect(rows.length).toEqual(1 + 1);
             expect(getRowContent(rows[0], 'td')).toEqual([
@@ -146,7 +146,7 @@ describe('Summary', () => {
                 opponent: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('table.table tbody tr')) as HTMLTableRowElement[];
             expect(rows.length).toEqual(1 + 1);
             expect(getRowContent(rows[1], 'td')).toEqual([
@@ -173,7 +173,7 @@ describe('Summary', () => {
                 opponent: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('table.table tfoot tr')) as HTMLTableRowElement[];
             expect(rows.length).toEqual(2);
             expect(getRowContent(rows[0], 'td')).toEqual([
@@ -202,7 +202,7 @@ describe('Summary', () => {
                 opponent: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const rows = Array.from(context.container.querySelectorAll('table.table tfoot tr')) as HTMLTableRowElement[];
             expect(rows.length).toEqual(2);
             expect(getRowContent(rows[1], 'td')).toEqual([

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/SummaryDataRow.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/SummaryDataRow.test.tsx
@@ -84,7 +84,7 @@ describe('SummaryDataRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const row = context.container.querySelector('tr');
             expect(getRowContent(row, 'td')).toEqual([
                 '1', 'HOST', '2', '6', '6', '0', '0', '33.4',
@@ -108,7 +108,7 @@ describe('SummaryDataRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const row = context.container.querySelector('tr');
             const cells = Array.from(row.querySelectorAll('td'));
             expect(cells[1].className).toEqual('bg-winner');
@@ -131,7 +131,7 @@ describe('SummaryDataRow', () => {
                 opponentPlayerName: 'OPPONENT',
             });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const row = context.container.querySelector('tr');
             const cells = Array.from(row.querySelectorAll('td'));
             expect(cells[1].className).toEqual('');

--- a/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/SuperLeaguePrintout.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/tournaments/superleague/SuperLeaguePrintout.test.tsx
@@ -124,7 +124,7 @@ describe('SuperLeaguePrintout', () => {
                 tournamentData,
             }, { division });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const headings = Array.from(context.container.querySelectorAll('h2'));
             expect(headings.map(h => h.textContent)).toEqual([
                 'Master draw', 'Match log', 'Summary', 'SOMERSET DARTS ORGANISATION'

--- a/CourageScores/ClientApp/src/components/division_health/DivisionHealth.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_health/DivisionHealth.test.tsx
@@ -72,7 +72,10 @@ describe('DivisionHealth', () => {
             onReloadDivision,
         });
 
-        expect(reportedError.hasError()).toEqual(true);
+        reportedError.verifyErrorEquals({
+            message: 'SOME ERROR',
+            stack: expect.any(String),
+        });
     });
 
     it('shows health-check results', async () => {
@@ -87,7 +90,7 @@ describe('DivisionHealth', () => {
             onReloadDivision,
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         expect(context.container.querySelector('div[datatype="view-health-check"]')).toBeTruthy();
     });
 
@@ -113,7 +116,7 @@ describe('DivisionHealth', () => {
             onReloadDivision,
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         assertHeading('Status: Healthy', 'text-success');
     });
 
@@ -139,7 +142,7 @@ describe('DivisionHealth', () => {
             onReloadDivision,
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         assertHeading('Status: Unhealthy', 'text-warning');
     });
 
@@ -165,7 +168,7 @@ describe('DivisionHealth', () => {
             onReloadDivision,
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         assertHeading('Status: Unhealthy', 'text-warning');
     });
 
@@ -191,7 +194,7 @@ describe('DivisionHealth', () => {
             onReloadDivision,
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         assertHeading('Status: Healthy', 'text-success');
     });
 
@@ -217,7 +220,7 @@ describe('DivisionHealth', () => {
             onReloadDivision,
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         assertHeading('Status: Unhealthy', 'text-warning');
     });
 });

--- a/CourageScores/ClientApp/src/components/division_health/ViewHealthCheck.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_health/ViewHealthCheck.test.tsx
@@ -38,7 +38,7 @@ describe('DivisionHealth', () => {
             },
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const checkItems = Array.from(context.container.querySelectorAll('ol li'));
         expect(checkItems.length).toEqual(1);
         expect(checkItems[0].textContent).toContain('✔ some description');
@@ -60,7 +60,7 @@ describe('DivisionHealth', () => {
             },
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const checkItems = Array.from(context.container.querySelectorAll('ol li'));
         expect(checkItems.length).toEqual(1);
         expect(checkItems[0].textContent).toContain('❌ some description');
@@ -82,7 +82,7 @@ describe('DivisionHealth', () => {
             },
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const checkItems = Array.from(context.container.querySelectorAll('ol li'));
         expect(checkItems.length).toEqual(1);
         expect(checkItems[0].textContent).toContain('some error');
@@ -104,7 +104,7 @@ describe('DivisionHealth', () => {
             },
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const checkItems = Array.from(context.container.querySelectorAll('ol li'));
         expect(checkItems.length).toEqual(1);
         expect(checkItems[0].textContent).toContain('some warning');
@@ -126,7 +126,7 @@ describe('DivisionHealth', () => {
             },
         });
 
-        expect(reportedError.hasError()).toEqual(false);
+        reportedError.verifyNoError();
         const checkItems = Array.from(context.container.querySelectorAll('ol li'));
         expect(checkItems.length).toEqual(1);
         expect(checkItems[0].textContent).toContain('some message');

--- a/CourageScores/ClientApp/src/components/division_players/DivisionPlayer.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_players/DivisionPlayer.test.tsx
@@ -122,7 +122,7 @@ describe('DivisionPlayer', () => {
                     },
                     account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('td'));
                 expect(cells.length).toEqual(10);
                 expect(cells.map(c => c.textContent)).toEqual([
@@ -154,7 +154,7 @@ describe('DivisionPlayer', () => {
                     },
                     account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('td'));
                 expect(cells.length).toEqual(10);
                 const nameCell = cells[1];
@@ -175,7 +175,7 @@ describe('DivisionPlayer', () => {
                     },
                     account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('td'));
                 expect(cells.length).toEqual(9);
                 expect(cells.map(c => c.textContent)).toEqual([
@@ -204,7 +204,7 @@ describe('DivisionPlayer', () => {
                     },
                     account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('td'));
                 const playerLinkCell = cells[1];
                 expect(playerLinkCell.querySelector('button')).toBeFalsy();
@@ -224,7 +224,7 @@ describe('DivisionPlayer', () => {
                     },
                     account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('td'));
                 const playerLinkCell = cells[1];
                 const link = playerLinkCell.querySelector('a');
@@ -246,7 +246,7 @@ describe('DivisionPlayer', () => {
                     },
                     account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('td'));
                 const teamLinkCell = cells[2];
                 const link = teamLinkCell.querySelector('a');
@@ -270,7 +270,7 @@ describe('DivisionPlayer', () => {
                     },
                     account);
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 const cells = Array.from(context.container.querySelectorAll('td'));
                 const teamLinkCell = cells[2];
                 const link = teamLinkCell.querySelector('a');
@@ -484,7 +484,7 @@ describe('DivisionPlayer', () => {
 
                 await doClick(findButton(dialog, 'Save player'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedPlayer).not.toBeNull();
                 expect(updatedPlayer.playerDetails.name).toEqual('NEW NAME');
                 expect(divisionReloaded).toEqual(true);
@@ -512,7 +512,7 @@ describe('DivisionPlayer', () => {
 
                 await doClick(findButton(dialog, 'Save player'));
 
-                expect(reportedError.hasError()).toEqual(false);
+                reportedError.verifyNoError();
                 expect(updatedPlayer).not.toBeNull();
                 expect(nameCell.textContent).toContain('Could not save player details');
                 expect(divisionReloaded).toEqual(false);

--- a/CourageScores/ClientApp/src/components/division_players/DivisionPlayers.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_players/DivisionPlayers.test.tsx
@@ -103,7 +103,7 @@ describe('DivisionPlayers', () => {
                 {...divisionData, onReloadDivision, setDivisionData},
                 {hideVenue: undefined, hideHeading: undefined});
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playersRows = Array.from(context.container.querySelectorAll('.content-background table.table tbody tr')) as HTMLTableRowElement[];
             expect(playersRows.length).toEqual(2);
             assertPlayer(playersRows[0], ['1', '🤴 A captain', 'A team', '6', '7', '8', '2', '3', '4', '5']);
@@ -125,7 +125,7 @@ describe('DivisionPlayers', () => {
                 {...divisionData, onReloadDivision, setDivisionData},
                 {hideVenue: undefined, hideHeading: undefined});
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playersRows = Array.from(context.container.querySelectorAll('.content-background table.table tbody tr')) as HTMLTableRowElement[];
             expect(playersRows.length).toEqual(1);
             assertPlayer(playersRows[0], ['11', 'A player', 'A team', '16', '17', '18', '12', '13', '14', '15']);
@@ -139,7 +139,7 @@ describe('DivisionPlayers', () => {
                 {...divisionData, onReloadDivision, setDivisionData},
                 {hideVenue: undefined, hideHeading: true});
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playersRows = Array.from(context.container.querySelectorAll('.content-background table.table tbody tr')) as HTMLTableRowElement[]
             expect(playersRows.length).toEqual(2);
             const heading = context.container.querySelector('.content-background > div > p');
@@ -154,7 +154,7 @@ describe('DivisionPlayers', () => {
                 {...divisionData, onReloadDivision, setDivisionData},
                 {hideVenue: true, hideHeading: undefined});
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playersRows = Array.from(context.container.querySelectorAll('.content-background table.table tbody tr')) as HTMLTableRowElement[]
             expect(playersRows.length).toEqual(2);
             assertPlayer(playersRows[0], ['1', '🤴 A captain', '6', '7', '8', '2', '3', '4', '5']);
@@ -184,7 +184,7 @@ describe('DivisionPlayers', () => {
                 {...divisionData, onReloadDivision, setDivisionData},
                 {hideVenue: undefined, hideHeading: undefined});
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playersRows = Array.from(context.container.querySelectorAll('.content-background table.table tbody tr')) as HTMLTableRowElement[]
             expect(playersRows.length).toEqual(2);
             assertPlayer(playersRows[0], ['1', '✏️🗑️🤴 A captain', 'A team', '6', '7', '8', '2', '3', '4', '5']);
@@ -206,7 +206,7 @@ describe('DivisionPlayers', () => {
                 {...divisionData, onReloadDivision, setDivisionData},
                 {hideVenue: undefined, hideHeading: undefined});
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playersRows = Array.from(context.container.querySelectorAll('.content-background table.table tbody tr')) as HTMLTableRowElement[]
             expect(playersRows.length).toEqual(2);
             assertPlayer(playersRows[0], ['1', '✏️🗑️🤴 A captain', 'A team', '0', '0', '0', '2', '3', '4', '5']);
@@ -221,7 +221,7 @@ describe('DivisionPlayers', () => {
                 {...divisionData, onReloadDivision, setDivisionData},
                 {hideVenue: undefined, hideHeading: true});
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playersRows = Array.from(context.container.querySelectorAll('.content-background table.table tbody tr')) as HTMLTableRowElement[]
             expect(playersRows.length).toEqual(2);
             const heading = context.container.querySelector('.content-background > div > p');
@@ -236,7 +236,7 @@ describe('DivisionPlayers', () => {
                 {...divisionData, onReloadDivision, setDivisionData},
                 {hideVenue: true, hideHeading: undefined});
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const playersRows = Array.from(context.container.querySelectorAll('.content-background table.table tbody tr')) as HTMLTableRowElement[]
             expect(playersRows.length).toEqual(2);
             assertPlayer(playersRows[0], ['1', '✏️🗑️🤴 A captain', '6', '7', '8', '2', '3', '4', '5']);

--- a/CourageScores/ClientApp/src/components/division_players/EditPlayerDetails.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_players/EditPlayerDetails.test.tsx
@@ -137,7 +137,7 @@ describe('EditPlayerDetails', () => {
                 onChange,
             }, [team], [division]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(findInput('name').value).toEqual('NAME');
             expect(findInput('emailAddress').value).toEqual('EMAIL');
             expect(findInput('captain').checked).toEqual(true);
@@ -160,7 +160,7 @@ describe('EditPlayerDetails', () => {
                 onChange,
             }, [team], [division]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(findInput('name').value).toEqual('NAME');
             expect(findInput('emailAddress').value).toEqual('EMAIL');
             expect(findInput('captain').checked).toEqual(true);
@@ -182,7 +182,7 @@ describe('EditPlayerDetails', () => {
                 onChange,
             }, [team], [division]);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(findInput('name').value).toEqual('NAME');
             expect(findInput('emailAddress').value).toEqual('EMAIL');
             expect(findInput('captain').checked).toEqual(true);
@@ -224,7 +224,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team], [division]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             const multiAdd = context.container.querySelector('input[name="multiple"]');
             expect(multiAdd).toBeTruthy();
@@ -242,7 +242,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team], [division]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             const multiAdd = context.container.querySelector('input[name="multiple"]');
             expect(multiAdd).toBeFalsy();
@@ -286,7 +286,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(findNewTeamDropdown().querySelector('.dropdown-item.active')).toBeTruthy();
 
             await doSelectOption(findNewTeamDropdown().querySelector('.dropdown-menu'), 'OTHER TEAM');
@@ -308,7 +308,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(findNewTeamDropdown().querySelector('.dropdown-item.active')).toBeTruthy();
 
             await doSelectOption(findNewTeamDropdown().querySelector('.dropdown-menu'), 'OTHER TEAM');
@@ -330,7 +330,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(context.container, 'input[name="multiple"]');
 
@@ -352,7 +352,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             await doClick(context.container, 'input[name="multiple"]');
             await doChange(context.container, 'textarea', 'NAME 1\nNAME 2', context.user);
 
@@ -376,7 +376,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findInput('captain'));
 
@@ -397,7 +397,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doSelectOption(findNewDivisionDropdown().querySelector('.dropdown-menu'), 'OTHER DIVISION');
 
@@ -418,7 +418,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doSelectOption(findNewDivisionDropdown().querySelector('.dropdown-menu'), 'OTHER DIVISION');
 
@@ -439,7 +439,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'Add player'));
 
@@ -458,7 +458,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'Add player'));
 
@@ -477,7 +477,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'Add player'));
 
@@ -503,11 +503,11 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'Add player'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(saved).not.toBeNull();
             expect(saved.newPlayers).toEqual([{
                 name: 'NAME',
@@ -530,7 +530,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             await doClick(context.container, 'input[name="multiple"]');
 
             await doClick(findButton(context.container, 'Add players'));
@@ -562,12 +562,12 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             await doClick(context.container, 'input[name="multiple"]');
 
             await doClick(findButton(context.container, 'Add players'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(saved).not.toBeNull();
             expect(saved.newPlayers).toEqual([{
                 id: expect.any(String),
@@ -597,11 +597,11 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'Save player'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedPlayer).not.toBeNull();
             expect(updatedPlayer.playerId).toEqual(playerId);
             expect(updatedPlayer.seasonId).toEqual(season.id);
@@ -629,11 +629,11 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             await doClick(findButton(context.container, 'Save player'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedPlayer).not.toBeNull();
             expect(updatedPlayer.playerId).toEqual(playerId);
             expect(updatedPlayer.seasonId).toEqual(season.id);
@@ -659,7 +659,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             apiResponse = {success: false};
 
             await doClick(findButton(context.container, 'Save player'));
@@ -680,7 +680,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             apiResponse = {success: false};
             await doClick(findButton(context.container, 'Save player'));
             expect(context.container.textContent).toContain('Could not save player details');
@@ -702,7 +702,7 @@ describe('EditPlayerDetails', () => {
                 onSaved,
                 onChange,
             }, [team, otherTeam], [division, otherDivision]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             apiResponse = {success: false};
 
             await doClick(findButton(context.container, 'Cancel'));

--- a/CourageScores/ClientApp/src/components/division_players/PlayerOverview.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_players/PlayerOverview.test.tsx
@@ -74,7 +74,7 @@ describe('PlayerOverview', () => {
                     .season(season)
                     .build());
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('h3');
             expect(heading).toBeTruthy();
             expect(heading.textContent).toContain(player.name);
@@ -93,7 +93,7 @@ describe('PlayerOverview', () => {
                     .season(season)
                     .build());
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).toContain('⚠ Player could not be found');
         });
 
@@ -106,7 +106,7 @@ describe('PlayerOverview', () => {
                     .season(season)
                     .build());
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table.table');
             expect(table).toBeTruthy();
             const headings = Array.from(table.querySelectorAll('thead tr th')).map(th => th.textContent);
@@ -129,7 +129,7 @@ describe('PlayerOverview', () => {
                     .season(season)
                     .build());
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table.table');
             expect(table).toBeTruthy();
             const rows = Array.from(table.querySelectorAll('tbody tr'));
@@ -169,7 +169,7 @@ describe('PlayerOverview', () => {
                     .season(season)
                     .build());
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table.table');
             expect(table).toBeTruthy();
             const rows = Array.from(table.querySelectorAll('tbody tr'));
@@ -211,7 +211,7 @@ describe('PlayerOverview', () => {
                     .season(season)
                     .build());
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table.table');
             expect(table).toBeTruthy();
             const rows = Array.from(table.querySelectorAll('tbody tr'));
@@ -253,7 +253,7 @@ describe('PlayerOverview', () => {
                     .season(season)
                     .build());
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table.table');
             expect(table).toBeTruthy();
             const rows = Array.from(table.querySelectorAll('tbody tr'));
@@ -293,7 +293,7 @@ describe('PlayerOverview', () => {
                     .season(season)
                     .build());
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table.table');
             expect(table).toBeTruthy();
             const rows = Array.from(table.querySelectorAll('tbody tr'));
@@ -326,7 +326,7 @@ describe('PlayerOverview', () => {
                     .season(season)
                     .build());
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table.table');
             expect(table).toBeTruthy();
             const rows = Array.from(table.querySelectorAll('tbody tr'));
@@ -359,7 +359,7 @@ describe('PlayerOverview', () => {
                     .season(season)
                     .build());
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const table = context.container.querySelector('table.table');
             expect(table).toBeTruthy();
             const rows = Array.from(table.querySelectorAll('tbody tr'));

--- a/CourageScores/ClientApp/src/components/division_reports/DivisionReports.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_reports/DivisionReports.test.tsx
@@ -86,7 +86,7 @@ describe('DivisionReports', () => {
 
             await renderComponent(account, divisionData);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const input = context.container.querySelectorAll('.content-background input');
             expect(input).toBeTruthy();
         });
@@ -107,7 +107,7 @@ describe('DivisionReports', () => {
 
             await doClick(findButton(context.container, '📊 Get reports...'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
         });
 
         it('handles api exception when fetching reports', async () => {
@@ -236,7 +236,7 @@ describe('DivisionReports', () => {
 
             await doClick(findButton(context.container, '📊 Get reports...'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const messages = Array.from(context.container.querySelectorAll('.content-background ul > li')) as HTMLElement[];
             expect(messages.map(li => li.textContent)).toEqual(['A message']);
         });
@@ -262,7 +262,7 @@ describe('DivisionReports', () => {
 
             await doClick(findButton(context.container, '📊 Get reports...'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const reportOptions = Array.from(context.container.querySelectorAll('.content-background div.btn-group > div[role="menu"] > button')) as HTMLButtonElement[];
             expect(reportOptions.map(li => li.textContent)).toEqual(['A report description', 'Another report description']);
         });
@@ -291,7 +291,7 @@ describe('DivisionReports', () => {
 
             await doClick(findButton(context.container, '📊 Get reports...'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const reportTable = context.container.querySelector('.content-background table');
             expect(reportTable).toBeTruthy();
             const reportHeadings = Array.from(reportTable.querySelectorAll('thead tr th')) as HTMLTableCellElement[];
@@ -327,7 +327,7 @@ describe('DivisionReports', () => {
 
             await doClick(findButton(context.container, '📊 Get reports...'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('div[datatype="print-division-heading"]');
             expect(heading).toBeTruthy();
             expect(heading.textContent).toEqual('DIVISION, A season');
@@ -358,7 +358,7 @@ describe('DivisionReports', () => {
 
             await doClick(findButton(context.container, '📊 Get reports...'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('div[datatype="print-division-heading"]');
             expect(heading).toBeTruthy();
             expect(heading.textContent).toEqual('A season');

--- a/CourageScores/ClientApp/src/components/division_teams/AssignTeamToSeasons.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/AssignTeamToSeasons.test.tsx
@@ -86,7 +86,7 @@ describe('AssignTeamToSeasons', () => {
             const team = teamBuilder('TEAM').build();
             await renderComponent(team, [], [season], season);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).toContain('Team not found: TEAM');
         });
 
@@ -97,7 +97,7 @@ describe('AssignTeamToSeasons', () => {
                 .build();
             await renderComponent(team, [team], [season, otherSeason], season);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).toContain('Associate TEAM with the following seasons');
             const seasons = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(seasons.length).toEqual(2);
@@ -119,14 +119,14 @@ describe('AssignTeamToSeasons', () => {
 
             await doClick(context.container, '.list-group .list-group-item'); // select the season
             await doClick(findButton(context.container, 'Apply changes'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(apiDeleted).toEqual([]);
             expect(apiAdded.length).toEqual(1);
             expect(apiAdded[0].copyPlayersFromSeasonId).toEqual(season.id);
 
             await doClick(context.container, 'input[id="copyTeamFromCurrentSeason"]');
             await doClick(findButton(context.container, 'Apply changes'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(apiDeleted).toEqual([]);
             expect(apiAdded.length).toEqual(2);
             expect(apiAdded[1].copyPlayersFromSeasonId).toEqual(null);
@@ -144,7 +144,7 @@ describe('AssignTeamToSeasons', () => {
             const items = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(items.map(i => i.className)).toEqual(['list-group-item', 'list-group-item bg-danger']);
             await doClick(findButton(context.container, 'Apply changes'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(apiAdded).toEqual([]);
             expect(apiDeleted).toEqual([{teamId: team.id, seasonId: season.id}]);
         });
@@ -161,7 +161,7 @@ describe('AssignTeamToSeasons', () => {
             const items = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(items.map(i => i.className)).toEqual(['list-group-item bg-success', 'list-group-item active']);
             await doClick(findButton(context.container, 'Apply changes'));
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(apiAdded).toEqual([{
                 id: team.id,
                 seasonId: otherSeason.id,
@@ -198,7 +198,7 @@ describe('AssignTeamToSeasons', () => {
 
             await doClick(findButton(context.container, 'Close'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(closed).toEqual(true);
         });
     });

--- a/CourageScores/ClientApp/src/components/division_teams/DivisionTeam.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/DivisionTeam.test.tsx
@@ -87,7 +87,7 @@ describe('DivisionTeam', () => {
             };
 
             await renderComponent(team, account, {id: division.id, season, onReloadDivision, name: '', setDivisionData: null});
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             const cells = Array.from(context.container.querySelectorAll('td'));
             const cellText = cells.map(c => c.textContent);
@@ -116,7 +116,7 @@ describe('DivisionTeam', () => {
             };
 
             await renderComponent(team, account, {id: division.id, season, onReloadDivision, name: '', setDivisionData: null});
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
 
             const firstCell = context.container.querySelector('td:first-child');
             expect(firstCell.textContent).toEqual('TEAM');
@@ -151,12 +151,12 @@ describe('DivisionTeam', () => {
                 address: '',
             };
             await renderComponent(team, account, {id: division.id, season, onReloadDivision, name: '', setDivisionData: null});
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstCell = context.container.querySelector('td:first-child');
 
             await doClick(findButton(firstCell, '✏️'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
             expect(dialog.textContent).toContain('Edit team: TEAM');
@@ -176,7 +176,7 @@ describe('DivisionTeam', () => {
                 address: '',
             };
             await renderComponent(team, account, {id: division.id, season, onReloadDivision, name: '', setDivisionData: null});
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstCell = context.container.querySelector('td:first-child');
             await doClick(findButton(firstCell, '✏️'));
             const dialog = context.container.querySelector('.modal-dialog');
@@ -184,7 +184,7 @@ describe('DivisionTeam', () => {
             await doChange(dialog, 'input[name="name"]', 'NEW TEAM', context.user);
             await doClick(findButton(dialog, 'Save team'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(updatedTeam).not.toBeNull();
             expect(updatedTeam.lastUpdated).toEqual('2023-07-01T00:00:00');
             expect(updatedTeam.name).toEqual('NEW TEAM');
@@ -203,13 +203,13 @@ describe('DivisionTeam', () => {
                 address: '',
             };
             await renderComponent(team, account, {id: division.id, season, onReloadDivision, name: '', setDivisionData: null});
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstCell = context.container.querySelector('td:first-child');
             await doClick(findButton(firstCell, '✏️'));
 
             await doClick(findButton(context.container.querySelector('.modal-dialog'), 'Cancel'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.querySelector('.modal-dialog')).toBeFalsy();
         });
 
@@ -227,12 +227,12 @@ describe('DivisionTeam', () => {
                 seasons: [],
             };
             await renderComponent(team, account, {id: division.id, season, onReloadDivision, name: '', setDivisionData: null}, [team]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstCell = context.container.querySelector('td:first-child');
 
             await doClick(findButton(firstCell, '➕'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
             expect(dialog.textContent).toContain('Assign seasons');
@@ -252,7 +252,7 @@ describe('DivisionTeam', () => {
                 seasons: [],
             };
             await renderComponent(team, account, {id: division.id, season, onReloadDivision, name: '', setDivisionData: null}, [team]);
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const firstCell = context.container.querySelector('td:first-child');
             await doClick(findButton(firstCell, '➕'));
             const dialog = context.container.querySelector('.modal-dialog');

--- a/CourageScores/ClientApp/src/components/division_teams/DivisionTeams.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/DivisionTeams.test.tsx
@@ -119,7 +119,7 @@ describe('DivisionTeams', () => {
             await renderComponent(
                 {...divisionData, onReloadDivision, setDivisionData });
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const teamsRows = Array.from(context.container.querySelectorAll('.content-background table.table tbody tr')) as HTMLTableRowElement[];
             expect(teamsRows.length).toEqual(2);
             assertTeam(teamsRows[0], ['A team 1', '1', '2', '3', '4', '5', '6']);
@@ -133,7 +133,7 @@ describe('DivisionTeams', () => {
             await renderComponent(
                 {...divisionData, onReloadDivision, setDivisionData});
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const addTeamButton = context.container.querySelector('.content-background > div > div .btn-primary');
             expect(addTeamButton).toBeFalsy();
         });
@@ -158,7 +158,7 @@ describe('DivisionTeams', () => {
             await renderComponent(
                 {...divisionData, onReloadDivision, setDivisionData});
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const teamsRows = Array.from(context.container.querySelectorAll('.content-background table.table tbody tr')) as HTMLTableRowElement[];
             expect(teamsRows.length).toEqual(2);
             assertTeam(teamsRows[0], ['✏️➕A team 1', '1', '2', '3', '4', '5', '6']);
@@ -172,7 +172,7 @@ describe('DivisionTeams', () => {
             await renderComponent(
                 {...divisionData, onReloadDivision, setDivisionData});
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const addTeamButton = context.container.querySelector('.content-background > div > div .btn-primary');
             expect(addTeamButton).toBeTruthy();
         });
@@ -185,7 +185,7 @@ describe('DivisionTeams', () => {
 
             await doClick(findButton(context.container, 'Add team'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');
             expect(dialog).toBeTruthy();
             expect(dialog.textContent).toContain('Create a new team...');
@@ -216,7 +216,7 @@ describe('DivisionTeams', () => {
             await doChange(dialog, 'input[name="name"]', 'NEW TEAM', context.user);
             await doClick(findButton(dialog, 'Add team'));
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(divisionReloaded).toEqual(true);
             expect(context.container.querySelector('.modal-dialog')).toBeFalsy(); // dialog closed
         });

--- a/CourageScores/ClientApp/src/components/division_teams/TeamOverview.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/TeamOverview.test.tsx
@@ -112,7 +112,7 @@ describe('TeamOverview', () => {
 
             await renderComponent(divisionData, teams, teamId);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('.content-background > h3');
             const address = context.container.querySelector('.content-background > p');
             expect(heading).toBeTruthy();
@@ -129,7 +129,7 @@ describe('TeamOverview', () => {
 
             await renderComponent(divisionData, teams, createTemporaryId());
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             expect(context.container.textContent).toContain('Team could not be found');
         });
 
@@ -141,7 +141,7 @@ describe('TeamOverview', () => {
 
             await renderComponent(divisionData, [team], team.id);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const tableSections = context.container.querySelectorAll('.content-background > div.overflow-x-auto');
             expect(tableSections.length).toEqual(2);
             const fixturesSection = tableSections[0];
@@ -160,7 +160,7 @@ describe('TeamOverview', () => {
 
             await renderComponent(divisionData, [team], team.id);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const tableSections = Array.from(context.container.querySelectorAll('.content-background > div.overflow-x-auto')) as HTMLElement[];
             expect(tableSections.length).toEqual(2);
             const fixturesSection = tableSections[0];
@@ -181,7 +181,7 @@ describe('TeamOverview', () => {
 
             await renderComponent(divisionData, [team], team.id);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const tableSections = Array.from(context.container.querySelectorAll('.content-background > div.overflow-x-auto')) as HTMLElement[];
             expect(tableSections.length).toEqual(2);
             const fixturesSection = tableSections[0];
@@ -201,7 +201,7 @@ describe('TeamOverview', () => {
 
             await renderComponent(divisionData, [team], team.id);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const tableSections = Array.from(context.container.querySelectorAll('.content-background > div.overflow-x-auto')) as HTMLElement[];
             expect(tableSections.length).toEqual(2);
             const playersSection = tableSections[1];
@@ -220,7 +220,7 @@ describe('TeamOverview', () => {
 
             await renderComponent(divisionData, teams, teamId);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const heading = context.container.querySelector('.content-background > h3');
             const address = context.container.querySelector('.content-background > p');
             expect(heading).toBeTruthy();
@@ -236,7 +236,7 @@ describe('TeamOverview', () => {
 
             await renderComponent(divisionData, [team], team.id);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const tableSections = Array.from(context.container.querySelectorAll('.content-background > div.overflow-x-auto')) as HTMLElement[];
             expect(tableSections.length).toEqual(2);
             const fixturesSection = tableSections[0];
@@ -251,7 +251,7 @@ describe('TeamOverview', () => {
 
             await renderComponent(divisionData, [team], team.id);
 
-            expect(reportedError.hasError()).toEqual(false);
+            reportedError.verifyNoError();
             const tableSections = Array.from(context.container.querySelectorAll('.content-background > div.overflow-x-auto')) as HTMLElement[];
             expect(tableSections.length).toEqual(2);
             const playersSection = tableSections[1];

--- a/CourageScores/ClientApp/src/helpers/tests.tsx
+++ b/CourageScores/ClientApp/src/helpers/tests.tsx
@@ -125,8 +125,13 @@ export class ErrorState {
         }
     }
 
-    hasError(): boolean {
-        return !!this.error;
+    verifyNoError(): void {
+        expect(this.error).toBeFalsy();
+    }
+
+    verifyErrorEquals(expected: any) {
+        expect(this.error).toBeTruthy();
+        expect(this.error).toEqual(expected);
     }
 }
 

--- a/CourageScores/ClientApp/src/helpers/tournaments.test.ts
+++ b/CourageScores/ClientApp/src/helpers/tournaments.test.ts
@@ -5,6 +5,7 @@
     ILayoutDataForRound, setRoundNames
 } from "./tournaments";
 import {distinct} from "./collections";
+import {repeat} from "./projection";
 
 describe('tournaments', () => {
     describe('getRoundNameFromSides', () => {
@@ -112,7 +113,7 @@ describe('tournaments', () => {
         }
 
         it('4 sides', () => {
-            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(4);
+            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(repeat(4));
 
             expect(layout.length).toEqual(2);
             expect(layout[0]).toEqual({
@@ -121,17 +122,21 @@ describe('tournaments', () => {
                     layoutMatchBuilder({ a: 'C', vs: 'D', m: 'M2' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[1]).toEqual({
                 matches: [
                     layoutMatchBuilder({ a: 'winner(M1)', vs: 'winner(M2)', m: 'M3' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
         });
 
         it('5 sides', () => {
-            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(5);
+            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(repeat(5));
 
             expect(layout.length).toEqual(3);
             expect(layout[0]).toEqual({
@@ -141,6 +146,8 @@ describe('tournaments', () => {
                     layoutMatchBuilder({ a: 'E' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[1]).toEqual({
                 matches: [
@@ -148,17 +155,21 @@ describe('tournaments', () => {
                     layoutMatchBuilder({  a: 'winner(M2)' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[2]).toEqual({
                 matches: [
                     layoutMatchBuilder({  a: 'winner(M2)', vs: 'winner(M3)', m: 'M4' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
         });
 
         it('6 sides', () => {
-            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(6);
+            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(repeat(6));
 
             expect(layout.length).toEqual(3);
             expect(layout[0]).toEqual({
@@ -168,6 +179,8 @@ describe('tournaments', () => {
                     layoutMatchBuilder({  a: 'E', vs: 'F', m: 'M3' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[1]).toEqual({
                 matches: [
@@ -175,17 +188,21 @@ describe('tournaments', () => {
                     layoutMatchBuilder({  a: 'winner(M3)' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[2]).toEqual({
                 matches: [
                     layoutMatchBuilder({ a: 'winner(M3)', vs: 'winner(M4)', m: 'M5' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
         });
 
         it('7 sides', () => {
-            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(7);
+            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(repeat(7));
 
             expect(layout.length).toEqual(3);
             expect(layout[0]).toEqual({
@@ -196,6 +213,8 @@ describe('tournaments', () => {
                     layoutMatchBuilder({ a: 'G' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[1]).toEqual({
                 matches: [
@@ -203,17 +222,21 @@ describe('tournaments', () => {
                     layoutMatchBuilder({ a: 'winner(M2)', vs: 'winner(M3)', m: 'M5' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[2]).toEqual({
                 matches: [
                     layoutMatchBuilder({ a: 'winner(M4)', vs: 'winner(M5)', m: 'M6' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
         });
 
         it('8 sides', () => {
-            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(8);
+            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(repeat(8));
 
             expect(layout.length).toEqual(3);
             expect(layout[0]).toEqual({
@@ -224,6 +247,8 @@ describe('tournaments', () => {
                     layoutMatchBuilder({ a: 'G', vs: 'H', m: 'M4' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[1]).toEqual({
                 matches: [
@@ -231,17 +256,21 @@ describe('tournaments', () => {
                     layoutMatchBuilder({ a: 'winner(M3)', vs: 'winner(M4)', m: 'M6' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[2]).toEqual({
                 matches: [
                     layoutMatchBuilder({ a: 'winner(M5)', vs: 'winner(M6)', m: 'M7' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
         });
 
         it('9 sides', () => {
-            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(9);
+            const layout: ILayoutDataForRound[] = getUnplayedLayoutData(repeat(9));
 
             expect(layout.length).toEqual(4);
             expect(layout[0]).toEqual({
@@ -253,6 +282,8 @@ describe('tournaments', () => {
                     layoutMatchBuilder({ a: 'I' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[1]).toEqual({
                 matches: [
@@ -261,6 +292,8 @@ describe('tournaments', () => {
                     layoutMatchBuilder({ a: 'winner(M4)' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[2]).toEqual({
                 matches: [
@@ -268,54 +301,58 @@ describe('tournaments', () => {
                     layoutMatchBuilder({ a: 'winner(M6)' }), // TODO: 728 This is a bye-to-the-final
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
             expect(layout[3]).toEqual({
                 matches: [
                     layoutMatchBuilder({ a: 'winner(M6)', vs: 'winner(M7)', m: 'M8' }),
                 ],
                 name: null,
+                alreadySelectedSides: expect.any(Array),
+                possibleSides: expect.any(Array),
             });
         });
     });
 
     describe('setRoundNames', () => {
         it('4 sides', () => {
-            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(4));
+            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(repeat(4)));
 
             const roundNames = layoutData.map((r: ILayoutDataForRound) => r.name);
             expect(roundNames).toEqual([ 'Semi-Final', 'Final' ]);
         });
 
         it('5 sides', () => {
-            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(5));
+            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(repeat(5)));
 
             const roundNames = layoutData.map((r: ILayoutDataForRound) => r.name);
             expect(roundNames).toEqual([ 'Quarter-Final', 'Semi-Final', 'Final' ]);
         });
 
         it('6 sides', () => {
-            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(6));
+            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(repeat(6)));
 
             const roundNames = layoutData.map((r: ILayoutDataForRound) => r.name);
             expect(roundNames).toEqual([ 'Quarter-Final', 'Semi-Final', 'Final' ]);
         });
 
         it('7 sides', () => {
-            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(7));
+            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(repeat(7)));
 
             const roundNames = layoutData.map((r: ILayoutDataForRound) => r.name);
             expect(roundNames).toEqual([ 'Quarter-Final', 'Semi-Final', 'Final' ]);
         });
 
         it('8 sides', () => {
-            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(8));
+            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(repeat(8)));
 
             const roundNames = layoutData.map((r: ILayoutDataForRound) => r.name);
             expect(roundNames).toEqual([ 'Quarter-Final', 'Semi-Final', 'Final' ]);
         });
 
         it('9 sides', () => {
-            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(9));
+            const layoutData: ILayoutDataForRound[] = setRoundNames(getUnplayedLayoutData(repeat(9)));
 
             const roundNames = layoutData.map((r: ILayoutDataForRound) => r.name);
             expect(roundNames).toEqual([ 'Round 1',  'Quarter-Final', 'Semi-Final', 'Final' ]);

--- a/CourageScores/ClientApp/src/helpers/tournaments.test.ts
+++ b/CourageScores/ClientApp/src/helpers/tournaments.test.ts
@@ -1,6 +1,4 @@
-﻿// noinspection JSUnresolvedReference
-
-import {
+﻿import {
     getRoundNameFromSides,
     getUnplayedLayoutData,
     hasScore,

--- a/CourageScores/ClientApp/src/helpers/tournaments.ts
+++ b/CourageScores/ClientApp/src/helpers/tournaments.ts
@@ -1,10 +1,11 @@
 import {repeat} from "./projection";
 import {any} from "./collections";
 import {IBootstrapDropdownItem} from "../components/common/BootstrapDropdown";
-import {TournamentGameDto} from "../interfaces/models/dtos/Game/TournamentGameDto";
 import {TournamentSideDto} from "../interfaces/models/dtos/Game/TournamentSideDto";
+import {TournamentGameDto} from "../interfaces/models/dtos/Game/TournamentGameDto";
 import {TournamentRoundDto} from "../interfaces/models/dtos/Game/TournamentRoundDto";
 import {TournamentMatchDto} from "../interfaces/models/dtos/Game/TournamentMatchDto";
+import {GameMatchOptionDto} from "../interfaces/models/dtos/Game/GameMatchOptionDto";
 
 export interface ILayoutDataForSide {
     id: string;
@@ -28,6 +29,53 @@ export interface ILayoutDataForMatch {
 export interface ILayoutDataForRound {
     name: string;
     matches: ILayoutDataForMatch[];
+    possibleSides: TournamentSideDto[];
+    alreadySelectedSides: TournamentSideDto[];
+}
+
+export interface IMnemonicAccumulator {
+    next: () => string;
+}
+
+export interface ITournamentLayoutGenerationContext {
+    matchOptionDefaults: GameMatchOptionDto;
+    getLinkToSide: (side: TournamentSideDto) => JSX.Element;
+    matchMnemonic?: IMnemonicAccumulator;
+}
+
+interface IRoundLayoutGenerationContext {
+    matchOptionDefaults: GameMatchOptionDto;
+    matchMnemonic: IMnemonicAccumulator;
+    getLinkToSide: (side: TournamentSideDto) => JSX.Element;
+    sideMnemonicCalculator: IMnemonicAccumulator;
+    winnersFromThisRound: TournamentSideDto[];
+    sides: TournamentSideDto[];
+}
+
+interface IMatchLayoutGenerationContext {
+    round: TournamentRoundDto;
+    roundContext: IRoundLayoutGenerationContext;
+    playedInThisRound: TournamentSideDto[];
+}
+
+export function getPrefixIncrementingMnemonicCalculator(prefix: string): IMnemonicAccumulator {
+    let index: number = 0;
+    return {
+        next(): string {
+            return prefix + (++index);
+        }
+    };
+}
+
+export function getAlphaMnemonicCalculator(): IMnemonicAccumulator {
+    let ordinal: number = 0;
+    const mnemonics = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    return {
+        next(): string {
+            return mnemonics[ordinal++];
+        }
+    };
 }
 
 export function getRoundNameFromSides(round: { name?: string | null }, sideLength: number, depth: number): string {
@@ -59,19 +107,19 @@ export function sideSelection(side: { id: string, name: string}): IBootstrapDrop
     };
 }
 
-export function getUnplayedLayoutData(noOfSides: number): ILayoutDataForRound[] {
-    if (noOfSides <= 1) {
+export function getUnplayedLayoutData(sides: TournamentSideDto[]): ILayoutDataForRound[] {
+    if (sides.length <= 1) {
         return [];
     }
 
-    const sideMnemonics: string[] = repeat(noOfSides, getMnemonicForIndex);
-    return getUnplayedLayoutDataForSides(sideMnemonics, []);
+    const sideMnemonics: string[] = repeat(sides.length, getMnemonicForIndex);
+    return getUnplayedLayoutDataForSides(sideMnemonics, [], sides);
 }
 
-export function getUnplayedLayoutDataForSides(mnemonics: string[], previousByes: string[], matchMnemonic?: number): ILayoutDataForRound[] {
+export function getUnplayedLayoutDataForSides(mnemonics: string[], previousByes: string[], sides: TournamentSideDto[], matchMnemonic?: IMnemonicAccumulator, singleRound?: boolean): ILayoutDataForRound[] {
     const mnemonicsToCreateMatchesFor: string[] = previousByes.concat(mnemonics.sort().filter((m: string) => !any(previousByes, (b: string) => b === m)));
     // any mnemonics with byes first then the remaining mnemonics in alphabetical order
-    matchMnemonic = matchMnemonic || 0;
+    matchMnemonic = matchMnemonic || getPrefixIncrementingMnemonicCalculator('M');
 
     const matches: ILayoutDataForMatch[] = [];
     const byes: string[] = [];
@@ -87,7 +135,7 @@ export function getUnplayedLayoutDataForSides(mnemonics: string[], previousByes:
             bye,
             scoreA: null,
             scoreB: null,
-            mnemonic: bye ? null : 'M' + (++matchMnemonic),
+            mnemonic: bye ? null : matchMnemonic.next(),
         };
 
         if (match.sideB) {
@@ -102,13 +150,125 @@ export function getUnplayedLayoutDataForSides(mnemonics: string[], previousByes:
     const round: ILayoutDataForRound = {
         matches: matches,
         name: null,
+        possibleSides: sides,
+        alreadySelectedSides: [],
     };
 
-    if ((round.matches.length === 1 && byes.length === 0) || mnemonics.length <= 1) {
+    if ((round.matches.length === 1 && byes.length === 0) || mnemonics.length <= 1 || singleRound) {
         return [round];
     }
 
-    return [round].concat(getUnplayedLayoutDataForSides(followOnMnemonics.concat(byes), byes, matchMnemonic));
+    return [round].concat(getUnplayedLayoutDataForSides(followOnMnemonics.concat(byes), byes, sides, matchMnemonic));
+}
+
+function getMatchLayoutData(match: TournamentMatchDto, index: number, context: IMatchLayoutGenerationContext): ILayoutDataForMatch {
+    let winner = null;
+    context.playedInThisRound.push(match.sideA);
+    context.playedInThisRound.push(match.sideB);
+    const matchOptions: GameMatchOptionDto = context.round.matchOptions[index] || context.roundContext.matchOptionDefaults;
+    const numberOfLegs: number = matchOptions.numberOfLegs;
+
+    if (match.scoreA > (numberOfLegs / 2.0)) {
+        context.roundContext.winnersFromThisRound.push(match.sideA);
+        winner = 'sideA';
+    } else if (match.scoreB > (numberOfLegs / 2.0)) {
+        context.roundContext.winnersFromThisRound.push(match.sideB);
+        winner = 'sideB';
+    }
+
+    return {
+        sideA: {id: match.sideA.id, name: match.sideA.name, link: context.roundContext.getLinkToSide(match.sideA), mnemonic: match.sideA.id ? null : context.roundContext.sideMnemonicCalculator.next()},
+        sideB: {id: match.sideB.id, name: match.sideB.name, link: context.roundContext.getLinkToSide(match.sideB), mnemonic: match.sideB.id ? null : context.roundContext.sideMnemonicCalculator.next()},
+        scoreA: (match.scoreA ? match.scoreA.toString() : null) || '0',
+        scoreB: (match.scoreB ? match.scoreB.toString() : null) || '0',
+        bye: false,
+        winner: winner,
+        saygId: match.saygId,
+        mnemonic: context.roundContext.matchMnemonic.next(),
+        hideMnemonic: allSidesSelectedInNextRound(context.round, match) || context.roundContext.sides.length === 2,
+    };
+}
+
+function allSidesSelectedInNextRound(round: TournamentRoundDto, match: TournamentMatchDto): boolean {
+    const nextRound: TournamentRoundDto = round.nextRound;
+    if (!nextRound) {
+        return false;
+    }
+
+    const sideIdsToFind: string[] = [ match.sideA, match.sideB ].map((s: TournamentSideDto) => s ? s.id : null).filter((id: string) => !!id);
+    return any(nextRound.matches, (m: TournamentMatchDto) => any(sideIdsToFind, (id: string) => (m.sideA && m.sideA.id === id) || (m.sideB && m.sideB.id === id)));
+}
+
+function getRoundLayoutData(round: TournamentRoundDto, roundContext: IRoundLayoutGenerationContext): ILayoutDataForRound {
+    const matchContext: IMatchLayoutGenerationContext = {
+        roundContext,
+        round,
+        playedInThisRound: [],
+    };
+
+    return {
+        name: round.name,
+        matches: round.matches.map((match: TournamentMatchDto, index: number): ILayoutDataForMatch => {
+            return getMatchLayoutData(match, index, matchContext);
+        }),
+        possibleSides: roundContext.sides,
+        alreadySelectedSides: matchContext.playedInThisRound,
+    };
+}
+
+export function getPlayedLayoutData(sides: TournamentSideDto[], round: TournamentRoundDto, context: ITournamentLayoutGenerationContext): ILayoutDataForRound[] {
+    if (!round) {
+        return [];
+    }
+
+    const sideMnemonicCalculator: IMnemonicAccumulator = getAlphaMnemonicCalculator();
+    const layoutContext: IRoundLayoutGenerationContext = {
+        getLinkToSide: context.getLinkToSide,
+        matchOptionDefaults: context.matchOptionDefaults,
+        matchMnemonic: context.matchMnemonic || getPrefixIncrementingMnemonicCalculator('M'),
+        sideMnemonicCalculator,
+        winnersFromThisRound: [],
+        sides,
+    }
+
+    const layoutDataForRound: ILayoutDataForRound = getRoundLayoutData(round, layoutContext);
+    const winnersFromThisRound: TournamentSideDto[] = layoutContext.winnersFromThisRound;
+
+    const sidesThatHaveNotPlayedInThisRound: TournamentSideDto[] = layoutContext.sides
+        .filter((side: TournamentSideDto) => !side.noShow)
+        .filter((side: TournamentSideDto) => !any(layoutDataForRound.alreadySelectedSides, (s: TournamentSideDto) => s.id === side.id))
+    const winnersAndByes: TournamentSideDto[] = sidesThatHaveNotPlayedInThisRound.concat(winnersFromThisRound);
+
+    if (any(sidesThatHaveNotPlayedInThisRound)) {
+        const totalOfUnbalancedMatches: number = layoutDataForRound.matches.filter((m: ILayoutDataForMatch) => (m.sideA.id && !m.sideB.id) || (m.sideB.id && !m.sideA.id)).length;
+        if (totalOfUnbalancedMatches < sidesThatHaveNotPlayedInThisRound.length) {
+            const mnemonics: string[] = repeat(sidesThatHaveNotPlayedInThisRound.length - totalOfUnbalancedMatches, (_: number) => sideMnemonicCalculator.next());
+            const byeLayout: ILayoutDataForRound = getUnplayedLayoutDataForSides(mnemonics, mnemonics, winnersAndByes, layoutContext.matchMnemonic, true)[0];
+            layoutDataForRound.matches = layoutDataForRound.matches.concat(byeLayout.matches);
+        }
+    }
+
+    if ((!round.nextRound || !any(round.nextRound.matches)) && layoutContext.sides.length > 2) {
+        // partially played tournament... project the remaining rounds as unplayed...
+        const mnemonics: string[] = layoutDataForRound.matches.map((m: ILayoutDataForMatch): string => {
+            if (m.sideB) {
+                return m.winner ? m[m.winner].name : `winner(${m.mnemonic})`;
+            }
+
+            return m.sideA.name || m.sideA.mnemonic;
+        });
+
+        const byes: string[] = layoutDataForRound.matches.flatMap((m: ILayoutDataForMatch): string[] => {
+            if (m.sideB) {
+                return [];
+            }
+
+            return [ m.sideA.name || m.sideA.mnemonic ];
+        });
+        return [layoutDataForRound].concat(getUnplayedLayoutDataForSides(mnemonics, byes, winnersAndByes, context.matchMnemonic));
+    }
+
+    return [layoutDataForRound].concat(getPlayedLayoutData(winnersAndByes, round.nextRound, context));
 }
 
 export function setRoundNames(layoutData: ILayoutDataForRound[]): ILayoutDataForRound[] {
@@ -194,4 +354,3 @@ export function addSide(tournamentData: TournamentGameDto, newSide: TournamentSi
     newTournamentData.sides.push(newSide);
     return newTournamentData;
 }
-

--- a/CourageScores/ClientApp/src/helpers/tournaments.ts
+++ b/CourageScores/ClientApp/src/helpers/tournaments.ts
@@ -1,6 +1,10 @@
 import {repeat} from "./projection";
 import {any} from "./collections";
 import {IBootstrapDropdownItem} from "../components/common/BootstrapDropdown";
+import {TournamentGameDto} from "../interfaces/models/dtos/Game/TournamentGameDto";
+import {TournamentSideDto} from "../interfaces/models/dtos/Game/TournamentSideDto";
+import {TournamentRoundDto} from "../interfaces/models/dtos/Game/TournamentRoundDto";
+import {TournamentMatchDto} from "../interfaces/models/dtos/Game/TournamentMatchDto";
 
 export interface ILayoutDataForSide {
     id: string;
@@ -150,3 +154,44 @@ function getLayoutSide(id?: string, name?: string, link?: JSX.Element, mnemonic?
         mnemonic: mnemonic || null,
     };
 }
+
+export function sideChanged(tournamentData: TournamentGameDto, newSide: TournamentSideDto, sideIndex: number): TournamentGameDto {
+    const newTournamentData: TournamentGameDto = Object.assign({}, tournamentData);
+    newSide.name = (newSide.name || '').trim();
+    newTournamentData.sides[sideIndex] = newSide;
+    updateSideDataInRound(newTournamentData.round, newSide);
+    return newTournamentData;
+}
+
+function updateSideDataInRound(round: TournamentRoundDto, side: TournamentSideDto) {
+    if (!round) {
+        return;
+    }
+
+    if (round.matches) {
+        for (let index = 0; index < round.matches.length; index++) {
+            const match: TournamentMatchDto = round.matches[index];
+            if (match.sideA && match.sideA.id === side.id) {
+                match.sideA = side;
+            } else if (match.sideB && match.sideB.id === side.id) {
+                match.sideB = side;
+            }
+        }
+    }
+
+    updateSideDataInRound(round.nextRound, side);
+}
+
+export function removeSide(tournamentData: TournamentGameDto, side: TournamentSideDto): TournamentGameDto {
+    const newTournamentData: TournamentGameDto = Object.assign({}, tournamentData);
+    newTournamentData.sides = tournamentData.sides.filter((s: TournamentSideDto) => s.id !== side.id);
+    return newTournamentData;
+}
+
+export function addSide(tournamentData: TournamentGameDto, newSide: TournamentSideDto): TournamentGameDto {
+    const newTournamentData: TournamentGameDto = Object.assign({}, tournamentData);
+    newSide.name = (newSide.name || '').trim();
+    newTournamentData.sides.push(newSide);
+    return newTournamentData;
+}
+

--- a/CourageScores/ClientApp/src/helpers/tournaments.ts
+++ b/CourageScores/ClientApp/src/helpers/tournaments.ts
@@ -138,7 +138,7 @@ export function setRoundNames(layoutData: ILayoutDataForRound[]): ILayoutDataFor
 }
 
 function getMnemonicForIndex(ordinal: number): string {
-    const mnemonics = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const mnemonics: string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     return mnemonics[ordinal];
 }
 

--- a/CourageScores/Controllers/DivisionController.cs
+++ b/CourageScores/Controllers/DivisionController.cs
@@ -59,7 +59,7 @@ public class DivisionController : Controller
     public async Task<ActionResultDto<DivisionDto>> Update(EditDivisionDto division, CancellationToken token)
     {
         var command = _commandFactory.GetCommand<AddOrUpdateDivisionCommand>().WithData(division);
-        return await _divisionService.Upsert(division.Id ?? Guid.NewGuid(), command, token);
+        return await _divisionService.Upsert(division.Id, command, token);
     }
 
     [HttpDelete("/api/Division/{id}")]

--- a/CourageScores/Controllers/GameController.cs
+++ b/CourageScores/Controllers/GameController.cs
@@ -36,7 +36,7 @@ public class GameController : Controller
     public async Task<ActionResultDto<GameDto>> Update(EditGameDto game, CancellationToken token)
     {
         var command = _commandFactory.GetCommand<AddOrUpdateGameCommand>().WithData(game);
-        return await _gameService.Upsert(game.Id ?? Guid.NewGuid(), command, token);
+        return await _gameService.Upsert(game.Id, command, token);
     }
 
     [HttpPut("/api/Scores/{id}")]

--- a/CourageScores/Controllers/SeasonController.cs
+++ b/CourageScores/Controllers/SeasonController.cs
@@ -40,7 +40,7 @@ public class SeasonController : Controller
     public async Task<ActionResultDto<SeasonDto>> Update(EditSeasonDto season, CancellationToken token)
     {
         var command = _commandFactory.GetCommand<AddOrUpdateSeasonCommand>().WithData(season);
-        return await _seasonService.Upsert(season.Id ?? Guid.NewGuid(), command, token);
+        return await _seasonService.Upsert(season.Id, command, token);
     }
 
     [HttpDelete("/api/Season/{id}")]

--- a/CourageScores/Controllers/TeamController.cs
+++ b/CourageScores/Controllers/TeamController.cs
@@ -42,7 +42,7 @@ public class TeamController : Controller
     public async Task<ActionResultDto<TeamDto>> Update(EditTeamDto team, CancellationToken token)
     {
         var command = _commandFactory.GetCommand<AddOrUpdateTeamCommand>().WithData(team);
-        return await _teamService.Upsert(team.Id ?? Guid.NewGuid(), command, token);
+        return await _teamService.Upsert(team.Id, command, token);
     }
 
     [HttpDelete("/api/Team/{id}/{seasonId}")]

--- a/CourageScores/Controllers/TournamentGameController.cs
+++ b/CourageScores/Controllers/TournamentGameController.cs
@@ -37,7 +37,7 @@ public class TournamentGameController : Controller
     public async Task<ActionResultDto<TournamentGameDto>> Update(EditTournamentGameDto game, CancellationToken token)
     {
         var command = _commandFactory.GetCommand<AddOrUpdateTournamentGameCommand>().WithData(game);
-        return await _tournamentService.Upsert(game.Id ?? Guid.NewGuid(), command, token);
+        return await _tournamentService.Upsert(game.Id, command, token);
     }
 
     [HttpDelete("/api/Tournament/{id}")]

--- a/CourageScores/CourageScores.csproj
+++ b/CourageScores/CourageScores.csproj
@@ -45,10 +45,13 @@
         <Exec WorkingDirectory="$(SpaRoot)" Command="npm install"/>
     </Target>
 
-    <Target Name="Write typescript interfaces" AfterTargets="Build">
+    <Target Name="Clean typescript interfaces" BeforeTargets="Clean">
         <Message Importance="high" Text="Removing existing typescript generated files..." Condition=" '$(Configuration)' == 'Debug' "/>
         <RemoveDir Directories="$(ProjectDir)$(SpaRoot)src/interfaces/models" Condition=" '$(Configuration)' == 'Debug' " />
         <RemoveDir Directories="$(ProjectDir)$(SpaRoot)src/interfaces/apis" Condition=" '$(Configuration)' == 'Debug' " />
+    </Target>
+
+    <Target Name="Write typescript interfaces" AfterTargets="Build">
         <Exec WorkingDirectory="$(OutDir)" Command="dotnet TypeScriptMapper.dll $(ProjectDir)$(SpaRoot)src/interfaces"/>
     </Target>
 

--- a/CourageScores/Models/Adapters/Identity/AccessAdapter.cs
+++ b/CourageScores/Models/Adapters/Identity/AccessAdapter.cs
@@ -29,6 +29,7 @@ public class AccessAdapter : ISimpleAdapter<Access, AccessDto>
             ShowDebugOptions = model.ShowDebugOptions,
             ManageSockets = model.ManageSockets,
             UseWebSockets = model.UseWebSockets,
+            EnterTournamentResults = model.EnterTournamentResults,
         });
     }
 
@@ -56,6 +57,7 @@ public class AccessAdapter : ISimpleAdapter<Access, AccessDto>
             ShowDebugOptions = dto.ShowDebugOptions,
             ManageSockets = dto.ManageSockets,
             UseWebSockets = dto.UseWebSockets,
+            EnterTournamentResults = dto.EnterTournamentResults,
         });
     }
 }

--- a/CourageScores/Models/Cosmos/Identity/Access.cs
+++ b/CourageScores/Models/Cosmos/Identity/Access.cs
@@ -25,4 +25,5 @@ public class Access
     public bool ShowDebugOptions { get; set; }
     public bool ManageSockets { get; set; }
     public bool UseWebSockets { get; set; }
+    public bool EnterTournamentResults { get; set; }
 }

--- a/CourageScores/Models/Dtos/Identity/AccessDto.cs
+++ b/CourageScores/Models/Dtos/Identity/AccessDto.cs
@@ -25,4 +25,5 @@ public class AccessDto
     public bool ShowDebugOptions { get; set; }
     public bool ManageSockets { get; set; }
     public bool UseWebSockets { get; set; }
+    public bool EnterTournamentResults { get; set; }
 }

--- a/CourageScores/Services/CachingDataService.cs
+++ b/CourageScores/Services/CachingDataService.cs
@@ -49,7 +49,8 @@ public class CachingDataService<TModel, TDto> : IGenericDataService<TModel, TDto
         }
     }
 
-    public Task<ActionResultDto<TDto>> Upsert<TOut>(Guid id, IUpdateCommand<TModel, TOut> updateCommand, CancellationToken token)
+    public Task<ActionResultDto<TDto>> Upsert<TOut>(Guid? id, IUpdateCommand<TModel, TOut> updateCommand,
+        CancellationToken token)
     {
         InvalidateCaches(new[]
         {

--- a/CourageScores/Services/Command/AddOrUpdateTeamCommand.cs
+++ b/CourageScores/Services/Command/AddOrUpdateTeamCommand.cs
@@ -111,7 +111,7 @@ public class AddOrUpdateTeamCommand : AddOrUpdateCommand<Models.Cosmos.Team.Team
         foreach (var gameUpdate in gamesToUpdate)
         {
             var command = _commandFactory.GetCommand<AddOrUpdateGameCommand>().WithData(gameUpdate);
-            await _gameService.Upsert(gameUpdate.Id ?? Guid.NewGuid(), command, token);
+            await _gameService.Upsert(gameUpdate.Id, command, token);
         }
 
         team.Name = update.Name;

--- a/CourageScores/Services/Division/CachingDivisionService.cs
+++ b/CourageScores/Services/Division/CachingDivisionService.cs
@@ -93,7 +93,8 @@ public class CachingDivisionService : ICachingDivisionService
         return _divisionService.GetWhere(query, token);
     }
 
-    public Task<ActionResultDto<DivisionDto>> Upsert<TOut>(Guid id, IUpdateCommand<Models.Cosmos.Division, TOut> updateCommand, CancellationToken token)
+    public Task<ActionResultDto<DivisionDto>> Upsert<TOut>(Guid? id,
+        IUpdateCommand<Models.Cosmos.Division, TOut> updateCommand, CancellationToken token)
     {
         try
         {

--- a/CourageScores/Services/Division/DivisionService.cs
+++ b/CourageScores/Services/Division/DivisionService.cs
@@ -142,7 +142,8 @@ public class DivisionService : IDivisionService
     }
 
     [ExcludeFromCodeCoverage]
-    public Task<ActionResultDto<DivisionDto>> Upsert<TOut>(Guid id, IUpdateCommand<Models.Cosmos.Division, TOut> updateCommand, CancellationToken token)
+    public Task<ActionResultDto<DivisionDto>> Upsert<TOut>(Guid? id,
+        IUpdateCommand<Models.Cosmos.Division, TOut> updateCommand, CancellationToken token)
     {
         return _genericDivisionService.Upsert(id, updateCommand, token);
     }

--- a/CourageScores/Services/Game/GameService.cs
+++ b/CourageScores/Services/Game/GameService.cs
@@ -34,7 +34,8 @@ public class GameService : IGameService
         return _underlyingService.GetWhere(query, token).SelectAsync(g => Adapt(g, token));
     }
 
-    public async Task<ActionResultDto<GameDto>> Upsert<TOut>(Guid id, IUpdateCommand<Models.Cosmos.Game.Game, TOut> updateCommand, CancellationToken token)
+    public async Task<ActionResultDto<GameDto>> Upsert<TOut>(Guid? id,
+        IUpdateCommand<Models.Cosmos.Game.Game, TOut> updateCommand, CancellationToken token)
     {
         var result = await _underlyingService.Upsert(id, updateCommand, token);
         if (result.Result != null)

--- a/CourageScores/Services/GenericDataService.cs
+++ b/CourageScores/Services/GenericDataService.cs
@@ -57,7 +57,8 @@ public class GenericDataService<TModel, TDto> : IGenericDataService<TModel, TDto
         }
     }
 
-    public async Task<ActionResultDto<TDto>> Upsert<TOut>(Guid id, IUpdateCommand<TModel, TOut> updateCommand, CancellationToken token)
+    public async Task<ActionResultDto<TDto>> Upsert<TOut>(Guid? id, IUpdateCommand<TModel, TOut> updateCommand,
+        CancellationToken token)
     {
         var user = await _userService.GetUser(token);
 
@@ -66,14 +67,11 @@ public class GenericDataService<TModel, TDto> : IGenericDataService<TModel, TDto
             return await _actionResultAdapter.Warning<TDto>("Not logged in");
         }
 
-        var item = await _repository.Get(id, token);
+        var item = id != null ? await _repository.Get(id.Value, token) : null;
 
         if (item == null)
         {
-            item = new TModel
-            {
-                Id = id,
-            };
+            item = new TModel();
 
             if (!item.CanCreate(user))
             {

--- a/CourageScores/Services/IGenericDataService.cs
+++ b/CourageScores/Services/IGenericDataService.cs
@@ -14,7 +14,7 @@ public interface IGenericDataService<TModel, TDto>
 
     IAsyncEnumerable<TDto> GetWhere(string query, CancellationToken token);
 
-    Task<ActionResultDto<TDto>> Upsert<TOut>(Guid id, IUpdateCommand<TModel, TOut> updateCommand,
+    Task<ActionResultDto<TDto>> Upsert<TOut>(Guid? id, IUpdateCommand<TModel, TOut> updateCommand,
         CancellationToken token);
 
     Task<ActionResultDto<TDto>> Delete(Guid id, CancellationToken token);

--- a/CourageScores/Services/Season/Creation/SeasonTemplateService.cs
+++ b/CourageScores/Services/Season/Creation/SeasonTemplateService.cs
@@ -189,7 +189,8 @@ public class SeasonTemplateService : ISeasonTemplateService
     }
 
     [ExcludeFromCodeCoverage]
-    public Task<ActionResultDto<TemplateDto>> Upsert<TOut>(Guid id, IUpdateCommand<Template, TOut> updateCommand, CancellationToken token)
+    public Task<ActionResultDto<TemplateDto>> Upsert<TOut>(Guid? id, IUpdateCommand<Template, TOut> updateCommand,
+        CancellationToken token)
     {
         return _underlyingService.Upsert(id, updateCommand, token);
     }


### PR DESCRIPTION
Resolves #729
Resolves #738

- [x] confirm side is selected to set side on match
- [x] should be able to add a side to an empty tournament
![Screenshot_2024-02-02-15-03-55-26_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/laingsimon/courage_scores/assets/2243314/ac0a6da3-e5b8-41b7-a7e9-56c42fb8d043)
- [x] don't use links to players/teams when editing sides (navigates to players and loses any unsaved data)