### PR TITLE
#855 favourite team

### DIFF
--- a/CourageScores/ClientApp/package-lock.json
+++ b/CourageScores/ClientApp/package-lock.json
@@ -12,6 +12,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "bootstrap": "^5.1.3",
         "jest-junit": "^16.0.0",
+        "react-cookie": "^7.1.4",
         "react-markdown": "^8.0.7",
         "react-router-bootstrap": "^0.26.1",
         "react-router-dom": "^6.3.0",
@@ -4016,6 +4017,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
     "node_modules/@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -4054,6 +4060,15 @@
       "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -5924,6 +5939,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.36.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.0.tgz",
@@ -7673,6 +7696,14 @@
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
       "dependencies": {
         "@babel/runtime": "^7.7.6"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -12031,6 +12062,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-7.1.4.tgz",
+      "integrity": "sha512-wDxxa/HYaSXSMlyWJvJ5uZTzIVtQTPf1gMksFgwAz/2/W3lCtY8r4OChCXMPE7wax0PAdMY97UkNJedGv7KnDw==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.5",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^7.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -13386,6 +13430,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.1.4.tgz",
+      "integrity": "sha512-Q+DVJsdykStWRMtXr2Pdj3EF98qZHUH/fXv/gwFz/unyToy1Ek1w5GsWt53Pf38tT8Gbcy5QNsj61Xe9TggP4g==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.6.0"
       }
     },
     "node_modules/universal-user-agent": {
@@ -16717,6 +16770,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
     "@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -16755,6 +16813,15 @@
       "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
       "requires": {
         "@types/unist": "*"
+      }
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -18035,6 +18102,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+    },
+    "cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
     },
     "core-js": {
       "version": "3.36.0",
@@ -19321,6 +19393,14 @@
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
       "requires": {
         "@babel/runtime": "^7.7.6"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "html-encoding-sniffer": {
@@ -22410,6 +22490,16 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "react-cookie": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-7.1.4.tgz",
+      "integrity": "sha512-wDxxa/HYaSXSMlyWJvJ5uZTzIVtQTPf1gMksFgwAz/2/W3lCtY8r4OChCXMPE7wax0PAdMY97UkNJedGv7KnDw==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.5",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^7.0.0"
+      }
+    },
     "react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -23388,6 +23478,15 @@
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.1.4.tgz",
+      "integrity": "sha512-Q+DVJsdykStWRMtXr2Pdj3EF98qZHUH/fXv/gwFz/unyToy1Ek1w5GsWt53Pf38tT8Gbcy5QNsj61Xe9TggP4g==",
+      "requires": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.6.0"
       }
     },
     "universal-user-agent": {

--- a/CourageScores/ClientApp/package.json
+++ b/CourageScores/ClientApp/package.json
@@ -8,6 +8,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "bootstrap": "^5.1.3",
     "jest-junit": "^16.0.0",
+    "react-cookie": "^7.1.4",
     "react-markdown": "^8.0.7",
     "react-router-bootstrap": "^0.26.1",
     "react-router-dom": "^6.3.0",

--- a/CourageScores/ClientApp/src/App.test.tsx
+++ b/CourageScores/ClientApp/src/App.test.tsx
@@ -100,6 +100,7 @@ describe('App', () => {
                 }
             },
             user: null,
+            cookies: null,
         };
     }
 

--- a/CourageScores/ClientApp/src/App.tsx
+++ b/CourageScores/ClientApp/src/App.tsx
@@ -21,6 +21,7 @@ import {TeamDto} from "./interfaces/models/dtos/Team/TeamDto";
 import {UserDto} from "./interfaces/models/dtos/Identity/UserDto";
 import {Tv} from "./components/Tv";
 import {IBrowserType} from "./components/common/IBrowserType";
