### PR TITLE
#743 edit tournament from printable sheet

### DIFF
--- a/CourageScores/ClientApp/src/components/sayg/PlayerInput.tsx
+++ b/CourageScores/ClientApp/src/components/sayg/PlayerInput.tsx
@@ -65,9 +65,6 @@ export function PlayerInput({ home, away, homeScore, awayScore, on180, onHiCheck
             const input = document.querySelector('input[data-score-input="true"]') as HTMLInputElement;
             if (input) {
                 input.focus();
-            } else {
-                /* istanbul ignore next */
-                console.log('Unable to find input to focus');
             }
             setFocusEventHandle(null);
         }, 300);

--- a/CourageScores/ClientApp/src/components/tournaments/EditTournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditTournament.tsx
@@ -8,7 +8,6 @@ import {useState} from "react";
 import {useApp} from "../common/AppContainer";
 import {useTournament} from "./TournamentContainer";
 import {EditSide} from "./EditSide";
-import {createTemporaryId} from "../../helpers/projection";
 import {TournamentRoundDto} from "../../interfaces/models/dtos/Game/TournamentRoundDto";
 import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
@@ -84,7 +83,7 @@ export function EditTournament({canSave, disabled, saving, applyPatch}: IEditTou
                     }}/>);
             })}
             {!readOnly && !hasStarted
-                ? (<button className="btn btn-primary" onClick={() => setNewSide({ id: createTemporaryId() })}>➕</button>)
+                ? (<button className="btn btn-primary" onClick={() => setNewSide({ id: null })}>➕</button>)
                 : null}
             {newSide && !readOnly && !hasStarted ? renderEditNewSide() : null}
         </div>

--- a/CourageScores/ClientApp/src/components/tournaments/ITournament.ts
+++ b/CourageScores/ClientApp/src/components/tournaments/ITournament.ts
@@ -15,4 +15,7 @@ export interface ITournament {
     saveTournament?: (preventLoading?: boolean) => Promise<TournamentGameDto>;
     setWarnBeforeSave?: (warning: string) => Promise<any>;
     matchOptionDefaults?: GameMatchOptionDto;
+    saving?: boolean;
+    editTournament?: boolean;
+    setEditTournament?: (edit: boolean) => Promise<any>;
 }

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
@@ -218,7 +218,10 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({}, reportedError));
 
             reportedError.verifyNoError();
             const rounds = getRounds();
@@ -250,7 +253,10 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({}, reportedError));
 
             reportedError.verifyNoError();
             const rounds = getRounds();
@@ -285,7 +291,10 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE).withSide(sideF)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({}, reportedError));
 
             reportedError.verifyNoError();
             const rounds = getRounds();
@@ -367,7 +376,10 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({}, reportedError));
 
             reportedError.verifyNoError();
             const rounds = getRounds();