+import {PreferencesContainer} from "./components/common/PreferencesContainer";
 
 export interface IAppProps {
     embed: boolean;
@@ -135,23 +136,25 @@ export function App({embed, controls, testRoute}: IAppProps) {
 
     try {
         return (<AppContainer {...appData}>
-            <Layout>
-                <Routes>
-                    <Route path='/' element={<Home/>}/>
-                    <Route path='/division/:divisionId' element={<Division/>}/>
-                    <Route path='/division/:divisionId/:mode' element={<Division/>}/>
-                    <Route path='/division/:divisionId/:mode/:seasonId' element={<Division/>}/>
-                    <Route path='/score/:fixtureId' element={<Score/>}/>
-                    <Route path='/admin' element={<AdminHome/>}/>
-                    <Route path='/admin/:mode' element={<AdminHome/>}/>
-                    <Route path='/tournament/:tournamentId' element={<Tournament/>}/>
-                    <Route path='/practice' element={<Practice/>}/>
-                    <Route path='/about' element={<About/>}/>
-                    <Route path='/live/match/:id' element={<LiveSayg />}/>
-                    <Route path='/tv' element={<Tv/>}/>
-                    {testRoute}
-                </Routes>
-            </Layout>
+            <PreferencesContainer>
+                <Layout>
+                    <Routes>
+                        <Route path='/' element={<Home/>}/>
+                        <Route path='/division/:divisionId' element={<Division/>}/>
+                        <Route path='/division/:divisionId/:mode' element={<Division/>}/>
+                        <Route path='/division/:divisionId/:mode/:seasonId' element={<Division/>}/>
+                        <Route path='/score/:fixtureId' element={<Score/>}/>
+                        <Route path='/admin' element={<AdminHome/>}/>
+                        <Route path='/admin/:mode' element={<AdminHome/>}/>
+                        <Route path='/tournament/:tournamentId' element={<Tournament/>}/>
+                        <Route path='/practice' element={<Practice/>}/>
+                        <Route path='/about' element={<About/>}/>
+                        <Route path='/live/match/:id' element={<LiveSayg />}/>
+                        <Route path='/tv' element={<Tv/>}/>
+                        {testRoute}
+                    </Routes>
+                </Layout>
+            </PreferencesContainer>
         </AppContainer>);
     } catch (e) {
         /* istanbul ignore next */

--- a/CourageScores/ClientApp/src/components/common/IPreferences.ts
+++ b/CourageScores/ClientApp/src/components/common/IPreferences.ts
@@ -1,0 +1,4 @@
+export interface IPreferences {
+    getPreference<T>(name: string): T | null;
+    upsertPreference<T>(name: string, value: T): void;
+}

--- a/CourageScores/ClientApp/src/components/common/PreferencesContainer.test.tsx
+++ b/CourageScores/ClientApp/src/components/common/PreferencesContainer.test.tsx
@@ -1,0 +1,154 @@
+import {
+    appProps,
+    brandingProps,
+    cleanUp,
+    ErrorState,
+    iocProps,
+    renderApp,
+    TestContext
+} from "../../helpers/tests";
+import {PreferencesContainer, usePreferences} from "./PreferencesContainer";
+import {IPreferences} from "./IPreferences";
+import {Cookies} from "react-cookie";
+import {act} from "@testing-library/react";
+
+describe('PreferencesContainer', () => {
+    let context: TestContext;
+    let reportedError: ErrorState;
+
+    afterEach(() => {
+        cleanUp(context);
+    });
+
+    beforeEach(() => {
+        reportedError = new ErrorState();
+    });
+
+    async function renderComponent(preferenceStore: IPreferences) {
+        context = await renderApp(
+            iocProps(),
+            brandingProps(),
+            appProps(),
+            (<PreferencesContainer>
+                <PreferencesContainerAccessor exposeVia={preferenceStore} />
+            </PreferencesContainer>));
+
+        // don't allow onError to be called - would call infinite-loop/recursion
+        reportedError.verifyNoError();
+    }
+
+    describe('interactivity', () => {
+        it('can get preference when no cookie defined', async () => {
+            const accessor: IPreferences = {
+                getPreference: null,
+                upsertPreference: null,
+            };
+            await renderComponent(accessor);
+            context.cookies.remove('preferences');
+
+            const result = accessor.getPreference('anything');
+
+            expect(result).toBeFalsy();
+        });
+
+        it('can get preference when cookie is empty', async () => {
+            const accessor: IPreferences = {
+                getPreference: null,
+                upsertPreference: null,
+            };
+            await renderComponent(accessor);
+            context.cookies.set('preferences', { });
+
+            const result = accessor.getPreference('anything');
+
+            expect(result).toBeFalsy();
+        });
+
+        it('can get preference when cookie populated', async () => {
+            const cookies = new Cookies();
+            cookies.set('preferences', { anything: 'else' });
+            const accessor: IPreferences = {
+                getPreference: null,
+                upsertPreference: null,
+            };
+            await renderComponent(accessor);
+
+            const result = accessor.getPreference('anything');
+
+            expect(result).toEqual('else');
+        });
+
+        it('can create cookie with preference', async () => {
+            const accessor: IPreferences = {
+                getPreference: null,
+                upsertPreference: null,
+            };
+            await renderComponent(accessor);
+            context.cookies.remove('preferences');
+
+            await act(async () => {
+                accessor.upsertPreference('anything', 'else');
+            });
+
+            const cookie = context.cookies.get('preferences');
+            expect(cookie).toEqual({ anything: 'else' });
+        });
+
+        it('can replace preference in cookie', async () => {
+            const accessor: IPreferences = {
+                getPreference: null,
+                upsertPreference: null,
+            };
+            await renderComponent(accessor);
+            context.cookies.set('preferences', { anything: 'else' });
+
+            await act(async () => {
+                accessor.upsertPreference('anything', 'ELSE');
+            });
+
+            const cookie = context.cookies.get('preferences');
+            expect(cookie).toEqual({ anything: 'ELSE' });
+        });
+
+        it('can remove preference from cookie', async () => {
+            const accessor: IPreferences = {
+                getPreference: null,
+                upsertPreference: null,
+            };
+            await renderComponent(accessor);
+            context.cookies.set('preferences', { anything: 'else' });
+
+            await act(async () => {
+                accessor.upsertPreference('anything', null);
+            });
+
+            const cookie = context.cookies.get('preferences');
+            expect(cookie).toEqual({ });
+        });
+
+        it('can replace preference with different type of object', async () => {
+            const accessor: IPreferences = {
+                getPreference: null,
+                upsertPreference: null,
+            };
+            await renderComponent(accessor);
+            context.cookies.set('preferences', { anything: 'else' });
+
+            await act(async () => {
+                accessor.upsertPreference('anything', [ 1, 2, 3 ]);
+            });
+
+            const cookie = context.cookies.get('preferences');
+            expect(cookie).toEqual({ anything: [ 1, 2, 3 ] });
+        });
+    });
+
+    function PreferencesContainerAccessor({ exposeVia }) {
+        const { getPreference, upsertPreference } = usePreferences();
+
+        exposeVia.getPreference = getPreference;
+        exposeVia.upsertPreference = upsertPreference;
+
+        return (<div>Rendered</div>);
+    }
+});

--- a/CourageScores/ClientApp/src/components/common/PreferencesContainer.tsx
+++ b/CourageScores/ClientApp/src/components/common/PreferencesContainer.tsx
@@ -1,0 +1,46 @@
+import React, {createContext, useContext, useState} from "react";
+import {IPreferences} from "./IPreferences";
+
+const PreferencesContext = createContext({});
+
+export interface IPreferenceData {
+    [ key: string]: any;
+}
+
+export function usePreferences(): IPreferences {
+    return useContext(PreferencesContext) as IPreferences;
+}
+
+export interface IPreferencesContainerProps {
+    children?: React.ReactNode;
+    initialPreferences?: IPreferenceData;
+}
+
+/* istanbul ignore next */
+export function PreferencesContainer({children, initialPreferences} : IPreferencesContainerProps) {
+    const [ preferences, updatePreferences ] = useState<IPreferenceData>(initialPreferences || {});
+
+    function getPreference<T>(name: string): T | null {
+        return preferences[name];
+    }
+
+    function upsertPreference<T>(name: string, value: T): void {
+        const newPreferences: IPreferenceData = Object.assign({}, preferences);
+
+        if (!value) {
+            delete newPreferences[name];
+        } else {
+            newPreferences[name] = value;
+        }
+
+        updatePreferences(newPreferences);
+    }
+
+    const preferenceAccessor: IPreferences = {
+        getPreference,
+        upsertPreference,
+    };
+    return (<PreferencesContext.Provider value={preferenceAccessor}>
+        {children}
+    </PreferencesContext.Provider>)
+}

--- a/CourageScores/ClientApp/src/components/common/ToggleFavouriteTeam.test.tsx
+++ b/CourageScores/ClientApp/src/components/common/ToggleFavouriteTeam.test.tsx
@@ -1,0 +1,91 @@
+import {
+    appProps,
+    brandingProps,
+    cleanUp, doClick, findButton,
+    iocProps,
+    renderApp, TestContext
+} from "../../helpers/tests";
+import {IToggleFavouriteTeamProps, ToggleFavouriteTeam} from "./ToggleFavouriteTeam";
+import {IPreferenceData} from "./PreferencesContainer";
+import {createTemporaryId} from "../../helpers/projection";
+import {DivisionDataContainer} from "../league/DivisionDataContainer";
+
+describe('ToggleFavouriteTeam', () => {
+    let context: TestContext;
+
+    afterEach(() => {
+        cleanUp(context);
+    });
+
+    beforeEach(() => {
+    });
+
+    async function renderComponent(props: IToggleFavouriteTeamProps, favouritesEnabled: boolean, initialPreferences?: IPreferenceData) {
+        context = await renderApp(
+            iocProps(),
+            brandingProps(),
+            appProps(),
+            (<DivisionDataContainer onReloadDivision={null}
+                                    setDivisionData={null}
+                                    name="DIVISION"
+                                    favouritesEnabled={favouritesEnabled}>
+                <ToggleFavouriteTeam {...props} />
+            </DivisionDataContainer>),
+            null,
+            null,
+            null,
+            initialPreferences);
+    }
+
+    describe('renders', () => {
+        it('when team is a favourite', async () => {
+            const teamId: string = createTemporaryId();
+
+            await renderComponent({ teamId }, true, { favouriteTeamIds: [ teamId ]});
+
+            expect(context.container.querySelector('button').className).not.toContain('opacity-25');
+        });
+
+        it('when team is not a favourite', async () => {
+            const teamId: string = createTemporaryId();
+
+            await renderComponent({ teamId }, true, { favouriteTeamIds: [ ]});
+
+            expect(context.container.querySelector('button').className).toContain('opacity-25');
+        });
+
+        it('nothing when favourites not enabled', async () => {
+            const teamId: string = createTemporaryId();
+
+            await renderComponent({ teamId }, false);
+
+            expect(context.container.querySelector('button')).toBeNull();
+        });
+    });
+
+    describe('interactivity', () => {
+        it('can add a team to being a favourite', async () => {
+            const teamId: string = createTemporaryId();
+            const otherTeamId: string = createTemporaryId();
+            await renderComponent({ teamId }, true, { favouriteTeamIds: [ otherTeamId ]});
+
+            await doClick(findButton(context.container, '⭐'));
+
+            expect(context.cookies.get('preferences')).toEqual({
+                favouriteTeamIds: [ otherTeamId, teamId ],
+            });
+        });
+
+        it('can remove a team from being a favourite', async () => {
+            const teamId: string = createTemporaryId();
+            const otherTeamId: string = createTemporaryId();
+            await renderComponent({ teamId }, true, { favouriteTeamIds: [ otherTeamId, teamId ]});
+
+            await doClick(findButton(context.container, '⭐'));
+
+            expect(context.cookies.get('preferences')).toEqual({
+                favouriteTeamIds: [ otherTeamId ],
+            });
+        });
+    });
+});

--- a/CourageScores/ClientApp/src/components/common/ToggleFavouriteTeam.tsx
+++ b/CourageScores/ClientApp/src/components/common/ToggleFavouriteTeam.tsx
@@ -1,0 +1,33 @@
+import {any} from "../../helpers/collections";
+import {usePreferences} from "./PreferencesContainer";
+import {useDivisionData} from "../league/DivisionDataContainer";
+
+export interface IToggleFavouriteTeamProps {
+    teamId: string;
+}
+
+export function ToggleFavouriteTeam({ teamId }: IToggleFavouriteTeamProps) {
+    const { getPreference, upsertPreference } = usePreferences();
+    const { favouritesEnabled } = useDivisionData();
+    const favouriteTeamIds: string[] = getPreference<string[]>('favouriteTeamIds') || [];
+    const isFavourite: boolean = any(favouriteTeamIds, id => id === teamId);
+
+    if (!favouritesEnabled) {
+        return null;
+    }
+
+    function toggleFavourite(teamId: string) {
+        const newFavourites: string[] = any(favouriteTeamIds, (id: string) => id === teamId)
+            ? favouriteTeamIds.filter(id => id !== teamId)
+            : favouriteTeamIds.concat(teamId);
+
+        upsertPreference('favouriteTeamIds', newFavourites);
+    }
+
+    return (<button onClick={() => toggleFavourite(teamId)}
+                    tabIndex={-1}
+                    datatype="toggle-favourite"
+                    className={(isFavourite ? '' : 'opacity-25') + ' bg-white border-0 p-0 m-0 me-1'}>
+        ⭐
+    </button>);
+}

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.test.tsx
@@ -346,15 +346,13 @@ describe('DivisionFixture', () => {
                     .build(),
                 account,
                 toMap([team]),
-                {
-                    favouriteTeamIds: [],
-                });
+                { favouriteTeamIds: [] });
             const row = context.container.querySelector('tr');
             const favouriteToggles = Array.from(row.querySelectorAll('button[datatype="toggle-favourite"]'));
 
             await doClick(favouriteToggles[0]);
 
-            const favouriteTeamIds = [];
+            const favouriteTeamIds = context.cookies.get('preferences').favouriteTeamIds;
             expect(favouriteTeamIds).toEqual([fixture.homeTeam.id]);
         });
 
@@ -373,15 +371,13 @@ describe('DivisionFixture', () => {
                     .build(),
                 account,
                 toMap([team]),
-                {
-                    favouriteTeamIds: [fixture.homeTeam.id],
-                });
+                { favouriteTeamIds: [fixture.homeTeam.id] });
             const row = context.container.querySelector('tr');
             const favouriteToggles = Array.from(row.querySelectorAll('button[datatype="toggle-favourite"]'));
 
             await doClick(favouriteToggles[0]);
 
-            const favouriteTeamIds = [fixture.homeTeam.id];
+            const favouriteTeamIds = context.cookies.get('preferences').favouriteTeamIds;
             expect(favouriteTeamIds).toEqual([]);
         });
     });

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
@@ -285,7 +285,7 @@ export function DivisionFixture({fixture, date, readOnly, onUpdateFixtures, befo
     }
 
     function renderFavouriteButton(teamId: string, isFavourite: boolean) {
-        if (!favouritesEnabled) {
+        if (!favouritesEnabled || isAdmin) {
             return null;
         }
 

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
@@ -38,7 +38,7 @@ export function DivisionFixture({fixture, date, readOnly, onUpdateFixtures, befo
     };
     const {account, teams: allTeams, onError} = useApp();
     const {getPreference} = usePreferences();
-    const {id: divisionId, name: divisionName, fixtures, season, teams, onReloadDivision} = useDivisionData();
+    const {id: divisionId, name: divisionName, fixtures, season, teams, onReloadDivision, favouritesEnabled} = useDivisionData();
     const isAdmin = account && account.access && account.access.manageGames;
     const [saving, setSaving] = useState<boolean>(false);
     const [deleting, setDeleting] = useState<boolean>(false);
@@ -286,7 +286,7 @@ export function DivisionFixture({fixture, date, readOnly, onUpdateFixtures, befo
     }
 
     try {
-        return (<tr className={(deleting ? 'text-decoration-line-through' : '') + (notAFavourite ? ' opacity-25' : '')}>
+        return (<tr className={(deleting ? 'text-decoration-line-through' : '') + (notAFavourite && favouritesEnabled ? ' opacity-25' : '')}>
             <td className="text-end">
                 {awayTeamId && (fixture.id !== fixture.homeTeam.id)
                     ? (<EmbedAwareLink to={`/score/${fixture.id}`}

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
@@ -17,6 +17,7 @@ import {TeamDto} from "../../interfaces/models/dtos/Team/TeamDto";
 import {IEditableDivisionFixtureDateDto} from "./IEditableDivisionFixtureDateDto";
 import {TeamSeasonDto} from "../../interfaces/models/dtos/Team/TeamSeasonDto";
 import {usePreferences} from "../common/PreferencesContainer";
+import {ToggleFavouriteTeam} from "../common/ToggleFavouriteTeam";
 
 export interface IDivisionFixtureProps {
     fixture: IEditableDivisionFixtureDto;
@@ -36,8 +37,8 @@ export function DivisionFixture({fixture, date, readOnly, onUpdateFixtures, befo
         value: '',
     };
     const {account, teams: allTeams, onError} = useApp();
-    const {getPreference, upsertPreference} = usePreferences();
-    const {id: divisionId, name: divisionName, fixtures, season, teams, onReloadDivision, favouritesEnabled} = useDivisionData();
+    const {getPreference} = usePreferences();
+    const {id: divisionId, name: divisionName, fixtures, season, teams, onReloadDivision} = useDivisionData();
     const isAdmin = account && account.access && account.access.manageGames;
     const [saving, setSaving] = useState<boolean>(false);
     const [deleting, setDeleting] = useState<boolean>(false);
@@ -196,7 +197,7 @@ export function DivisionFixture({fixture, date, readOnly, onUpdateFixtures, befo
             return (fixture.awayTeam
                 ? awayTeamId && (fixture.id !== fixture.homeTeam.id)
                     ? (<>
-                        {renderFavouriteButton(fixture.awayTeam.id, awayTeamIsFavourite)}
+                        {isAdmin ? null : <ToggleFavouriteTeam teamId={fixture.awayTeam.id} />}
                         <EmbedAwareLink to={`/score/${fixture.id}`} className="margin-right">
                             {fixture.awayTeam.name}
                         </EmbedAwareLink>
@@ -284,27 +285,6 @@ export function DivisionFixture({fixture, date, readOnly, onUpdateFixtures, befo
         }
     }
 
-    function renderFavouriteButton(teamId: string, isFavourite: boolean) {
-        if (!favouritesEnabled || isAdmin) {
-            return null;
-        }
-
-        return (<button onClick={() => toggleFavourite(teamId)}
-                        tabIndex={-1}
-                        datatype="toggle-favourite"
-                        className={(isFavourite ? '' : 'opacity-25') + ' bg-white border-0 p-0 m-0 me-1'}>
-            ⭐
-        </button>);
-    }
-
-    function toggleFavourite(teamId: string) {
-        const newFavourites: string[] = any(favouriteTeamIds, (id: string) => id === teamId)
-            ? favouriteTeamIds.filter(id => id !== teamId)
-            : favouriteTeamIds.concat(teamId);
-
-        upsertPreference('favouriteTeamIds', newFavourites);
-    }
-
     try {
         return (<tr className={(deleting ? 'text-decoration-line-through' : '') + (notAFavourite ? ' opacity-25' : '')}>
             <td className="text-end">
@@ -313,7 +293,7 @@ export function DivisionFixture({fixture, date, readOnly, onUpdateFixtures, befo
                                        className="margin-right">{fixture.homeTeam.name}</EmbedAwareLink>)
                     : (<EmbedAwareLink to={`/division/${divisionName}/team:${fixture.homeTeam.name}/${season.name}`}
                                        className="margin-right">{fixture.homeTeam.name}</EmbedAwareLink>)}
-                {renderFavouriteButton(fixture.homeTeam.id, homeTeamIsFavourite)}
+                {isAdmin ? null : <ToggleFavouriteTeam teamId={fixture.homeTeam.id} />}
             </td>
             <td className="narrow-column text-primary fw-bolder">{fixture.postponed
                 ? (<span className="text-danger">P</span>)

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
@@ -37,7 +37,7 @@ export function DivisionFixture({fixture, date, readOnly, onUpdateFixtures, befo
     };
     const {account, teams: allTeams, onError} = useApp();
     const {getPreference, upsertPreference} = usePreferences();
-    const {id: divisionId, name: divisionName, fixtures, season, teams, onReloadDivision} = useDivisionData();
+    const {id: divisionId, name: divisionName, fixtures, season, teams, onReloadDivision, favouritesEnabled} = useDivisionData();
     const isAdmin = account && account.access && account.access.manageGames;
     const [saving, setSaving] = useState<boolean>(false);
     const [deleting, setDeleting] = useState<boolean>(false);
@@ -45,7 +45,6 @@ export function DivisionFixture({fixture, date, readOnly, onUpdateFixtures, befo
     const [clipCellRegion, setClipCellRegion] = useState<boolean>(true);
     const {gameApi} = useDependencies();
     const awayTeamId: string = fixture.awayTeam ? fixture.awayTeam.id : '';
-    const favouritesEnabled = false;
     const favouriteTeamIds: string[] = getPreference<string[]>('favouriteTeamIds') || [];
     const homeTeamIsFavourite: boolean = any(favouriteTeamIds) && any(favouriteTeamIds, id => id === fixture.homeTeam.id);
     const awayTeamIsFavourite: boolean = any(favouriteTeamIds) && fixture.awayTeam && any(favouriteTeamIds, id => id === fixture.awayTeam.id);

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
@@ -307,13 +307,13 @@ export function DivisionFixture({fixture, date, readOnly, onUpdateFixtures, befo
 
     try {
         return (<tr className={(deleting ? 'text-decoration-line-through' : '') + (notAFavourite ? ' opacity-25' : '')}>
-            <td>
-                {renderFavouriteButton(fixture.homeTeam.id, homeTeamIsFavourite)}
+            <td className="text-end">
                 {awayTeamId && (fixture.id !== fixture.homeTeam.id)
                     ? (<EmbedAwareLink to={`/score/${fixture.id}`}
                                        className="margin-right">{fixture.homeTeam.name}</EmbedAwareLink>)
                     : (<EmbedAwareLink to={`/division/${divisionName}/team:${fixture.homeTeam.name}/${season.name}`}
                                        className="margin-right">{fixture.homeTeam.name}</EmbedAwareLink>)}
+                {renderFavouriteButton(fixture.homeTeam.id, homeTeamIsFavourite)}
             </td>
             <td className="narrow-column text-primary fw-bolder">{fixture.postponed
                 ? (<span className="text-danger">P</span>)

--- a/CourageScores/ClientApp/src/components/division_teams/DivisionTeam.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/DivisionTeam.tsx
@@ -8,18 +8,25 @@ import {AssignTeamToSeasons} from "./AssignTeamToSeasons";
 import {EmbedAwareLink} from "../common/EmbedAwareLink";
 import {DivisionTeamDto} from "../../interfaces/models/dtos/Division/DivisionTeamDto";
 import {EditTeamDto} from "../../interfaces/models/dtos/Team/EditTeamDto";
+import {ToggleFavouriteTeam} from "../common/ToggleFavouriteTeam";
+import {usePreferences} from "../common/PreferencesContainer";
+import {any} from "../../helpers/collections";
 
 export interface IDivisionTeamProps {
     team: DivisionTeamDto;
 }
 
 export function DivisionTeam({team}: IDivisionTeamProps) {
-    const {id: divisionId, season, onReloadDivision, name: divisionName} = useDivisionData();
+    const {id: divisionId, season, onReloadDivision, name: divisionName, favouritesEnabled} = useDivisionData();
     const {account, onError} = useApp();
     const [teamDetails, setTeamDetails] = useState<EditTeamDto>(Object.assign({newDivisionId: divisionId}, team));
     const [editTeam, setEditTeam] = useState<boolean>(false);
     const [addTeamToSeason, setAddTeamToSeason] = useState<boolean>(false);
     const isAdmin = account && account.access && account.access.manageTeams;
+    const {getPreference} = usePreferences();
+    const favouriteTeamIds: string[] = getPreference<string[]>('favouriteTeamIds') || [];
+    const teamIsFavourite: boolean = any(favouriteTeamIds, id => id === team.id);
+    const notAFavourite: boolean = any(favouriteTeamIds) && !teamIsFavourite;
 
     async function teamDetailSaved() {
         await onReloadDivision();
@@ -58,12 +65,13 @@ export function DivisionTeam({team}: IDivisionTeamProps) {
     }
 
     try {
-        return (<tr>
+        return (<tr className={(notAFavourite && favouritesEnabled ? ' opacity-25' : '')}>
             <td>
                 {isAdmin ? (<button onClick={() => setEditTeam(true)}
                                     className="btn btn-sm btn-primary margin-right d-print-none">✏️</button>) : null}
                 {isAdmin ? (<button onClick={() => setAddTeamToSeason(true)}
                                     className="btn btn-sm btn-primary margin-right d-print-none">➕</button>) : null}
+                {isAdmin ? null : (<ToggleFavouriteTeam teamId={team.id} />)}
                 <EmbedAwareLink to={`/division/${divisionName}/team:${team.name}/${season.name}`}>
                     {team.name}
                 </EmbedAwareLink>

--- a/CourageScores/ClientApp/src/components/league/IDivisionData.ts
+++ b/CourageScores/ClientApp/src/components/league/IDivisionData.ts
@@ -3,4 +3,5 @@ import {DivisionDataDto} from "../../interfaces/models/dtos/Division/DivisionDat
 export interface IDivisionData extends DivisionDataDto {
     onReloadDivision(preventReloadIfIdsAreTheSame?: boolean): Promise<DivisionDataDto | null>;
     setDivisionData(data: DivisionDataDto): Promise<any>;
+    favouritesEnabled?: boolean;
 }

--- a/CourageScores/ClientApp/src/helpers/builders/divisions.ts
+++ b/CourageScores/ClientApp/src/helpers/builders/divisions.ts
@@ -249,6 +249,7 @@ export interface IDivisionDataBuilder extends IAddableBuilder<DivisionDataDto & 
     onReloadDivision(onReloadDivision: (preventReloadIfIdsAreTheSame?: boolean) => Promise<DivisionDataDto | null>): IDivisionDataBuilder;
     setDivisionData(setDivisionData: (value: (((prevState: DivisionDataDto) => DivisionDataDto) | DivisionDataDto)) => Promise<any>): IDivisionDataBuilder;
     children(children: ReactNode): IDivisionDataBuilder;
+    favouritesEnabled(enabled?: boolean): IDivisionDataBuilder;
 }
 
 export function divisionDataBuilder(divisionOrId?: any): IDivisionDataBuilder {
@@ -314,8 +315,12 @@ export function divisionDataBuilder(divisionOrId?: any): IDivisionDataBuilder {
             divisionData.setDivisionData = setDivisionData;
             return builder;
         },
-        children: (children: React.ReactNode) => {
+        children: (children: ReactNode) => {
             divisionData.children = children;
+            return builder;
+        },
+        favouritesEnabled: (enabled?: boolean) => {
+            divisionData.favouritesEnabled = enabled;
             return builder;
         },
     };

--- a/CourageScores/ClientApp/src/helpers/tests.tsx
+++ b/CourageScores/ClientApp/src/helpers/tests.tsx
@@ -12,6 +12,7 @@ import {IParentHeight} from "../components/layout/ParentHeight";
 import {IHttp} from "../api/http";
 import {ReactNode} from "react";
 import {MessageType} from "../interfaces/models/dtos/MessageType";
+import {IPreferenceData, PreferencesContainer} from "../components/common/PreferencesContainer";
 
 /* istanbul ignore file */
 
@@ -209,7 +210,7 @@ export function appProps(props?: any, errorState?: ErrorState): IAppContainerPro
     return Object.assign({}, defaultProps, props);
 }
 
-export async function renderApp(iocProps: IIocContainerProps, brandingProps: IBrandingContainerProps, appProps: IAppContainerProps, content: ReactNode, route?: string, currentPath?: string, containerTag?: string): Promise<TestContext> {
+export async function renderApp(iocProps: IIocContainerProps, brandingProps: IBrandingContainerProps, appProps: IAppContainerProps, content: ReactNode, route?: string, currentPath?: string, containerTag?: string, initialPreferences?: IPreferenceData): Promise<TestContext> {
     const container = document.createElement(containerTag || 'div') as HTMLElement;
     document.body.appendChild(container);
 
@@ -229,7 +230,9 @@ export async function renderApp(iocProps: IIocContainerProps, brandingProps: IBr
                 <Route path={route} element={<IocContainer {...iocProps}>
                     <BrandingContainer {...brandingProps}>
                         <AppContainer {...appProps}>
-                            {content}
+                            <PreferencesContainer initialPreferences={initialPreferences}>
+                                {content}
+                            </PreferencesContainer>
                         </AppContainer>
                     </BrandingContainer>
                 </IocContainer>}/>

--- a/CourageScores/Repository/FeatureLookup.cs
+++ b/CourageScores/Repository/FeatureLookup.cs
@@ -30,6 +30,14 @@ public class FeatureLookup : IFeatureLookup
         "true",
         AllFeatures);
 
+    public static readonly Feature Favourites = new(
+        Guid.Parse("0EDB9FC6-6579-4C4C-9506-77C2485C09A0"),
+        "FavouritesEnabled",
+        "Favourite teams can be selected by any user",
+        Feature.FeatureValueType.Boolean,
+        "false",
+        AllFeatures);
+
     public IEnumerable<Feature> GetAll()
     {
         return AllFeatures.Values;


### PR DESCRIPTION
Resolves #855

- [x] add tests
  - [x] renders when team a favourite 
  - [x] renders when team not a favourite 
  - [x] renders when no teams are a favourite 
  - [x] can set a favourite 
  - [x] can unset a favourite 
  - [x] add a preference 
  - [x] update a preference 
  - [x] delete a preference 
  - [x] retrieve preferences 
- [x] add persistence via cookies/local storage
- [x] don't show/highlight favourites when managing fixtures
- [x] ? Right align home team name (and place favourite icon on right)
- [x] highlight favourite teams in teams table
- [x] highlight favourite teams' players in players table
- [x] allow toggling favourite team via teams table
- [x] allow toggling favourite team via players table