@@ -431,7 +443,10 @@ describe('PrintableSheet', () => {
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({}, reportedError));
 
             reportedError.verifyNoError();
             const rounds = getRounds();
@@ -537,7 +552,10 @@ describe('PrintableSheet', () => {
                 .withSide(sideG).withSide(sideH).withSide(sideI).withSide(sideJ).withSide(sideK).withSide(sideL)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({}, reportedError));
 
             reportedError.verifyNoError();
             const rounds = getRounds();
@@ -697,7 +715,10 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             const winner = getWinner();
@@ -740,7 +761,10 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({teams, divisions}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({teams, divisions}, reportedError));
 
             reportedError.verifyNoError();
             const winner = getWinner();
@@ -770,7 +794,10 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             const winner = getWinner();
@@ -795,7 +822,10 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division: null, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             const winner = getWinner();
@@ -816,7 +846,10 @@ describe('PrintableSheet', () => {
                     .build()]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -839,7 +872,10 @@ describe('PrintableSheet', () => {
             const teams: DataMap<TeamDto> = toMap<TeamDto>([team]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -860,7 +896,10 @@ describe('PrintableSheet', () => {
             ]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division: null, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b']);
@@ -883,7 +922,10 @@ describe('PrintableSheet', () => {
             ]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division: null, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b']);
@@ -899,7 +941,10 @@ describe('PrintableSheet', () => {
             const teams: DataMap<TeamDto> = toMap([]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - a', '2 - b', '-3 - c-']);
@@ -914,7 +959,10 @@ describe('PrintableSheet', () => {
                 .date('2023-06-01')
                 .build();
 
-            await renderComponent({tournamentData, season, division}, {printOnly: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division},
+                {printOnly: false},
+                appProps({}, reportedError));
 
             reportedError.verifyNoError();
             const heading = context.container.querySelector('div[datatype="heading"]');
@@ -939,7 +987,10 @@ describe('PrintableSheet', () => {
             ]);
             const divisions: DivisionDto[] = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             expect(getAccolades('180s', d => d.textContent)).toEqual(['PLAYER 1 x 3', 'PLAYER 2 x 1']);
@@ -965,7 +1016,10 @@ describe('PrintableSheet', () => {
             ]);
             const divisions = [division];
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division: null, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             expect(getAccolades('180s', d => d.textContent)).toEqual(['PLAYER 1 x 3', 'PLAYER 2 x 1']);
@@ -988,7 +1042,10 @@ describe('PrintableSheet', () => {
             ]);
             const divisions = [division];
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             expect(getAccolades('hi-checks', d => d.textContent)).toEqual(['PLAYER 1 (100)', 'PLAYER 2 (120)']);
@@ -1012,7 +1069,10 @@ describe('PrintableSheet', () => {
             ]);
             const divisions = [division];
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({ teams, divisions }, reportedError));
+            await renderComponent(
+                {tournamentData, season, division: null, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
 
             reportedError.verifyNoError();
             expect(getAccolades('hi-checks', d => d.textContent)).toEqual(['PLAYER 1 (100)', 'PLAYER 2 (120)']);
@@ -1031,7 +1091,10 @@ describe('PrintableSheet', () => {
                         .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
                 .build();
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData},
+                {printOnly: false, editable: false},
+                appProps({}, reportedError));
             reportedError.verifyNoError();
             const firstSideA = context.container.querySelector('div[datatype="sideA"]');
 
@@ -1053,7 +1116,10 @@ describe('PrintableSheet', () => {
                         .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE)
                 .build();
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData},
+                {printOnly: false, editable: true},
+                appProps({}, reportedError));
             reportedError.verifyNoError();
             const firstSideA = context.container.querySelector('div[datatype="sideA"]');
             await doClick(firstSideA);
@@ -1083,7 +1149,10 @@ describe('PrintableSheet', () => {
                         .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
                 .build();
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData},
+                {printOnly: false, editable: true},
+                appProps({}, reportedError));
             reportedError.verifyNoError();
             const firstSideA = context.container.querySelector('div[datatype="sideA"]');
             await doClick(firstSideA);
@@ -1109,7 +1178,10 @@ describe('PrintableSheet', () => {
                         .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD).withSide(sideE)
                 .build();
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData},
+                {printOnly: false, editable: true},
+                appProps({}, reportedError));
             reportedError.verifyNoError();
             const firstSideA = context.container.querySelector('div[datatype="sideB"]');
             await doClick(firstSideA);
@@ -1139,7 +1211,10 @@ describe('PrintableSheet', () => {
                         .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
                 .withSide(sideA).withSide(sideB).withSide(sideC).withSide(sideD)
                 .build();
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData},
+                {printOnly: false, editable: true},
+                appProps({}, reportedError));
             reportedError.verifyNoError();
             const firstSideA = context.container.querySelector('div[datatype="sideB"]');
             await doClick(firstSideA);
@@ -1167,7 +1242,10 @@ describe('PrintableSheet', () => {
                 .build();
             const player1 = playerBuilder('PLAYER 1').build();
             const allPlayers: ISelectablePlayer[] = [player1];
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers},
+                {printOnly: false, editable: true},
+                appProps({}, reportedError));
             reportedError.verifyNoError();
 
             await doClick(context.container.querySelector('div[data-accolades="180s"]'));
@@ -1196,7 +1274,10 @@ describe('PrintableSheet', () => {
                 .build();
             const player1 = playerBuilder('PLAYER 1').build();
             const allPlayers: ISelectablePlayer[] = [player1];
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers},
+                {printOnly: false, editable: true},
+                appProps({}, reportedError));
             reportedError.verifyNoError();
 
             await doClick(context.container.querySelector('div[data-accolades="hi-checks"]'));
@@ -1233,7 +1314,10 @@ describe('PrintableSheet', () => {
                 emailAddress: '',
                 access: {}
             }
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers}, {printOnly: false, editable: true}, appProps({account}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers},
+                {printOnly: false, editable: true},
+                appProps({account}, reportedError));
             reportedError.verifyNoError();
             const playing = context.container.querySelector('div[datatype="playing"]');
             const firstSide = playing.querySelector('li');
@@ -1266,7 +1350,10 @@ describe('PrintableSheet', () => {
                 teamBuilder('TEAM')
                     .forSeason(season, division, [player1])
                     .build()]);
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers, alreadyPlaying: {}}, {printOnly: false, editable: true}, appProps({account, teams}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers, alreadyPlaying: {}},
+                {printOnly: false, editable: true},
+                appProps({account, teams}, reportedError));
             reportedError.verifyNoError();
             const addSide = context.container.querySelector('li[datatype="add-side"]');
             await doClick(addSide);
@@ -1295,7 +1382,10 @@ describe('PrintableSheet', () => {
                 access: {}
             }
             window.confirm = () => true;
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}}, {printOnly: false, editable: true}, appProps({account}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}},
+                {printOnly: false, editable: true},
+                appProps({account}, reportedError));
             reportedError.verifyNoError();
             const playing = context.container.querySelector('div[datatype="playing"]');
             const firstSide = playing.querySelector('li.list-group-item');
@@ -1318,6 +1408,12 @@ describe('PrintableSheet', () => {
             .withDivision(division)
             .build();
         const matchOptionDefaults = matchOptionsBuilder().build();
+        const account: UserDto = {
+            name: '',
+            givenName: '',
+            emailAddress: '',
+            access: {}
+        };
 
         it('renders tournament with 2 sides', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder()
@@ -1325,7 +1421,10 @@ describe('PrintableSheet', () => {
                 .withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({}, reportedError));
 
             reportedError.verifyNoError();
             const rounds = getRounds();
@@ -1351,7 +1450,10 @@ describe('PrintableSheet', () => {
                 .withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({}, reportedError));
 
             reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -1363,7 +1465,10 @@ describe('PrintableSheet', () => {
                 .withSide(sideB)
                 .build();
 
-            await renderComponent({tournamentData, season, division: null, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division: null, matchOptionDefaults},
+                {printOnly: false},
+                appProps({}, reportedError));
 
             reportedError.verifyNoError();
             expect(getWhoIsPlaying(whoIsPlayingText)).toEqual(['1 - A', '2 - B']);
@@ -1377,7 +1482,10 @@ describe('PrintableSheet', () => {
                 .date('2023-06-01')
                 .build();
 
-            await renderComponent({tournamentData, season, division, matchOptionDefaults}, {printOnly: false}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({}, reportedError));
 
             reportedError.verifyNoError();
             const heading = context.container.querySelector('div[datatype="heading"]');
@@ -1389,7 +1497,10 @@ describe('PrintableSheet', () => {
                 .withSide(sideA)
                 .withSide(sideB)
                 .build();
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData},
+                {printOnly: false, editable: true},
+                appProps({}, reportedError));
             const firstSideA = context.container.querySelector('div[datatype="sideA"]');
             await doClick(firstSideA);
             const dialog = context.container.querySelector('div.modal-dialog');
@@ -1409,7 +1520,10 @@ describe('PrintableSheet', () => {
                 .withSide(sideA)
                 .withSide(sideB)
                 .build();
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData},
+                {printOnly: false, editable: true},
+                appProps({}, reportedError));
             const firstSideA = context.container.querySelector('div[datatype="sideB"]');
             await doClick(firstSideA);
             const dialog = context.container.querySelector('div.modal-dialog');
@@ -1431,16 +1545,12 @@ describe('PrintableSheet', () => {
                 teamBuilder('TEAM')
                     .forSeason(season, division, [player1])
                     .build()]);
-            const account: UserDto = {
-                name: '',
-                givenName: '',
-                emailAddress: '',
-                access: {}
-            }
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers, alreadyPlaying: {}}, {printOnly: false, editable: true}, appProps({teams, account}, reportedError));
-            const addSideOption = context.container.querySelector('li[datatype="add-side"]');
-            await doClick(addSideOption);
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers, alreadyPlaying: {}},
+                {printOnly: false, editable: true},
+                appProps({teams, account}, reportedError));
+            await doClick(context.container.querySelector('li[datatype="add-side"]'));
             reportedError.verifyNoError();
             const dialog = context.container.querySelector('div.modal-dialog');
             expect(dialog).toBeTruthy();
@@ -1458,14 +1568,11 @@ describe('PrintableSheet', () => {
                 .withSide(sideA)
                 .withSide(sideB)
                 .build();
-            const account: UserDto = {
-                name: '',
-                givenName: '',
-                emailAddress: '',
-                access: {}
-            }
             window.confirm = () => true;
-            await renderComponent({tournamentData, season, division, matchOptionDefaults, setTournamentData}, {printOnly: false, editable: true}, appProps({account}, reportedError));
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData},
+                {printOnly: false, editable: true},
+                appProps({account}, reportedError));
             const playing = context.container.querySelector('div[datatype="playing"]');
             const firstSide = playing.querySelector('li.list-group-item');
             await doClick(firstSide);

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
@@ -1032,6 +1032,35 @@ describe('PrintableSheet', () => {
             expect(getAccolades('180s', linkHref)).toEqual([`http://localhost/division/${division.name}/player:${encodeURI(player1.name)}@TEAM/${season.name}`, null]);
         });
 
+        it('renders 180s where team division cannot be found', async () => {
+            const player1: TournamentPlayerDto = playerBuilder('PLAYER 1').build();
+            const player2: TournamentPlayerDto = playerBuilder('PLAYER 2').build();
+            const tournamentData: TournamentGameDto = tournamentBuilder()
+                .withSide(createSide('A', [player1]))
+                .withSide(createSide('B', [player2]))
+                .withOneEighty(player1)
+                .withOneEighty(player2)
+                .withOneEighty(player1)
+                .withOneEighty(player1)
+                .build();
+            const teams: DataMap<TeamDto> = toMap([
+                teamBuilder('TEAM')
+                    .forSeason(season, null, [player1])
+                    .build()
+            ]);
+            const divisions: DivisionDto[] = [division];
+
+            await renderComponent(
+                {tournamentData, season, division, matchOptionDefaults},
+                {printOnly: false},
+                appProps({ teams, divisions }, reportedError));
+
+            reportedError.verifyNoError();
+            expect(getAccolades('180s', d => d.textContent)).toEqual(['PLAYER 1 x 3', 'PLAYER 2 x 1']);
+            expect(getAccolades('180s', linkHref))
+                .toEqual([`http://localhost/division/${division.name}/player:${encodeURI(player1.name)}@TEAM/${season.name}`, null]);
+        });
+
         it('renders hi checks', async () => {
             const player1: NotableTournamentPlayerDto = playerBuilder('PLAYER 1').build();
             const player2: NotableTournamentPlayerDto = playerBuilder('PLAYER 2').build();

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
@@ -1,5 +1,5 @@
 import {useTournament} from "./TournamentContainer";
-import {createTemporaryId, repeat} from "../../helpers/projection";
+import {repeat} from "../../helpers/projection";
 import {any, count, sortBy} from "../../helpers/collections";
 import {renderDate} from "../../helpers/rendering";
 import {useEffect, useState} from "react";
@@ -375,7 +375,7 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
                             className={`list-group-item no-wrap${side.noShow ? ' text-decoration-line-through' : ''}`}>
                             {index + 1} - {editable ? side.name : getLinkToSide(side)}
                         </li>)}
-                        {editable ? (<li datatype="add-side" className="list-group-item text-secondary opacity-50 d-print-none" onClick={() => setNewSide({ id: createTemporaryId() })}>
+                        {editable ? (<li datatype="add-side" className="list-group-item text-secondary opacity-50 d-print-none" onClick={() => setNewSide({ id: null })}>
                             Add a side
                         </li>) : null}
                     </ul>

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
@@ -1,6 +1,6 @@
 import {useTournament} from "./TournamentContainer";
 import {repeat} from "../../helpers/projection";
-import {any, count, sortBy} from "../../helpers/collections";
+import {any, count, Frequency, groupAndSortByOccurrences, sortBy} from "../../helpers/collections";
 import {renderDate} from "../../helpers/rendering";
 import {useEffect, useState} from "react";
 import {useApp} from "../common/AppContainer";
@@ -207,46 +207,21 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
     }
 
     function render180s() {
-        const oneEightyMap = {};
-        const playerLookup = {};
-
-        tournamentData.oneEighties.forEach((player: TournamentPlayerDto) => {
-            if (oneEightyMap[player.id]) {
-                oneEightyMap[player.id]++;
-            } else {
-                oneEightyMap[player.id] = 1;
-            }
-
-            if (!playerLookup[player.id]) {
-                playerLookup[player.id] = player;
-            }
-        });
-
         return (<div data-accolades="180s" className="border-1 border-solid my-2 min-height-100 p-2 mb-5" onClick={editable ? () => setEditAccolades('one-eighties') : null}>
             <h5>180s</h5>
-            {Object.keys(oneEightyMap).sort((aId: string, bId: string) => {
-                if (oneEightyMap[aId] > oneEightyMap[bId]) {
-                    return -1;
-                }
-                if (oneEightyMap[aId] < oneEightyMap[bId]) {
-                    return 1;
-                }
-
-                return 0;
-            }).map((id: string, index: number) => {
-                const player = playerLookup[id];
+            {groupAndSortByOccurrences(tournamentData.oneEighties, 'id').map((player: TournamentPlayerDto & Frequency, index: number) => {
                 const { team, division } = findTeamAndDivisionForPlayer(player);
 
                 if (division && team) {
                     return (<div key={index} className="p-1 no-wrap">
                         <EmbedAwareLink to={`/division/${division.name}/player:${player.name}@${team.name}/${season.name}`}>
                             {player.name}
-                        </EmbedAwareLink> x {oneEightyMap[id]}
+                        </EmbedAwareLink> x {player.occurrences}
                     </div>);
                 }
 
-                return (<div key={id} className="p-1 no-wrap">
-                    {player.name} x {oneEightyMap[id]}
+                return (<div key={player.id} className="p-1 no-wrap">
+                    {player.name} x {player.occurrences}
                 </div>);
             })}
         </div>);

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
@@ -341,7 +341,7 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
                 </span>
             </div>
             <div datatype="rounds-and-players"
-                 className="d-flex flex-row align-items-center overflow-auto no-overflow-on-print">
+                 className="d-flex flex-row align-items-center justify-content-center overflow-auto no-overflow-on-print">
                 {layoutData.map((roundData: ILayoutDataForRound, roundIndex: number) => (
                     <div key={roundIndex} datatype={`round-${roundIndex}`} className="d-flex flex-column p-3">
                         {roundIndex === layoutData.length - 1 ? render180s() : null}
@@ -366,6 +366,11 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
                         </div>
                     </div>
                 </div>) : null}
+                {!any(tournamentData.sides) && editable
+                    ? (<div datatype="add-sides-hint" className="alert alert-warning m-3 d-print-none">
+                        Add who's playing by clicking <span className="text-secondary" onClick={() => setNewSide({ id: null })}>Add a side</span> &rarr;
+                    </div>)
+                    : null}
                 {any(tournamentData.sides) || editable ? (<div datatype="playing" className="ms-5">
                     <h4>Playing</h4>
                     <ul className="list-group">

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
@@ -28,6 +28,8 @@ import {DivisionDto} from "../../interfaces/models/dtos/DivisionDto";
 import {Dialog} from "../common/Dialog";
 import {add180, addHiCheck, remove180, removeHiCheck} from "../common/Accolades";
 import {MultiPlayerSelection} from "../common/MultiPlayerSelection";
+import {TournamentDetails} from "./TournamentDetails";
+import {TournamentGameDto} from "../../interfaces/models/dtos/Game/TournamentGameDto";
 
 export interface IPrintableSheetProps {
     printOnly: boolean;
@@ -46,7 +48,7 @@ interface IWiggler {
 export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
     const {name} = useBranding();
     const {onError, teams, divisions} = useApp();
-    const {tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers } = useTournament();
+    const {tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers, saving, editTournament, setEditTournament } = useTournament();
     const layoutData: ILayoutDataForRound[] = setRoundNames(tournamentData.round && any(tournamentData.round.matches)
         ? getPlayedLayoutData(tournamentData.sides, tournamentData.round, { matchOptionDefaults, getLinkToSide })
         : getUnplayedLayoutData(tournamentData.sides));
@@ -330,7 +332,7 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
             {winner ? null : (<div className="float-end">
                 <RefreshControl id={tournamentData.id} />
             </div>)}
-            <div datatype="heading" className="border-1 border-solid border-secondary p-3 text-center">
+            <div datatype="heading" className="border-1 border-solid border-secondary p-3 text-center" onClick={setEditTournament ? async () => await setEditTournament(true) : null}>
                 {tournamentData.type || 'tournament'} at <strong>{tournamentData.address}</strong> on <strong>{renderDate(tournamentData.date)}</strong>
                 {tournamentData.notes ? (<> - <strong>{tournamentData.notes}</strong></>) : null}
                 <span className="d-print-none margin-left">
@@ -382,6 +384,14 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
                 {newSide ? renderEditNewSide() : null}
                 {editAccolades === 'hi-checks' ? renderEditHiChecks() : null}
                 {editAccolades === 'one-eighties' ? renderEdit180s() : null}
+                {editTournament
+                    ? (<Dialog onClose={async () => await setEditTournament(false)}>
+                        <TournamentDetails
+                        tournamentData={tournamentData}
+                        disabled={saving}
+                        setTournamentData={async (data: TournamentGameDto) => setTournamentData(data)} />
+                        </Dialog>)
+                    : null}
             </div>
         </div>);
     } catch (e) {

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
@@ -1,6 +1,6 @@
 import {useTournament} from "./TournamentContainer";
 import {repeat} from "../../helpers/projection";
-import {any, count, Frequency, groupAndSortByOccurrences, sortBy} from "../../helpers/collections";
+import {any, count, IFrequency, groupAndSortByOccurrences, sortBy} from "../../helpers/collections";
 import {renderDate} from "../../helpers/rendering";
 import {useEffect, useState} from "react";
 import {useApp} from "../common/AppContainer";
@@ -209,7 +209,7 @@ export function PrintableSheet({printOnly, editable}: IPrintableSheetProps) {
     function render180s() {
         return (<div data-accolades="180s" className="border-1 border-solid my-2 min-height-100 p-2 mb-5" onClick={editable ? () => setEditAccolades('one-eighties') : null}>
             <h5>180s</h5>
-            {groupAndSortByOccurrences(tournamentData.oneEighties, 'id').map((player: TournamentPlayerDto & Frequency, index: number) => {
+            {groupAndSortByOccurrences(tournamentData.oneEighties, 'id').map((player: TournamentPlayerDto & IFrequency, index: number) => {
                 const { team, division } = findTeamAndDivisionForPlayer(player);
 
                 if (division && team) {

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheetMatch.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheetMatch.tsx
@@ -221,14 +221,16 @@ export function PrintableSheetMatch({ matchData, possibleSides, roundIndex, matc
                 {renderSide(matchData.sideA, 'A')}
                 <div datatype="scoreA">{matchData.scoreA || ''}</div>
             </div>
-            {matchData.bye ? null : (<div className="text-center dotted-line-through">
-                                        <span className="px-3 bg-white position-relative">
-                                            vs
-                                            {matchData.saygId ? (
-                                                <a href={`/live/match/${matchData.saygId}`} target="_blank" rel="noreferrer"
-                                                   className="margin-left no-underline">👁️</a>) : null}
-                                        </span>
-            </div>)}
+            {matchData.bye
+                ? null
+                : (<div className="text-center dotted-line-through">
+                        <span className="px-3 bg-white position-relative">
+                            vs
+                            {matchData.saygId
+                                ? (<a href={`/live/match/${matchData.saygId}`} target="_blank" rel="noreferrer" className="margin-left no-underline">👁️</a>)
+                                : null}
+                        </span>
+                    </div>)}
             {matchData.bye
                 ? null
                 : (<div datatype="sideB"

--- a/CourageScores/ClientApp/src/components/tournaments/Tournament.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/Tournament.test.tsx
@@ -1516,5 +1516,182 @@ describe('Tournament', () => {
             hiCheckPlayers = Array.from(hiChecksDropdown.querySelectorAll('.dropdown-item'));
             expect(hiCheckPlayers.map(p => p.textContent)).toEqual([ ' ', 'PLAYER B', 'PLAYER C' ]);
         });
+
+        it('cannot edit tournament details via printable sheet when logged out', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .date('2023-01-02T00:00:00')
+                .accoladesCount()
+                .round((r: ITournamentRoundBuilder) => r)
+                .addTo(tournamentDataLookup)
+                .build();
+            const team = teamBuilder('TEAM')
+                .forSeason(season, division, [ ])
+                .build();
+            const divisionData = divisionDataBuilder().build();
+            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            await renderComponent(tournamentData.id, {
+                account: null,
+                seasons: toMap([season]),
+                teams: [team],
+                divisions: [division],
+            }, false);
+
+            await doClick(context.container.querySelector('div[datatype="heading"]'));
+
+            reportedError.verifyNoError();
+            const editTournamentDialog = context.container.querySelector('.modal-dialog');
+            expect(editTournamentDialog).toBeFalsy();
+        });
+
+        it('cannot edit tournament details via printable sheet when not permitted', async () => {
+            const notPermittedAccount: UserDto = {
+                name: '',
+                emailAddress: '',
+                givenName: '',
+                access: { },
+            };
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .date('2023-01-02T00:00:00')
+                .accoladesCount()
+                .round((r: ITournamentRoundBuilder) => r)
+                .addTo(tournamentDataLookup)
+                .build();
+            const team = teamBuilder('TEAM')
+                .forSeason(season, division, [ ])
+                .build();
+            const divisionData = divisionDataBuilder().build();
+            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            await renderComponent(tournamentData.id, {
+                account: notPermittedAccount,
+                seasons: toMap([season]),
+                teams: [team],
+                divisions: [division],
+            }, false);
+
+            await doClick(context.container.querySelector('div[datatype="heading"]'));
+
+            reportedError.verifyNoError();
+            const editTournamentDialog = context.container.querySelector('.modal-dialog');
+            expect(editTournamentDialog).toBeFalsy();
+        });
+
+        it('can edit tournament details via printable sheet when permitted', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .date('2023-01-02T00:00:00')
+                .accoladesCount()
+                .round((r: ITournamentRoundBuilder) => r)
+                .addTo(tournamentDataLookup)
+                .build();
+            const team = teamBuilder('TEAM')
+                .forSeason(season, division, [ ])
+                .build();
+            const divisionData = divisionDataBuilder().build();
+            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            await renderComponent(tournamentData.id, {
+                account: account,
+                seasons: toMap([season]),
+                teams: [team],
+                divisions: [division],
+            }, false);
+
+            await doClick(context.container.querySelector('div[datatype="heading"]'));
+
+            reportedError.verifyNoError();
+            const editTournamentDialog = context.container.querySelector('.modal-dialog');
+            expect(editTournamentDialog).toBeTruthy();
+        });
+
+        it('cannot edit tournament details via superleague printable sheet when logged out', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .date('2023-01-02T00:00:00')
+                .accoladesCount()
+                .round((r: ITournamentRoundBuilder) => r)
+                .singleRound()
+                .addTo(tournamentDataLookup)
+                .build();
+            const team = teamBuilder('TEAM')
+                .forSeason(season, division, [ ])
+                .build();
+            const divisionData = divisionDataBuilder().build();
+            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            await renderComponent(tournamentData.id, {
+                account: null,
+                seasons: toMap([season]),
+                teams: [team],
+                divisions: [division],
+            }, false);
+
+            await doClick(context.container.querySelector('div[datatype="master-draw"] > h2'));
+
+            reportedError.verifyNoError();
+            const editTournamentDialog = context.container.querySelector('.modal-dialog');
+            expect(editTournamentDialog).toBeFalsy();
+        });
+
+        it('cannot edit tournament details via superleague printable sheet when not permitted', async () => {
+            const notPermittedAccount: UserDto = {
+                name: '',
+                emailAddress: '',
+                givenName: '',
+                access: { },
+            };
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .date('2023-01-02T00:00:00')
+                .accoladesCount()
+                .round((r: ITournamentRoundBuilder) => r)
+                .singleRound()
+                .addTo(tournamentDataLookup)
+                .build();
+            const team = teamBuilder('TEAM')
+                .forSeason(season, division, [ ])
+                .build();
+            const divisionData = divisionDataBuilder().build();
+            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            await renderComponent(tournamentData.id, {
+                account: notPermittedAccount,
+                seasons: toMap([season]),
+                teams: [team],
+                divisions: [division],
+            }, false);
+
+            await doClick(context.container.querySelector('div[datatype="master-draw"] > h2'));
+
+            reportedError.verifyNoError();
+            const editTournamentDialog = context.container.querySelector('.modal-dialog');
+            expect(editTournamentDialog).toBeFalsy();
+        });
+
+        it('can edit tournament details via superleague printable sheet when permitted', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .date('2023-01-02T00:00:00')
+                .accoladesCount()
+                .round((r: ITournamentRoundBuilder) => r)
+                .singleRound()
+                .addTo(tournamentDataLookup)
+                .build();
+            const team = teamBuilder('TEAM')
+                .forSeason(season, division, [ ])
+                .build();
+            const divisionData = divisionDataBuilder().build();
+            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            await renderComponent(tournamentData.id, {
+                account: account,
+                seasons: toMap([season]),
+                teams: [team],
+                divisions: [division],
+            }, false);
+
+            await doClick(context.container.querySelector('div[datatype="master-draw"] > h2'));
+
+            reportedError.verifyNoError();
+            const editTournamentDialog = context.container.querySelector('.modal-dialog');
+            expect(editTournamentDialog).toBeTruthy();
+        });
     });
 });

--- a/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
@@ -292,7 +292,7 @@ export function Tournament() {
                 {canManagePlayers ? (
                     <button className="btn btn-primary d-print-none margin-right" onClick={() => setAddPlayerDialogOpen(true)}>Add
                         player</button>) : null}
-                {canManageTournaments
+                {canManageTournaments && tournamentData.singleRound
                     ? (<button className="btn btn-primary d-print-none margin-right" onClick={() => setEditTournament(true)}>
                         Edit
                     </button>) : null}

--- a/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
@@ -58,6 +58,7 @@ export function Tournament() {
     const [newPlayerDetails, setNewPlayerDetails] = useState<EditTeamPlayerDto>({name: '', captain: false});
     const [warnBeforeSave, setWarnBeforeSave] = useState(null);
     const division: DivisionDto = tournamentData && tournamentData.divisionId ? divisions.filter(d => d.id === tournamentData.divisionId)[0] : null;
+    const [editTournament, setEditTournament] = useState<boolean>(false);
 
     useEffect(() => {
             /* istanbul ignore next */
@@ -253,13 +254,15 @@ export function Tournament() {
                 originalSeasonData={season}
                 originalDivisionData={division}
                 overrideMode="fixtures"/>
-            {tournamentData ? (<div className="content-background p-3">
-                {canManageTournaments
-                    ? (<TournamentDetails
+            {canManageTournaments && tournamentData && tournamentData.singleRound && editTournament
+                ? (<Dialog onClose={async () => setEditTournament(false)}>
+                    <TournamentDetails
                         tournamentData={tournamentData}
                         disabled={saving}
-                        setTournamentData={async (data: TournamentGameDto) => setTournamentData(data)} />)
-                    : null}
+                        setTournamentData={async (data: TournamentGameDto) => setTournamentData(data)} />
+                </Dialog>)
+                : null}
+            {tournamentData ? (<div className="content-background p-3">
                 <TournamentContainer
                     tournamentData={tournamentData}
                     setTournamentData={updateTournamentData}
@@ -270,13 +273,16 @@ export function Tournament() {
                     saveTournament={saveTournament}
                     setWarnBeforeSave={async (warning: string) => setWarnBeforeSave(warning)}
                     matchOptionDefaults={getMatchOptionDefaults(tournamentData)}
+                    saving={saving}
+                    editTournament={editTournament}
+                    setEditTournament={canManageTournaments ? async (value: boolean) => setEditTournament(value) : null}
                     liveOptions={liveOptions}>
-                    {canManageTournaments ? (<EditTournament canSave={true} saving={saving} applyPatch={applyPatch}/>) : null}
+                    {canManageTournaments && tournamentData.singleRound ? (<EditTournament canSave={true} saving={saving} applyPatch={applyPatch}/>) : null}
                     {tournamentData.singleRound && !canManageTournaments ? (<SuperLeaguePrintout division={division}/>) : null}
                     {tournamentData.singleRound && canManageTournaments ? (<div className="d-screen-none">
                         <SuperLeaguePrintout division={division}/>
                     </div>) : null}
-                    {!tournamentData.singleRound ? (<PrintableSheet printOnly={canManageTournaments} editable={canEnterTournamentResults} />) : null}
+                    {!tournamentData.singleRound ? (<PrintableSheet printOnly={false} editable={canEnterTournamentResults || canManageTournaments} />) : null}
                 </TournamentContainer>
                 {canManageTournaments || canEnterTournamentResults ? (
                     <button className="btn btn-primary d-print-none margin-right" onClick={saveTournament}>
@@ -284,8 +290,12 @@ export function Tournament() {
                         Save
                     </button>) : null}
                 {canManagePlayers ? (
-                    <button className="btn btn-primary d-print-none" onClick={() => setAddPlayerDialogOpen(true)}>Add
+                    <button className="btn btn-primary d-print-none margin-right" onClick={() => setAddPlayerDialogOpen(true)}>Add
                         player</button>) : null}
+                {canManageTournaments
+                    ? (<button className="btn btn-primary d-print-none margin-right" onClick={() => setEditTournament(true)}>
+                        Edit
+                    </button>) : null}
             </div>) : (<div>Tournament not found</div>)}
             {saveError ? (<ErrorDisplay {...saveError} onClose={async () => setSaveError(null)}
                                         title="Could not save tournament details"/>) : null}

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentContainer.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentContainer.tsx
@@ -16,11 +16,12 @@ export interface ITournamentContainerProps extends ITournament {
 
 /* istanbul ignore next */
 export function TournamentContainer({children, tournamentData, setTournamentData, season, division, alreadyPlaying,
-                                        allPlayers, saveTournament, setWarnBeforeSave, matchOptionDefaults, liveOptions}: ITournamentContainerProps) {
+                                        allPlayers, saveTournament, setWarnBeforeSave, matchOptionDefaults, liveOptions, saving, editTournament, setEditTournament }: ITournamentContainerProps) {
     const data: ITournament = {
         tournamentData, setTournamentData,
         season, division, alreadyPlaying,
         allPlayers, saveTournament, setWarnBeforeSave, matchOptionDefaults,
+        saving, editTournament, setEditTournament
     };
 
     return (<LiveContainer liveOptions={liveOptions} onDataUpdate={setTournamentData}>

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.test.tsx
@@ -89,6 +89,49 @@ describe('TournamentDetails', () => {
             }
         };
 
+        it('tournament without any sides', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .build();
+
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            // address
+            const address = context.container.querySelector('div:nth-child(2)');
+            expect(address).toBeTruthy();
+            expect(address.textContent).toContain('Address');
+            expect(address.querySelector('input').value).toEqual('ADDRESS');
+            // type
+            const type = context.container.querySelector('div:nth-child(3)');
+            expect(type).toBeTruthy();
+            expect(type.textContent).toContain('Type');
+            expect(type.querySelector('input').value).toEqual('TYPE');
+            // notes
+            const notes = context.container.querySelector('div:nth-child(4)');
+            expect(notes).toBeTruthy();
+            expect(notes.textContent).toContain('Notes');
+            expect(notes.querySelector('textarea').value).toEqual('NOTES');
+            // accolades qualify
+            const accoladesCountAndDivision = context.container.querySelector('div:nth-child(5)');
+            expect(accoladesCountAndDivision).toBeTruthy();
+            expect(accoladesCountAndDivision.textContent).toContain('Include 180s and Hi-checks in players table?');
+            expect(accoladesCountAndDivision.querySelector('input').checked).toEqual(true);
+            // division
+            expect(accoladesCountAndDivision.textContent).toContain('Division');
+            expect(accoladesCountAndDivision.querySelector('.dropdown-item.active').textContent).toEqual('DIVISION');
+        });
+
         it('super league options when single round', async () => {
             const tournamentData = tournamentBuilder()
                 .forSeason(season)

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.test.tsx
@@ -650,5 +650,40 @@ describe('TournamentDetails', () => {
                 }
             });
         });
+
+        it('can export tournament data where teamId for player cannot be found', async () => {
+            const player = playerBuilder('PLAYER').build();
+            const team = teamBuilder('TEAM')
+                .forSeason(season, null, [])
+                .build();
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .date('2023-01-02T00:00:00')
+                .withSide((s: ITournamentSideBuilder) => s.withPlayer(undefined, player.id))
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account: canExportAccount,
+                seasons: toMap([season]),
+                teams: [team],
+                divisions: [division],
+            }));
+            (window as any).open = noop;
+
+            await doClick(findButton(context.container, '🛒'));
+
+            // no teamId's could be identified, player's team could not be found, so it should be excluded from the request
+            expect(exportRequest).toEqual({
+                password: '',
+                includeDeletedEntries: false,
+                tables: {
+                    tournamentGame: [tournamentData.id],
+                    season: [tournamentData.seasonId],
+                }
+            });
+        });
     });
 });

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.test.tsx
@@ -1,0 +1,611 @@
+import {
+    api,
+    appProps,
+    brandingProps,
+    cleanUp,
+    doChange,
+    doClick, doSelectOption, findButton,
+    iocProps, noop,
+    renderApp,
+    TestContext
+} from "../../helpers/tests";
+import {ITournamentDetailsProps, TournamentDetails} from "./TournamentDetails";
+import {
+    ITournamentMatchBuilder,
+    ITournamentRoundBuilder,
+    ITournamentSideBuilder,
+    tournamentBuilder
+} from "../../helpers/builders/tournaments";
+import {divisionBuilder} from "../../helpers/builders/divisions";
+import {createTemporaryId} from "../../helpers/projection";
+import {toMap} from "../../helpers/collections";
+import {IMatchOptionsBuilder} from "../../helpers/builders/games";
+import {teamBuilder} from "../../helpers/builders/teams";
+import {playerBuilder} from "../../helpers/builders/players";
+import {ExportDataRequestDto} from "../../interfaces/models/dtos/Data/ExportDataRequestDto";
+import {IDataApi} from "../../interfaces/apis/IDataApi";
+import {DivisionDto} from "../../interfaces/models/dtos/DivisionDto";
+import {SeasonDto} from "../../interfaces/models/dtos/Season/SeasonDto";
+import {seasonBuilder} from "../../helpers/builders/seasons";
+import {UserDto} from "../../interfaces/models/dtos/Identity/UserDto";
+import {TournamentGameDto} from "../../interfaces/models/dtos/Game/TournamentGameDto";
+import {IAppContainerProps} from "../common/AppContainer";
+
+describe('TournamentDetails', () => {
+    let context: TestContext;
+    let exportRequest: ExportDataRequestDto;
+    let updatedTournamentData: TournamentGameDto;
+
+    const dataApi = api<IDataApi>({
+        export: async (request: ExportDataRequestDto) => {
+            exportRequest = request;
+            return {success: true, result: {zip: 'content'}};
+        }
+    });
+
+    beforeEach(() => {
+        exportRequest = null;
+        updatedTournamentData = null;
+    });
+
+    afterEach(() => {
+        cleanUp(context);
+    });
+
+    async function renderComponent(props: ITournamentDetailsProps, appProps: IAppContainerProps) {
+        context = await renderApp(
+            iocProps({
+                dataApi
+            }),
+            brandingProps(),
+            appProps,
+            (<TournamentDetails {...props }/>));
+    }
+
+    async function setTournamentData(data: TournamentGameDto) {
+        if (updatedTournamentData == null) {
+            updatedTournamentData = data;
+        } else {
+            updatedTournamentData = Object.assign({}, updatedTournamentData, data);
+        }
+    }
+
+    const division: DivisionDto = divisionBuilder('DIVISION').build();
+    const season: SeasonDto = seasonBuilder('SEASON')
+        .starting('2023-01-02T00:00:00')
+        .ending('2023-05-02T00:00:00')
+        .withDivision(division)
+        .build();
+
+    describe('renders', () => {
+        const account: UserDto = {
+            name: '',
+            emailAddress: '',
+            givenName: '',
+            access: {
+                manageTournaments: true,
+                managePlayers: true,
+                recordScoresAsYouGo: true,
+            }
+        };
+
+        it('super league options when single round', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .host('HOST')
+                .opponent('OPPONENT')
+                .gender('men')
+                .singleRound()
+                .accoladesCount()
+                .build();
+
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            const superLeagueOptions = context.container.querySelector('div[datatype="tournament-options"]');
+            expect(superLeagueOptions).toBeTruthy();
+            const hostInput = superLeagueOptions.querySelector('input[name="host"]') as HTMLInputElement;
+            const opponentInput = superLeagueOptions.querySelector('input[name="opponent"]') as HTMLInputElement;
+            expect(hostInput).toBeTruthy();
+            expect(hostInput.value).toEqual('HOST');
+            expect(opponentInput).toBeTruthy();
+            expect(opponentInput.value).toEqual('OPPONENT');
+            expect(superLeagueOptions.querySelector('div[datatype="superleague-gender"] .dropdown-menu .active').textContent).toEqual('Men');
+        });
+
+        it('no super league options when not single round', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .host('HOST')
+                .opponent('OPPONENT')
+                .gender('men')
+                .accoladesCount()
+                .build();
+
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            expect(context.container.querySelector('div[data-options-for="superleague"]')).toBeFalsy();
+        });
+    });
+
+    describe('interactivity', () => {
+        const account: UserDto = {
+            name: '',
+            emailAddress: '',
+            givenName: '',
+            access: {
+                manageTournaments: true,
+                managePlayers: true,
+                recordScoresAsYouGo: true,
+            }
+        };
+        const canExportAccount: UserDto = {
+            name: '',
+            emailAddress: '',
+            givenName: '',
+            access: {
+                manageTournaments: true,
+                managePlayers: true,
+                recordScoresAsYouGo: true,
+                exportData: true,
+            }
+        };
+
+        it('can update single round', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .singleRound()
+                .updated('2023-07-01T00:00:00')
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            const accoladesCountAndDivision = context.container.querySelector('div:nth-child(3)');
+            await doClick(accoladesCountAndDivision, 'input[type="checkbox"]');
+
+            expect(updatedTournamentData.singleRound).toEqual(false);
+        });
+
+        it('can update accolades count', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .singleRound()
+                .updated('2023-07-01T00:00:00')
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            const accoladesCountAndDivision = context.container.querySelector('div:nth-child(5)');
+            await doClick(accoladesCountAndDivision, 'input[type="checkbox"]');
+
+            expect(updatedTournamentData.accoladesCount).toEqual(false);
+        });
+
+        it('can update division', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .singleRound()
+                .updated('2023-07-01T00:00:00')
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            const accoladesCountAndDivision = context.container.querySelector('div:nth-child(5)');
+            await doSelectOption(accoladesCountAndDivision.querySelector('div[datatype="tournament-division"] .dropdown-menu'), 'All divisions');
+
+            expect(updatedTournamentData.divisionId).toEqual(null);
+        });
+
+        it('can update gender', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .singleRound()
+                .updated('2023-07-01T00:00:00')
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            const superLeagueOptions = context.container.querySelector('div[datatype="tournament-options"]');
+            await doSelectOption(superLeagueOptions.querySelector('div[datatype="superleague-gender"] .dropdown-menu'), 'Women');
+
+            expect(updatedTournamentData.gender).toEqual('women');
+        });
+
+        it('can update host', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .singleRound()
+                .updated('2023-07-01T00:00:00')
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            const superLeagueOptions = context.container.querySelector('div[datatype="tournament-options"]');
+            await doChange(superLeagueOptions, 'input[name="host"]', 'HOST', context.user);
+
+            expect(updatedTournamentData.host).toEqual('HOST');
+        });
+
+        it('can update opponent', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .singleRound()
+                .updated('2023-07-01T00:00:00')
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            const superLeagueOptions = context.container.querySelector('div[datatype="tournament-options"]');
+            await doChange(superLeagueOptions, 'input[name="opponent"]', 'OPPONENT', context.user);
+
+            expect(updatedTournamentData.opponent).toEqual('OPPONENT');
+        });
+
+        it('can update notes', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .singleRound()
+                .updated('2023-07-01T00:00:00')
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            const notes = context.container.querySelector('div:nth-child(4)');
+            await doChange(notes, 'textarea', 'NEW NOTES', context.user);
+
+            expect(updatedTournamentData.notes).toEqual('NEW NOTES');
+        });
+
+        it('can update details', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .singleRound()
+                .updated('2023-07-01T00:00:00')
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            const type = context.container.querySelector('div:nth-child(3)');
+            await doChange(type, 'input', 'NEW TYPE', context.user);
+
+            expect(updatedTournamentData.type).toEqual('NEW TYPE');
+        });
+
+        it('can update address', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .singleRound()
+                .updated('2023-07-01T00:00:00')
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+
+            const address = context.container.querySelector('div:nth-child(2)');
+            await doChange(address, 'input', 'NEW ADDRESS', context.user);
+
+            expect(updatedTournamentData.address).toEqual('NEW ADDRESS');
+        });
+
+        it('can export tournament and sayg data with no round', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account: canExportAccount,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+            (window as any).open = noop;
+
+            await doClick(findButton(context.container, '🛒'));
+
+            expect(exportRequest).toEqual({
+                password: '',
+                includeDeletedEntries: false,
+                tables: {
+                    tournamentGame: [tournamentData.id],
+                    division: [tournamentData.divisionId],
+                    season: [tournamentData.seasonId],
+                }
+            });
+            // NOTE: requestedScoreAsYouGo should NOT be present, to prevent export of ALL records
+        });
+
+        it('can export tournament and sayg data with round', async () => {
+            const saygId = createTemporaryId();
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m
+                        .saygId(saygId)
+                        .sideA('A')
+                        .sideB('B'))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3)))
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account: canExportAccount,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+            (window as any).open = noop;
+
+            await doClick(findButton(context.container, '🛒'));
+
+            expect(exportRequest).toEqual({
+                password: '',
+                includeDeletedEntries: false,
+                tables: {
+                    tournamentGame: [tournamentData.id],
+                    recordedScoreAsYouGo: [saygId],
+                    division: [tournamentData.divisionId],
+                    season: [tournamentData.seasonId],
+                }
+            });
+        });
+
+        it('can export tournament and sayg data with sub rounds', async () => {
+            const saygId1 = createTemporaryId();
+            const saygId2 = createTemporaryId();
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .forDivision(division)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .round((r: ITournamentRoundBuilder) => r
+                    .withMatch((m: ITournamentMatchBuilder) => m
+                        .saygId(saygId1)
+                        .sideA('A')
+                        .sideB('B'))
+                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))
+                    .round((r: ITournamentRoundBuilder) => r
+                        .withMatch((m: ITournamentMatchBuilder) => m
+                            .saygId(saygId2)
+                            .sideA('A')
+                            .sideB('B'))
+                        .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account: canExportAccount,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+            (window as any).open = noop;
+
+            await doClick(findButton(context.container, '🛒'));
+
+            expect(exportRequest).toEqual({
+                password: '',
+                includeDeletedEntries: false,
+                tables: {
+                    tournamentGame: [tournamentData.id],
+                    recordedScoreAsYouGo: [saygId1, saygId2],
+                    division: [tournamentData.divisionId],
+                    season: [tournamentData.seasonId],
+                }
+            });
+        });
+
+        it('can export tournament data for cross-divisional tournament', async () => {
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .date('2023-01-02T00:00:00')
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account: canExportAccount,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+            (window as any).open = noop;
+
+            await doClick(findButton(context.container, '🛒'));
+
+            expect(exportRequest).toEqual({
+                password: '',
+                includeDeletedEntries: false,
+                tables: {
+                    tournamentGame: [tournamentData.id],
+                    season: [tournamentData.seasonId],
+                }
+            });
+        });
+
+        it('can export tournament data and team data for team sides', async () => {
+            const team = teamBuilder('TEAM').build();
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .date('2023-01-02T00:00:00')
+                .withSide((s: ITournamentSideBuilder) => s.teamId(team.id))
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account: canExportAccount,
+                seasons: toMap([season]),
+                teams: [],
+                divisions: [division],
+            }));
+            (window as any).open = noop;
+
+            await doClick(findButton(context.container, '🛒'));
+
+            expect(exportRequest).toEqual({
+                password: '',
+                includeDeletedEntries: false,
+                tables: {
+                    tournamentGame: [tournamentData.id],
+                    season: [tournamentData.seasonId],
+                    team: [team.id],
+                }
+            });
+        });
+
+        it('can export tournament data and team data for sides with players', async () => {
+            const playerId = createTemporaryId();
+            const team = teamBuilder('TEAM')
+                .forSeason(season, null, [playerBuilder('PLAYER', playerId).build()])
+                .build();
+            const tournamentData = tournamentBuilder()
+                .forSeason(season)
+                .date('2023-01-02T00:00:00')
+                .withSide((s: ITournamentSideBuilder) => s.withPlayer(undefined, playerId))
+                .address('ADDRESS')
+                .type('TYPE')
+                .notes('NOTES')
+                .accoladesCount()
+                .build();
+            await renderComponent({ tournamentData, setTournamentData }, appProps({
+                account: canExportAccount,
+                seasons: toMap([season]),
+                teams: [team],
+                divisions: [division],
+            }));
+            (window as any).open = noop;
+
+            await doClick(findButton(context.container, '🛒'));
+
+            expect(exportRequest).toEqual({
+                password: '',
+                includeDeletedEntries: false,
+                tables: {
+                    tournamentGame: [tournamentData.id],
+                    season: [tournamentData.seasonId],
+                    team: [team.id],
+                }
+            });
+        });
+    });
+});

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.tsx
@@ -1,0 +1,187 @@
+import {renderDate} from "../../helpers/rendering";
+import {ExportDataButton} from "../common/ExportDataButton";
+import {propChanged, valueChanged} from "../../helpers/events";
+import {BootstrapDropdown, IBootstrapDropdownItem} from "../common/BootstrapDropdown";
+import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
+import {any, distinct} from "../../helpers/collections";
+import {TournamentPlayerDto} from "../../interfaces/models/dtos/Game/TournamentPlayerDto";
+import {TeamDto} from "../../interfaces/models/dtos/Team/TeamDto";
+import {TeamPlayerDto} from "../../interfaces/models/dtos/Team/TeamPlayerDto";
+import {useApp} from "../common/AppContainer";
+import {TournamentGameDto} from "../../interfaces/models/dtos/Game/TournamentGameDto";
+
+export interface ITournamentDetailsProps {
+    tournamentData: TournamentGameDto;
+    setTournamentData: (data: TournamentGameDto) => Promise<any>;
+    disabled?: boolean;
+}
+
+export function TournamentDetails({ tournamentData, disabled, setTournamentData }: ITournamentDetailsProps) {
+    const {teams, divisions} = useApp();
+
+    const genderOptions: IBootstrapDropdownItem[] = [
+        {text: <>&nbsp;</>, value: null},
+        {text: 'Men', value: 'men'},
+        {text: 'Women',value: 'women'}
+    ];
+
+    function getExportTables(): { [key: string]: string[] } {
+        let saygDataIds = [];
+        let teamIds = [];
+        let round = tournamentData.round;
+        while (round) {
+            saygDataIds = saygDataIds.concat(round.matches.map((m: TournamentMatchDto) => m.saygId).filter((id: string) => id));
+            round = round.nextRound;
+        }
+
+        const exportRequest: { [key: string]: string[] } = {
+            tournamentGame: [tournamentData.id],
+            season: [tournamentData.seasonId],
+        };
+
+        if (tournamentData.divisionId) {
+            exportRequest.division = [tournamentData.divisionId];
+        }
+
+        for (let i = 0; i < tournamentData.sides.length; i++) {
+            const side = tournamentData.sides[i];
+
+            if (side.teamId) {
+                teamIds = teamIds.concat([side.teamId]);
+            } else if (any(side.players || [])) {
+                // get the team ids for the players
+                // find the teamId for each player
+                teamIds = teamIds.concat(side.players.map(getTeamIdForPlayer));
+            }
+        }
+
+        if (any(saygDataIds)) {
+            exportRequest.recordedScoreAsYouGo = saygDataIds;
+        }
+
+        teamIds = distinct(teamIds.filter(id => id));
+        if (any(teamIds)) {
+            exportRequest.team = teamIds;
+        }
+
+        return exportRequest;
+    }
+
+    function getTeamIdForPlayer(player: TournamentPlayerDto) {
+        const teamToSeasonMaps = teams.map((t: TeamDto) => {
+            return {
+                teamSeason: t.seasons.filter(ts => ts.seasonId === tournamentData.seasonId)[0],
+                team: t,
+            }
+        });
+        const teamsWithPlayer = teamToSeasonMaps.filter(map => map.teamSeason && any(map.teamSeason.players, (p: TeamPlayerDto) => p.id === player.id));
+
+        if (any(teamsWithPlayer)) {
+            return teamsWithPlayer[0].team.id
+        }
+
+        return null;
+    }
+
+    return (<>
+        <h4 className="pb-2 d-print-none">
+            <span>Edit tournament: </span>
+            <span className="me-4">{renderDate(tournamentData.date)}</span>
+            <button className="btn btn-sm margin-left btn-outline-primary margin-right"
+                    onClick={window.print}>🖨️
+            </button>
+            <ExportDataButton tables={getExportTables()}/>
+        </h4>
+        <div className="input-group mb-1 d-print-none">
+            <div className="input-group-prepend">
+                <label htmlFor="address" className="input-group-text width-75">Address</label>
+            </div>
+            <input id="address" className="form-control" disabled={disabled} type="text"
+                   value={tournamentData.address}
+                   name="address" onChange={valueChanged(tournamentData, setTournamentData)}/>
+        </div>
+        <div className="form-group input-group mb-1 d-print-none">
+            <div className="input-group-prepend">
+                <label htmlFor="type" className="input-group-text width-75">Type</label>
+            </div>
+            <input id="type" className="form-control" disabled={disabled}
+                   value={tournamentData.type || ''} name="type"
+                   onChange={valueChanged(tournamentData, setTournamentData)}
+                   placeholder="Optional type for the tournament"/>
+
+            <div className="form-check form-switch my-1 ms-2">
+                <input disabled={disabled} type="checkbox" className="form-check-input margin-left"
+                       name="singleRound"
+                       id="singleRound"
+                       checked={tournamentData.singleRound}
+                       onChange={valueChanged(tournamentData, setTournamentData)}/>
+                <label className="form-check-label" htmlFor="singleRound">Super league</label>
+            </div>
+        </div>
+        <div className="form-group input-group mb-1 d-print-none">
+            <label htmlFor="note-text" className="input-group-text width-75">Notes</label>
+            <textarea id="note-text" className="form-control" disabled={disabled}
+                      value={tournamentData.notes || ''} name="notes"
+                      onChange={valueChanged(tournamentData, setTournamentData)}
+                      placeholder="Notes for the tournament">
+                        </textarea>
+        </div>
+        <div className="form-group input-group mb-3 d-print-none" datatype="tournament-options">
+            <label className="input-group-text width-75">Options</label>
+            <div className="form-control">
+                <div className="form-check form-switch margin-right my-1">
+                    <input disabled={disabled} type="checkbox" className="form-check-input"
+                           name="accoladesCount" id="accoladesCount"
+                           checked={tournamentData.accoladesCount}
+                           onChange={valueChanged(tournamentData, setTournamentData)}/>
+                    <label className="form-check-label" htmlFor="accoladesCount">Include 180s and Hi-checks
+                        in players table?</label>
+                </div>
+
+                <div className="input-group mb-1" datatype="tournament-division">
+                    <label className="input-group-text">Division</label>
+                    <BootstrapDropdown
+                        value={tournamentData.divisionId}
+                        onChange={propChanged(tournamentData, setTournamentData, 'divisionId')}
+                        options={[{value: null, text: 'All divisions'}].concat(divisions.map(d => {
+                            return {value: d.id, text: d.name}
+                        }))}
+                        disabled={disabled} className="margin-right"/>
+
+                    <label htmlFor="bestOf" className="input-group-text">Best of</label>
+                    <input disabled={disabled} className="form-control no-spinner width-50 d-inline"
+                           id="bestOf" type="number" min="3" value={tournamentData.bestOf || ''}
+                           name="bestOf" onChange={valueChanged(tournamentData, setTournamentData, '')}
+                           placeholder="Number of legs"/>
+                </div>
+
+                {tournamentData.singleRound
+                    ? (<>
+                        <div className="input-group mb-1" datatype="superleague-host">
+                            <label htmlFor="host" className="input-group-text">Host</label>
+                            <input id="host" className="form-control margin-right" disabled={disabled}
+                                   value={tournamentData.host || ''} name="host"
+                                   onChange={valueChanged(tournamentData, setTournamentData)}
+                                   placeholder="Host name"/>
+
+                            <label htmlFor="opponent" className="input-group-text">vs</label>
+                            <input id="opponent" className="form-control" disabled={disabled}
+                                   value={tournamentData.opponent || ''} name="opponent"
+                                   onChange={valueChanged(tournamentData, setTournamentData)}
+                                   placeholder="Opponent name"/>
+                        </div>
+
+                        <div className="input-group mb-1" datatype="superleague-gender">
+                            <label htmlFor="gender" className="input-group-text width-75">Gender</label>
+                            <BootstrapDropdown
+                                value={tournamentData.gender}
+                                onChange={propChanged(tournamentData, setTournamentData, 'gender')}
+                                options={genderOptions}
+                                disabled={disabled}/>
+                        </div>
+                    </>)
+                    : null}
+            </div>
+        </div>
+    </>);
+}

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.tsx
@@ -84,7 +84,7 @@ export function TournamentDetails({ tournamentData, disabled, setTournamentData 
     }
 
     return (<>
-        <h4 className="pb-2 d-print-none">
+        <h4 className="pb-2">
             <span>Edit tournament: </span>
             <span className="me-4">{renderDate(tournamentData.date)}</span>
             <button className="btn btn-sm margin-left btn-outline-primary margin-right"
@@ -92,7 +92,7 @@ export function TournamentDetails({ tournamentData, disabled, setTournamentData 
             </button>
             <ExportDataButton tables={getExportTables()}/>
         </h4>
-        <div className="input-group mb-1 d-print-none">
+        <div className="input-group mb-1">
             <div className="input-group-prepend">
                 <label htmlFor="address" className="input-group-text width-75">Address</label>
             </div>
@@ -100,7 +100,7 @@ export function TournamentDetails({ tournamentData, disabled, setTournamentData 
                    value={tournamentData.address}
                    name="address" onChange={valueChanged(tournamentData, setTournamentData)}/>
         </div>
-        <div className="form-group input-group mb-1 d-print-none">
+        <div className="form-group input-group mb-1">
             <div className="input-group-prepend">
                 <label htmlFor="type" className="input-group-text width-75">Type</label>
             </div>
@@ -118,7 +118,7 @@ export function TournamentDetails({ tournamentData, disabled, setTournamentData 
                 <label className="form-check-label" htmlFor="singleRound">Super league</label>
             </div>
         </div>
-        <div className="form-group input-group mb-1 d-print-none">
+        <div className="form-group input-group mb-1">
             <label htmlFor="note-text" className="input-group-text width-75">Notes</label>
             <textarea id="note-text" className="form-control" disabled={disabled}
                       value={tournamentData.notes || ''} name="notes"
@@ -126,7 +126,7 @@ export function TournamentDetails({ tournamentData, disabled, setTournamentData 
                       placeholder="Notes for the tournament">
                         </textarea>
         </div>
-        <div className="form-group input-group mb-3 d-print-none" datatype="tournament-options">
+        <div className="form-group input-group mb-3" datatype="tournament-options">
             <label className="input-group-text width-75">Options</label>
             <div className="form-control">
                 <div className="form-check form-switch margin-right my-1">

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentSide.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentSide.test.tsx
@@ -128,6 +128,26 @@ describe('TournamentSide', () => {
             expect(players.map(p => p.textContent)).toEqual(['PLAYER']);
         });
 
+        it('single player with side name same as player name', async () => {
+            await renderComponent({season, tournamentData: null}, {
+                side: sideBuilder('PLAYER A')
+                    .withPlayer('PLAYER A')
+                    .build(),
+                winner: null,
+                readOnly: false,
+                onChange,
+                onRemove,
+            }, [team]);
+
+            reportedError.verifyNoError();
+            const sideName = context.container.querySelector('strong');
+            expect(sideName.textContent).toEqual('PLAYER A');
+            const teamName = context.container.querySelector('div[data-name="team-name"]');
+            expect(teamName).toBeFalsy();
+            const players = context.container.querySelector('ol');
+            expect(players).toBeFalsy();
+        });
+
         it('multi player side', async () => {
             const side = sideBuilder('SIDE NAME')
                 .withPlayer('PLAYER 1', null, division.id)

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.test.tsx
@@ -1,19 +1,23 @@
 import {
     appProps,
     brandingProps,
-    cleanUp,
-    ErrorState,
+    cleanUp, doChange, doClick,
+    ErrorState, findButton,
     iocProps,
     renderApp,
     TestContext
 } from "../../../helpers/tests";
 import {IMasterDrawProps, MasterDraw} from "./MasterDraw";
 import {renderDate} from "../../../helpers/rendering";
-import {tournamentMatchBuilder} from "../../../helpers/builders/tournaments";
+import {tournamentBuilder, tournamentMatchBuilder} from "../../../helpers/builders/tournaments";
+import {ITournamentContainerProps, TournamentContainer} from "../TournamentContainer";
+import {TournamentGameDto} from "../../../interfaces/models/dtos/Game/TournamentGameDto";
 
 describe('MasterDraw', () => {
     let context: TestContext;
     let reportedError: ErrorState;
+    let updatedTournament: TournamentGameDto;
+    let editTournament: boolean;
 
     afterEach(() => {
         cleanUp(context);
@@ -21,17 +25,35 @@ describe('MasterDraw', () => {
 
     beforeEach(() => {
         reportedError = new ErrorState();
+        updatedTournament = null;
+        editTournament = null;
     });
 
-    async function renderComponent(props: IMasterDrawProps) {
+    async function setEditTournament(value: boolean) {
+        editTournament = value;
+    }
+
+    async function setTournamentData(update: TournamentGameDto) {
+        updatedTournament = update;
+    }
+
+    async function renderComponent(props: IMasterDrawProps, containerProps: ITournamentContainerProps) {
         context = await renderApp(
             iocProps(),
             brandingProps(),
             appProps({}, reportedError),
-            (<MasterDraw {...props} />));
+            (<TournamentContainer {...containerProps}>
+                <MasterDraw {...props} />
+            </TournamentContainer>));
     }
 
     describe('renders', () => {
+        const defaultContainerProps: ITournamentContainerProps = {
+            tournamentData: null,
+            setEditTournament: null,
+            setTournamentData: null,
+        };
+
         it('matches', async () => {
             const match1 = tournamentMatchBuilder().sideA('A').sideB('B').build();
             const match2 = tournamentMatchBuilder().sideA('C').sideB('D').build();
@@ -44,7 +66,7 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 notes: 'NOTES',
-            });
+            }, defaultContainerProps);
 
             reportedError.verifyNoError();
             const table = context.container.querySelector('table.table');
@@ -62,7 +84,7 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 notes: 'NOTES',
-            });
+            }, defaultContainerProps);
 
             reportedError.verifyNoError();
             const tournamentProperties = context.container.querySelector('div.d-flex > div:nth-child(2)');
@@ -79,12 +101,139 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 notes: '',
-            });
+            }, defaultContainerProps);
 
             reportedError.verifyNoError();
             const tournamentProperties = context.container.querySelector('div.d-flex > div:nth-child(2)');
             expect(tournamentProperties.textContent).toContain('Gender: GENDER');
             expect(tournamentProperties.textContent).not.toContain('Notes:');
+        });
+    });
+
+    describe('interactivity', () => {
+        it('can edit tournament from heading', async () => {
+            await renderComponent({
+                matches: [],
+                host: 'HOST',
+                opponent: 'OPPONENT',
+                gender: 'GENDER',
+                date: '2023-05-06',
+                notes: 'NOTES',
+            }, {
+                setEditTournament,
+                tournamentData: null,
+            });
+            reportedError.verifyNoError();
+
+            await doClick(context.container.querySelector('div[datatype="master-draw"] > h2'));
+
+            reportedError.verifyNoError();
+            expect(editTournament).toEqual(true);
+        });
+
+        it('can edit tournament from table of players', async () => {
+            await renderComponent({
+                matches: [],
+                host: 'HOST',
+                opponent: 'OPPONENT',
+                gender: 'GENDER',
+                date: '2023-05-06',
+                notes: 'NOTES',
+            }, {
+                setEditTournament,
+                tournamentData: null,
+            });
+            reportedError.verifyNoError();
+
+            await doClick(context.container.querySelector('div[datatype="master-draw"] > div'));
+
+            reportedError.verifyNoError();
+            expect(editTournament).toEqual(true);
+        });
+
+        it('can close edit tournament dialog', async () => {
+            await renderComponent({
+                matches: [],
+                host: 'HOST',
+                opponent: 'OPPONENT',
+                gender: 'GENDER',
+                date: '2023-05-06',
+                notes: 'NOTES',
+            }, {
+                setEditTournament,
+                tournamentData: tournamentBuilder().build(),
+                editTournament: true,
+            });
+            reportedError.verifyNoError();
+
+            const dialog = context.container.querySelector('.modal-dialog');
+            await doClick(findButton(dialog, 'Close'));
+
+            reportedError.verifyNoError();
+            expect(editTournament).toEqual(false);
+        });
+
+        it('can edit tournament details', async () => {
+            await renderComponent({
+                matches: [],
+                host: 'HOST',
+                opponent: 'OPPONENT',
+                gender: 'GENDER',
+                date: '2023-05-06',
+                notes: 'NOTES',
+            }, {
+                setEditTournament,
+                tournamentData: tournamentBuilder().build(),
+                editTournament: true,
+                setTournamentData,
+            });
+            reportedError.verifyNoError();
+
+            const dialog = context.container.querySelector('.modal-dialog');
+            await doChange(dialog, 'input[name="address"]', 'NEW ADDRESS', context.user);
+
+            reportedError.verifyNoError();
+            expect(updatedTournament.address).toEqual('NEW ADDRESS');
+        });
+
+        it('cannot edit tournament from heading when not permitted', async () => {
+            await renderComponent({
+                matches: [],
+                host: 'HOST',
+                opponent: 'OPPONENT',
+                gender: 'GENDER',
+                date: '2023-05-06',
+                notes: 'NOTES',
+            }, {
+                setEditTournament: null,
+                tournamentData: null,
+            });
+            reportedError.verifyNoError();
+
+            await doClick(context.container.querySelector('div[datatype="master-draw"] > h2'));
+
+            reportedError.verifyNoError();
+            expect(editTournament).toEqual(null);
+        });
+
+        it('cannot edit tournament from table of players when not permitted', async () => {
+            await renderComponent({
+                matches: [],
+                host: 'HOST',
+                opponent: 'OPPONENT',
+                gender: 'GENDER',
+                date: '2023-05-06',
+                notes: 'NOTES',
+            }, {
+                setEditTournament: null,
+                tournamentData: null,
+            });
+            reportedError.verifyNoError();
+
+            await doClick(context.container.querySelector('div[datatype="master-draw"] > div'));
+
+            reportedError.verifyNoError();
+            expect(editTournament).toEqual(null);
         });
     });
 });

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.tsx
@@ -1,6 +1,10 @@
 import {useApp} from "../../common/AppContainer";
 import {renderDate} from "../../../helpers/rendering";
 import {TournamentMatchDto} from "../../../interfaces/models/dtos/Game/TournamentMatchDto";
+import {Dialog} from "../../common/Dialog";
+import {TournamentDetails} from "../TournamentDetails";
+import {TournamentGameDto} from "../../../interfaces/models/dtos/Game/TournamentGameDto";
+import {useTournament} from "../TournamentContainer";
 
 export interface IMasterDrawProps {
     matches: TournamentMatchDto[];
@@ -13,11 +17,12 @@ export interface IMasterDrawProps {
 
 export function MasterDraw({matches, host, opponent, gender, date, notes}: IMasterDrawProps) {
     const {onError} = useApp();
+    const {tournamentData, setTournamentData, saving, editTournament, setEditTournament } = useTournament();
 
     try {
         return (<div className="page-break-after" datatype="master-draw">
-            <h2>Master draw</h2>
-            <div className="d-flex flex-row">
+            <h2 onClick={setEditTournament ? async () => await setEditTournament(true) : null}>Master draw</h2>
+            <div className="d-flex flex-row" onClick={setEditTournament ? async () => await setEditTournament(true) : null}>
                 <div>
                     <table className="table">
                         <thead>
@@ -46,6 +51,14 @@ export function MasterDraw({matches, host, opponent, gender, date, notes}: IMast
                     {notes ? (<div>Notes: <span className="fw-bold">{notes}</span></div>) : null}
                 </div>
             </div>
+            {editTournament
+                ? (<Dialog title="Edit tournament details" onClose={async () => await setEditTournament(false)}>
+                    <TournamentDetails
+                        tournamentData={tournamentData}
+                        disabled={saving}
+                        setTournamentData={async (data: TournamentGameDto) => setTournamentData(data)} />
+                </Dialog>)
+                : null}
         </div>);
     } catch (e) {
         /* istanbul ignore next */

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/MatchReport.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/MatchReport.test.tsx
@@ -164,5 +164,22 @@ describe('MatchReport', () => {
             expect(legsWon[0].textContent).toEqual('Legs won: 2');
             expect(legsWon[1].textContent).toEqual('Legs won: 0');
         });
+
+        it('when no division', async () => {
+            await renderComponent({
+                division: null,
+                showWinner: false,
+                noOfThrows: 3,
+                noOfLegs: 3,
+                gender: 'GENDER',
+                host: 'HOST',
+                opponent: 'OPPONENT',
+                saygMatches: []
+            });
+
+            reportedError.verifyNoError();
+            expect(context.container.querySelector('h2').textContent).toEqual('SOMERSET DARTS ORGANISATION');
+            expect(context.container.querySelector('h3').textContent).toEqual('(GENDER)');
+        });
     });
 });

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/MatchReport.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/MatchReport.tsx
@@ -22,7 +22,7 @@ export function MatchReport({division, showWinner, noOfThrows, noOfLegs, gender,
     try {
         return (<div className="page-break-after" datatype="match-report">
             <h2 className="text-center">SOMERSET DARTS ORGANISATION</h2>
-            <h3 className="text-center">{division.name} ({gender})</h3>
+            <h3 className="text-center">{division ? division.name + ' ' : ''}({gender})</h3>
             <table className="table">
                 <thead>
                 <tr>

--- a/CourageScores/ClientApp/src/helpers/collections.test.ts
+++ b/CourageScores/ClientApp/src/helpers/collections.test.ts
@@ -131,7 +131,7 @@ describe('collections', () => {
         });
     });
 
-    describe('groupAndSoryOccurrences', () => {
+    describe('groupAndSortOccurrences', () => {
         it('groups item by property', () => {
             const a1 = { id: 'A' };
             const a2 = { id: 'A' };
@@ -140,8 +140,38 @@ describe('collections', () => {
 
             const result = groupAndSortByOccurrences([ a1, a2, b1, a3 ], 'id');
 
-            expect(result.length).toEqual(2);
             expect(result.map(i => i.id)).toEqual([ 'A', 'B' ]);
+        });
+
+        it('groups item by property where later items have greater occurrences', () => {
+            const b1 = { id: 'B' };
+            const a1 = { id: 'A' };
+            const a2 = { id: 'A' };
+            const a3 = { id: 'A' };
+
+            const result = groupAndSortByOccurrences([ b1, a1, a2, a3 ], 'id');
+
+            expect(result.map(i => i.id)).toEqual([ 'A', 'B' ]);
+        });
+
+        it('groups item by property where items have same number of occurrences', () => {
+            const b1 = { id: 'B' };
+            const b2 = { id: 'B' };
+            const a1 = { id: 'A' };
+            const a2 = { id: 'A' };
+
+            const result = groupAndSortByOccurrences([ b1, a1, a2, b2 ], 'id');
+
+            expect(result.map(i => i.id)).toEqual([ 'A', 'B' ]);
+        });
+
+        it('groups item by property where items have same id', () => {
+            const a1 = { id: 'A' };
+            const a2 = { id: 'A' };
+
+            const result = groupAndSortByOccurrences([ a1, a2 ], 'id');
+
+            expect(result.map(i => i.id)).toEqual([ 'A' ]);
         });
 
         it('returns items with occurrences in descending order', () => {
@@ -152,7 +182,6 @@ describe('collections', () => {
 
             const result = groupAndSortByOccurrences([ a1, a2, b1, a3 ], 'id');
 
-            expect(result.length).toEqual(2);
             expect(result.map(i => i.occurrences)).toEqual([ 3, 1 ]);
         });
 

--- a/CourageScores/ClientApp/src/helpers/collections.test.ts
+++ b/CourageScores/ClientApp/src/helpers/collections.test.ts
@@ -5,7 +5,7 @@ import {
     any,
     count,
     distinct,
-    elementAt,
+    elementAt, groupAndSortByOccurrences,
     isEmpty,
     max,
     reverse,
@@ -128,6 +128,42 @@ describe('collections', () => {
                 {home: {name: 'a'}},
                 {home: {name: 'b'}},
                 {home: {name: 'c'}}]);
+        });
+    });
+
+    describe('groupAndSoryOccurrences', () => {
+        it('groups item by property', () => {
+            const a1 = { id: 'A' };
+            const a2 = { id: 'A' };
+            const b1 = { id: 'B' };
+            const a3 = { id: 'A' };
+
+            const result = groupAndSortByOccurrences([ a1, a2, b1, a3 ], 'id');
+
+            expect(result.length).toEqual(2);
+            expect(result.map(i => i.id)).toEqual([ 'A', 'B' ]);
+        });
+
+        it('returns items with occurrences in descending order', () => {
+            const a1 = { id: 'A' };
+            const a2 = { id: 'A' };
+            const b1 = { id: 'B' };
+            const a3 = { id: 'A' };
+
+            const result = groupAndSortByOccurrences([ a1, a2, b1, a3 ], 'id');
+
+            expect(result.length).toEqual(2);
+            expect(result.map(i => i.occurrences)).toEqual([ 3, 1 ]);
+        });
+
+        it('original items are unmodified', () => {
+            const a1 = { id: 'A' };
+            const a2 = { id: 'A' };
+
+            groupAndSortByOccurrences([ a1, a2 ], 'id');
+
+            expect(a1).toEqual({ id: 'A' });
+            expect(a2).toEqual({ id: 'A' });
         });
     });
 

--- a/CourageScores/ClientApp/src/helpers/collections.ts
+++ b/CourageScores/ClientApp/src/helpers/collections.ts
@@ -54,6 +54,45 @@ export function sortBy(property: string, descending?: boolean): (a: any, b: any)
     }
 }
 
+export interface Frequency {
+    occurrences: number;
+}
+
+/*
+* Group items in a collections by the given property and return them in order of occurrences, descending
+* */
+export function groupAndSortByOccurrences<T>(items: T[], property: string): (T & Frequency)[] {
+    const oneEightyMap: { [id: string]: number } = {};
+    const itemLookup: { [id: string]: T } = {};
+
+    items.forEach((item: T) => {
+        const id = item[property];
+
+        if (oneEightyMap[id]) {
+            oneEightyMap[id]++;
+        } else {
+            oneEightyMap[id] = 1;
+            itemLookup[id] = item;
+        }
+    });
+
+    return Object.keys(oneEightyMap).sort((aId: string, bId: string) => {
+        if (oneEightyMap[aId] > oneEightyMap[bId]) {
+            return -1;
+        }
+        if (oneEightyMap[aId] < oneEightyMap[bId]) {
+            return 1;
+        }
+
+        return 0;
+    }).map((id: string): T & Frequency => {
+        const occurrences: number = oneEightyMap[id];
+        const item: T = itemLookup[id];
+
+        return Object.assign({ occurrences }, item);
+    });
+}
+
 /*
 * Return true if there are any items (that match the optional predicate)
 * */

--- a/CourageScores/ClientApp/src/helpers/collections.ts
+++ b/CourageScores/ClientApp/src/helpers/collections.ts
@@ -54,14 +54,14 @@ export function sortBy(property: string, descending?: boolean): (a: any, b: any)
     }
 }
 
-export interface Frequency {
+export interface IFrequency {
     occurrences: number;
 }
 
 /*
 * Group items in a collections by the given property and return them in order of occurrences, descending
 * */
-export function groupAndSortByOccurrences<T>(items: T[], property: string): (T & Frequency)[] {
+export function groupAndSortByOccurrences<T>(items: T[], property: string): (T & IFrequency)[] {
     const oneEightyMap: { [id: string]: number } = {};
     const itemLookup: { [id: string]: T } = {};
 
@@ -84,8 +84,16 @@ export function groupAndSortByOccurrences<T>(items: T[], property: string): (T &
             return 1;
         }
 
+        // they have the same frequency, so sort by name instead
+        if (aId < bId) {
+            return -1;
+        }
+        if (aId > bId) {
+            return 1;
+        }
+
         return 0;
-    }).map((id: string): T & Frequency => {
+    }).map((id: string): T & IFrequency => {
         const occurrences: number = oneEightyMap[id];
         const item: T = itemLookup[id];
 

--- a/CourageScores/ClientApp/src/helpers/tournaments.ts
+++ b/CourageScores/ClientApp/src/helpers/tournaments.ts
@@ -1,4 +1,4 @@
-import {repeat} from "./projection";
+import {createTemporaryId, repeat} from "./projection";
 import {any} from "./collections";
 import {IBootstrapDropdownItem} from "../components/common/BootstrapDropdown";
 import {TournamentSideDto} from "../interfaces/models/dtos/Game/TournamentSideDto";
@@ -365,6 +365,7 @@ export function removeSide(tournamentData: TournamentGameDto, side: TournamentSi
 export function addSide(tournamentData: TournamentGameDto, newSide: TournamentSideDto): TournamentGameDto {
     const newTournamentData: TournamentGameDto = Object.assign({}, tournamentData);
     newSide.name = (newSide.name || '').trim();
+    newSide.id = createTemporaryId();
     newTournamentData.sides.push(newSide);
     return newTournamentData;
 }


### PR DESCRIPTION
Related to #743

- [x] **Cannot read properties of null (reading 'name')**
When switching to superleague [tournament](https://couragescoresdev.azurewebsites.net/tournament/e0b8270e-da64-4960-aa35-7b1474b46b32) from print screen
- [x] restore add side button for superleague tournaments