### PR TITLE
#878, 879 multi division support

### DIFF
--- a/CourageScores.Tests/Binders/CommaDelimitedModelBinderTest.cs
+++ b/CourageScores.Tests/Binders/CommaDelimitedModelBinderTest.cs
@@ -1,0 +1,282 @@
+using System.Collections;
+using CourageScores.Binders;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Moq;
+using NUnit.Framework;
+
+namespace CourageScores.Tests.Binders;
+
+[TestFixture]
+public class CommaDelimitedModelBinderTest
+{
+    private CommaDelimitedModelBinder _binder = null!;
+
+    [SetUp]
+    public void SetupEachTest()
+    {
+        _binder = new CommaDelimitedModelBinder();
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenStringProperty_DoesNotBindProperty()
+    {
+        var bindingContext = BindingContext<string>();
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.False);
+        Assert.That(bindingContext.Result.Model, Is.Null);
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenNonGenericIEnumerableProperty_DoesNotBindProperty()
+    {
+        var bindingContext = BindingContext<IEnumerable>();
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.False);
+        Assert.That(bindingContext.Result.Model, Is.Null);
+    }
+
+    [Test]
+    public async Task BindModelAsync_WhenUnableToGetValue_DoesNotBindProperty()
+    {
+        var bindingContext = BindingContext<IEnumerable<string>>();
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.False);
+        Assert.That(bindingContext.Result.Model, Is.Null);
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenIEnumerableProperty_BindsProperty()
+    {
+        var bindingContext = BindingContext<IEnumerable<string>>("abc");
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(bindingContext.Result.Model, Is.EqualTo(new[] { "abc" }));
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenListProperty_BindsProperty()
+    {
+        var bindingContext = BindingContext<List<string>>("abc");
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(bindingContext.Result.Model, Is.TypeOf<List<string>>());
+        Assert.That(bindingContext.Result.Model, Is.EqualTo(new[] { "abc" }));
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenIReadOnlyCollectionProperty_BindsProperty()
+    {
+        var bindingContext = BindingContext<IReadOnlyCollection<string>>("abc");
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(bindingContext.Result.Model, Is.TypeOf<string[]>());
+        Assert.That(bindingContext.Result.Model, Is.EqualTo(new[] { "abc" }));
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenArrayProperty_BindsProperty()
+    {
+        var bindingContext = BindingContext<string[]>("abc");
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(bindingContext.Result.Model, Is.TypeOf<string[]>());
+        Assert.That(bindingContext.Result.Model, Is.EqualTo(new[] { "abc" }));
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenTrailingComma_BindsOnlyFirstValue()
+    {
+        var bindingContext = BindingContext<List<string>>("abc,");
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(bindingContext.Result.Model, Is.EqualTo(new[] { "abc" }));
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenOnlyComma_BindsNoValues()
+    {
+        var bindingContext = BindingContext<List<string>>(",");
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(bindingContext.Result.Model, Is.Empty);
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenEmptyString_BindsNoValues()
+    {
+        var bindingContext = BindingContext<List<string>>("");
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(bindingContext.Result.Model, Is.Empty);
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenWhiteSpaceOnly_BindsNoValues()
+    {
+        var bindingContext = BindingContext<List<string>>("  ");
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(bindingContext.Result.Model, Is.Empty);
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenMultipleValues_BindsMultipleValues()
+    {
+        var bindingContext = BindingContext<List<string>>("abc,def");
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(bindingContext.Result.Model, Is.EqualTo(new[] { "abc", "def" }));
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenEmptyValueBetweenCommas_ExcludesEmptyValue()
+    {
+        var bindingContext = BindingContext<List<string>>("abc,,def");
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(bindingContext.Result.Model, Is.EqualTo(new[] { "abc", "def" }));
+    }
+
+    [TestCase(typeof(int), "1,2", new[] { 1, 2 })]
+    [TestCase(typeof(long), "3,4", new long[] { 3, 4 })]
+    [TestCase(typeof(short), "5,6", new short[] { 5, 6 })]
+    [TestCase(typeof(byte), "7,8", new byte[] { 7, 8 })]
+    [TestCase(typeof(uint), "9,10", new uint[] { 9, 10 })]
+    [TestCase(typeof(ulong), "11,12", new ulong[] { 11, 12 })]
+    [TestCase(typeof(ushort), "13,14", new ushort[] { 13, 14 })]
+    public async Task BindModelAsync_GivenSupportedPrimitiveType_BindsValues(Type elementType, string value, IEnumerable expected)
+    {
+        var tester = CreateTypedTester(elementType);
+
+        await tester.RunTest(value, expected);
+    }
+
+    [Test]
+    public async Task BindModelAsync_GivenGuidElementType_BindsValues()
+    {
+        var tester = new TypedTester<Guid>(_binder);
+
+        await tester.RunTest(
+            "cdc7f4f5-79b3-4ff4-be09-07b6a2ecf444,1915e870-6337-427d-9fcb-17eeff44038c",
+            new[]
+            {
+                Guid.Parse("cdc7f4f5-79b3-4ff4-be09-07b6a2ecf444"),
+                Guid.Parse("1915e870-6337-427d-9fcb-17eeff44038c"),
+            });
+    }
+
+    private interface ITypedTester
+    {
+        Task RunTest(string value, IEnumerable expected);
+    }
+
+    private class TypedTester<T> : ITypedTester
+    {
+        private readonly CommaDelimitedModelBinder _modelBinder;
+
+        public TypedTester(CommaDelimitedModelBinder modelBinder)
+        {
+            _modelBinder = modelBinder;
+        }
+
+        public async Task RunTest(string value, IEnumerable expected)
+        {
+            var bindingContext = BindingContext<List<T>>(value);
+
+            await _modelBinder.BindModelAsync(bindingContext);
+
+            Assert.That(bindingContext.Result.IsModelSet, Is.True);
+            Assert.That(bindingContext.Result.Model, Is.EqualTo(expected));
+        }
+    }
+
+    private class MockModelBindingContext<T> : ModelBindingContext
+    {
+        public override string ModelName { get; set; } = null!;
+        public override ModelBindingResult Result { get; set; }
+        public override IValueProvider ValueProvider { get; set; } = null!;
+
+        public override Type ModelType => typeof(T);
+
+        #region unused members
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public override ActionContext ActionContext { get; set; }
+        public override string? BinderModelName { get; set; }
+        public override BindingSource? BindingSource { get; set; }
+        public override string FieldName { get; set; }
+        public override bool IsTopLevelObject { get; set; }
+        public override object? Model { get; set; }
+        public override ModelMetadata ModelMetadata { get; set; }
+        public override ModelStateDictionary ModelState { get; set; }
+        public override Func<ModelMetadata, bool>? PropertyFilter { get; set; }
+        public override ValidationStateDictionary ValidationState { get; set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+        public override NestedScope EnterNestedScope(ModelMetadata modelMetadata, string fieldName, string modelName, object? model)
+        {
+            throw new NotSupportedException();
+        }
+        public override NestedScope EnterNestedScope()
+        {
+            throw new NotSupportedException();
+        }
+        protected override void ExitNestedScope()
+        {
+            throw new NotSupportedException();
+        }
+        #endregion
+    }
+
+    private static ModelBindingContext BindingContext<T>(string? value = null)
+    {
+        const string modelName = "MODEL NAME";
+        var valueProvider = new Mock<IValueProvider>();
+        valueProvider
+            .Setup(p => p.GetValue(modelName))
+            .Returns(value != null
+                ? new ValueProviderResult(value)
+                : ValueProviderResult.None);
+
+        return new MockModelBindingContext<T>
+        {
+            ModelName = modelName,
+            ValueProvider = valueProvider.Object,
+            Result = ModelBindingResult.Failed(),
+        };
+    }
+
+    private ITypedTester CreateTypedTester(Type elementType)
+    {
+        var typedTesterType = typeof(TypedTester<>).MakeGenericType(elementType);
+        return (ITypedTester)Activator.CreateInstance(typedTesterType, _binder)!;
+    }
+
+}

--- a/CourageScores.Tests/Binders/CommaDelimitedModelBinderTest.cs
+++ b/CourageScores.Tests/Binders/CommaDelimitedModelBinderTest.cs
@@ -100,6 +100,18 @@ public class CommaDelimitedModelBinderTest
     }
 
     [Test]
+    public async Task BindModelAsync_GivenHashSetProperty_BindsProperty()
+    {
+        var bindingContext = BindingContext<HashSet<string>>("abc");
+
+        await _binder.BindModelAsync(bindingContext);
+
+        Assert.That(bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(bindingContext.Result.Model, Is.TypeOf<HashSet<string>>());
+        Assert.That(bindingContext.Result.Model, Is.EqualTo(new[] { "abc" }));
+    }
+
+    [Test]
     public async Task BindModelAsync_GivenTrailingComma_BindsOnlyFirstValue()
     {
         var bindingContext = BindingContext<List<string>>("abc,");
@@ -191,6 +203,31 @@ public class CommaDelimitedModelBinderTest
                 Guid.Parse("cdc7f4f5-79b3-4ff4-be09-07b6a2ecf444"),
                 Guid.Parse("1915e870-6337-427d-9fcb-17eeff44038c"),
             });
+    }
+
+    [TestCase(typeof(List<string>), false)]
+    [TestCase(typeof(List<Guid>), true)]
+    [TestCase(typeof(List<int>), true)]
+    [TestCase(typeof(IReadOnlyCollection<string>), false)]
+    [TestCase(typeof(IReadOnlyCollection<object>), false)]
+    [TestCase(typeof(IReadOnlyCollection<Guid>), true)]
+    [TestCase(typeof(IReadOnlyCollection<int>), true)]
+    [TestCase(typeof(IEnumerable<string>), false)]
+    [TestCase(typeof(IEnumerable<object>), false)]
+    [TestCase(typeof(IEnumerable<Guid>), true)]
+    [TestCase(typeof(IEnumerable<int>), true)]
+    [TestCase(typeof(string[]), false)]
+    [TestCase(typeof(object[]), false)]
+    [TestCase(typeof(Guid[]), true)]
+    [TestCase(typeof(int[]), true)]
+    [TestCase(typeof(string), false)]
+    [TestCase(typeof(int), false)]
+    [TestCase(typeof(Guid), false)]
+    public void IsSupportedModelType_GivenModelTypes_ReturnsCorrectly(Type modelType, bool expected)
+    {
+        var isSupported = CommaDelimitedModelBinder.IsSupportedModelType(modelType);
+
+        Assert.That(isSupported, Is.EqualTo(expected));
     }
 
     private interface ITypedTester

--- a/CourageScores.Tests/Models/Adapters/Division/DivisionFixtureAdapterTests.cs
+++ b/CourageScores.Tests/Models/Adapters/Division/DivisionFixtureAdapterTests.cs
@@ -1,5 +1,6 @@
 ﻿using CourageScores.Models.Adapters.Division;
 using CourageScores.Models.Cosmos.Game;
+using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Team;
 using Moq;
@@ -93,8 +94,18 @@ public class DivisionFixtureAdapterTests
                 },
             },
         };
+        var homeDivision = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "HOME DIVISION",
+        };
+        var awayDivision = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "AWAY DIVISION",
+        };
 
-        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, _token);
+        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, homeDivision, awayDivision, _token);
 
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Home, _homeTeam.Address, _token));
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Away, _awayTeam.Address, _token));
@@ -106,6 +117,8 @@ public class DivisionFixtureAdapterTests
         Assert.That(result.HomeTeam, Is.EqualTo(_homeTeamDto));
         Assert.That(result.AwayTeam, Is.EqualTo(_awayTeamDto));
         Assert.That(result.IsKnockout, Is.EqualTo(game.IsKnockout));
+        Assert.That(result.HomeDivision, Is.EqualTo(homeDivision));
+        Assert.That(result.AwayDivision, Is.EqualTo(awayDivision));
     }
 
     [Test]
@@ -151,7 +164,7 @@ public class DivisionFixtureAdapterTests
             },
         };
 
-        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, _token);
+        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, null, null, _token);
 
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Home, _homeTeam.Address, _token));
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Away, _awayTeam.Address, _token));
@@ -227,7 +240,7 @@ public class DivisionFixtureAdapterTests
             },
         };
 
-        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, _token);
+        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, null, null, _token);
 
         Assert.That(result.HomeScore, Is.EqualTo(1));
         Assert.That(result.AwayScore, Is.EqualTo(0));
@@ -253,7 +266,7 @@ public class DivisionFixtureAdapterTests
             },
         };
 
-        var result = await _adapter.Adapt(game, _homeTeam, null, _token);
+        var result = await _adapter.Adapt(game, _homeTeam, null, null, null, _token);
 
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Home, _homeTeam.Address, _token));
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Away, null, _token));
@@ -282,7 +295,7 @@ public class DivisionFixtureAdapterTests
             AccoladesCount = true,
         };
 
-        var result = await _adapter.Adapt(game, null, null, _token);
+        var result = await _adapter.Adapt(game, null, null, null, null, _token);
 
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Home, null, _token));
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Away, null, _token));
@@ -320,7 +333,7 @@ public class DivisionFixtureAdapterTests
             },
         };
 
-        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, _token);
+        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, null, null, _token);
 
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Home, _homeTeam.Address, _token));
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Away, _awayTeam.Address, _token));
@@ -357,7 +370,7 @@ public class DivisionFixtureAdapterTests
             },
         };
 
-        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, _token);
+        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, null, null, _token);
 
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Home, _homeTeam.Address, _token));
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Away, _awayTeam.Address, _token));
@@ -410,7 +423,7 @@ public class DivisionFixtureAdapterTests
             },
         };
 
-        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, _token);
+        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, null, null, _token);
 
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Home, _homeTeam.Address, _token));
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Away, _awayTeam.Address, _token));
@@ -499,7 +512,7 @@ public class DivisionFixtureAdapterTests
             },
         };
 
-        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, _token);
+        var result = await _adapter.Adapt(game, _homeTeam, _awayTeam, null, null, _token);
 
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Home, _homeTeam.Address, _token));
         _divisionFixtureTeamAdapter.Verify(a => a.Adapt(game.Away, _awayTeam.Address, _token));
@@ -517,11 +530,16 @@ public class DivisionFixtureAdapterTests
             Address = "address",
             Name = "team",
         };
+        var division = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "DIVISION",
+        };
         _divisionFixtureTeamAdapter
             .Setup(a => a.Adapt(team, _token))
             .ReturnsAsync(_homeTeamDto);
 
-        var result = await _adapter.ForUnselectedTeam(team, isKnockout, Array.Empty<CosmosGame>(), _token);
+        var result = await _adapter.ForUnselectedTeam(team, isKnockout, Array.Empty<CosmosGame>(), division, _token);
 
         Assert.That(result.Id, Is.EqualTo(team.Id));
         Assert.That(result.Postponed, Is.False);
@@ -532,6 +550,7 @@ public class DivisionFixtureAdapterTests
         Assert.That(result.HomeTeam, Is.EqualTo(_homeTeamDto));
         Assert.That(result.IsKnockout, Is.EqualTo(expectedIsKnockout));
         Assert.That(result.AccoladesCount, Is.True);
+        Assert.That(result.HomeDivision, Is.EqualTo(division));
     }
 
     [Test]
@@ -565,7 +584,7 @@ public class DivisionFixtureAdapterTests
         var result = await _adapter.ForUnselectedTeam(team, false, new[]
         {
             game,
-        }, _token);
+        }, null, _token);
 
         Assert.That(result.Id, Is.EqualTo(team.Id));
         Assert.That(result.FixturesUsingAddress.Count, Is.EqualTo(1));

--- a/CourageScores.Tests/Models/Adapters/Division/DivisionPlayerAdapterTests.cs
+++ b/CourageScores.Tests/Models/Adapters/Division/DivisionPlayerAdapterTests.cs
@@ -1,4 +1,5 @@
 ﻿using CourageScores.Models.Adapters.Division;
+using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Team;
 using CourageScores.Services.Division;
@@ -80,8 +81,13 @@ public class DivisionPlayerAdapterTests
         };
         var playerTuple = new DivisionData.TeamPlayerTuple(player, team);
         var fixtures = new Dictionary<DateTime, Guid>();
+        var division = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "DIVISION",
+        };
 
-        var result = await _adapter.Adapt(score, playerTuple, fixtures, _token);
+        var result = await _adapter.Adapt(score, playerTuple, fixtures, division, _token);
 
         Assert.That(result.Id, Is.EqualTo(player.Id));
         Assert.That(result.Captain, Is.EqualTo(player.Captain));
@@ -97,6 +103,7 @@ public class DivisionPlayerAdapterTests
         Assert.That(result.Team, Is.EqualTo(team.Name));
         Assert.That(result.Fixtures, Is.EqualTo(fixtures));
         Assert.That(result.Updated, Is.EqualTo(player.Updated));
+        Assert.That(result.Division, Is.EqualTo(division));
     }
 
     [Test]
@@ -134,11 +141,54 @@ public class DivisionPlayerAdapterTests
         };
         var playerTuple = new DivisionData.TeamPlayerTuple(player, team);
         var fixtures = new Dictionary<DateTime, Guid>();
+        var division = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "DIVISION",
+        };
 
-        var result = await _adapter.Adapt(score, playerTuple, fixtures, _token);
+        var result = await _adapter.Adapt(score, playerTuple, fixtures, division, _token);
 
         Assert.That(result.Team, Is.EqualTo("team"));
         Assert.That(result.Name, Is.EqualTo("player"));
+    }
+
+    [Test]
+    public async Task Adapt_GivenNoFixturesAndNoDivision_SetsDivisionToNull()
+    {
+        var score = new DivisionData.PlayerScore
+        {
+            OneEighties = 3,
+            HiCheckout = 4,
+            PlayerPlayCount =
+            {
+                {
+                    1, _singles
+                },
+                {
+                    2, _pairs
+                },
+                {
+                    3, _triples
+                },
+            },
+        };
+        var team = new TeamDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "",
+        };
+        var player = new TeamPlayerDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "",
+        };
+        var playerTuple = new DivisionData.TeamPlayerTuple(player, team);
+        var fixtures = new Dictionary<DateTime, Guid>();
+
+        var result = await _adapter.Adapt(score, playerTuple, fixtures, null, _token);
+
+        Assert.That(result.Division, Is.Null);
     }
 
     [Test]
@@ -156,8 +206,13 @@ public class DivisionPlayerAdapterTests
             Captain = true,
             Updated = new DateTime(2001, 02, 03),
         };
+        var division = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "DIVISION",
+        };
 
-        var result = await _adapter.Adapt(team, player, _token);
+        var result = await _adapter.Adapt(team, player, division, _token);
 
         Assert.That(result.Id, Is.EqualTo(player.Id));
         Assert.That(result.Captain, Is.EqualTo(player.Captain));
@@ -173,6 +228,7 @@ public class DivisionPlayerAdapterTests
         Assert.That(result.Team, Is.EqualTo(team.Name));
         Assert.That(result.Fixtures, Is.Empty);
         Assert.That(result.Updated, Is.EqualTo(player.Updated));
+        Assert.That(result.Division, Is.EqualTo(division));
     }
 
     [Test]
@@ -190,10 +246,34 @@ public class DivisionPlayerAdapterTests
             Captain = true,
             Updated = new DateTime(2001, 02, 03),
         };
+        var division = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "DIVISION",
+        };
 
-        var result = await _adapter.Adapt(team, player, _token);
+        var result = await _adapter.Adapt(team, player, division, _token);
 
         Assert.That(result.Name, Is.EqualTo("Player"));
         Assert.That(result.Team, Is.EqualTo("Team"));
+    }
+
+    [Test]
+    public async Task Adapt_GivenTeamPlayerDtoAndNoDivision_SetsDivisionToNull()
+    {
+        var team = new TeamDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "",
+        };
+        var player = new TeamPlayerDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "",
+        };
+
+        var result = await _adapter.Adapt(team, player, null, _token);
+
+        Assert.That(result.Division, Is.Null);
     }
 }

--- a/CourageScores.Tests/Models/Adapters/Division/DivisionTeamAdapterTests.cs
+++ b/CourageScores.Tests/Models/Adapters/Division/DivisionTeamAdapterTests.cs
@@ -1,4 +1,5 @@
 using CourageScores.Models.Adapters.Division;
+using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Team;
 using CourageScores.Services.Division;
@@ -59,11 +60,16 @@ public class DivisionTeamAdapterTests
                 },
             },
         };
+        var division = new DivisionDto
+        {
+            Name = "division",
+        };
 
-        var result = await _adapter.Adapt(team, score, teamPlayers, _token);
+        var result = await _adapter.Adapt(team, score, teamPlayers, division, _token);
 
         Assert.That(result.Id, Is.EqualTo(team.Id));
         Assert.That(result.Name, Is.EqualTo(team.Name));
+        Assert.That(result.Division, Is.EqualTo(division));
         Assert.That(result.Played, Is.EqualTo(1));
         Assert.That(result.Points, Is.EqualTo(8d).Within(0.001));
         Assert.That(result.FixturesWon, Is.EqualTo(2));
@@ -79,6 +85,18 @@ public class DivisionTeamAdapterTests
     }
 
     [Test]
+    public async Task Adapt_GivenNoDivision_SetsDivisionToNull()
+    {
+        var team = new TeamDto();
+        var score = new DivisionData.TeamScore();
+        var teamPlayers = Array.Empty<DivisionPlayerDto>();
+
+        var result = await _adapter.Adapt(team, score, teamPlayers, null, _token);
+
+        Assert.That(result.Division, Is.Null);
+    }
+
+    [Test]
     public async Task WithoutFixtures_GivenTeam_SetsPropertiesCorrectly()
     {
         var team = new TeamDto
@@ -88,8 +106,13 @@ public class DivisionTeamAdapterTests
             Address = "address",
             Updated = new DateTime(2023, 01, 02),
         };
+        var division = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "division",
+        };
 
-        var result = await _adapter.WithoutFixtures(team, _token);
+        var result = await _adapter.WithoutFixtures(team, division, _token);
 
         Assert.That(result.Id, Is.EqualTo(team.Id));
         Assert.That(result.Name, Is.EqualTo(team.Name));
@@ -97,5 +120,19 @@ public class DivisionTeamAdapterTests
         Assert.That(result.Played, Is.EqualTo(0));
         Assert.That(result.Points, Is.EqualTo(0));
         Assert.That(result.Updated, Is.EqualTo(team.Updated));
+        Assert.That(result.Division, Is.EqualTo(division));
+    }
+
+    [Test]
+    public async Task WithoutFixtures_GivenNoDivision_SetsDivisionToNull()
+    {
+        var team = new TeamDto
+        {
+            Id = Guid.NewGuid(),
+        };
+
+        var result = await _adapter.WithoutFixtures(team, null, _token);
+
+        Assert.That(result.Division, Is.Null);
     }
 }

--- a/CourageScores.Tests/Models/Dtos/Division/DivisionDataFilterTests.cs
+++ b/CourageScores.Tests/Models/Dtos/Division/DivisionDataFilterTests.cs
@@ -156,13 +156,16 @@ public class DivisionDataFilterTests
         {
             Date = date == null ? null : DateTime.Parse(date),
             TeamId = teamId == null ? null : Guid.Parse(teamId),
-            DivisionId = divisionId == null ? null : Guid.Parse(divisionId),
             SeasonId = seasonId == null ? null : Guid.Parse(seasonId),
         };
+        if (divisionId != null)
+        {
+            filter1.DivisionId.Add(Guid.Parse(divisionId));
+        }
         var filter2 = new DivisionDataFilter
         {
             Date = DateTime.Parse(MatchingDate),
-            DivisionId = Guid.Parse(MatchingDivisionId),
+            DivisionId =  { Guid.Parse(MatchingDivisionId) },
             SeasonId = Guid.Parse(MatchingSeasonId),
             TeamId = Guid.Parse(MatchingTeamId),
         };

--- a/CourageScores.Tests/Services/Division/CachingDivisionServiceTests.cs
+++ b/CourageScores.Tests/Services/Division/CachingDivisionServiceTests.cs
@@ -80,17 +80,17 @@ public class CachingDivisionServiceTests
         var seasonId = Guid.NewGuid();
         var result1 = await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
 
         var result2 = await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
 
-        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId == divisionId), _token), Times.Exactly(2));
+        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId.Contains(divisionId)), _token), Times.Exactly(2));
         Assert.That(result1, Is.SameAs(_divisionData));
         Assert.That(result2, Is.SameAs(result1));
     }
@@ -102,17 +102,17 @@ public class CachingDivisionServiceTests
         var seasonId = Guid.NewGuid();
         var result1 = await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
 
         var result2 = await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
 
-        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId == divisionId), _token), Times.Once);
+        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId.Contains(divisionId)), _token), Times.Once);
         Assert.That(result1, Is.SameAs(_divisionData));
         Assert.That(result2, Is.SameAs(result1));
     }
@@ -124,18 +124,18 @@ public class CachingDivisionServiceTests
         var seasonId = Guid.NewGuid();
         var result1 = await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         _context!.Request.Headers.CacheControl = new StringValues("no-cache");
 
         var result2 = await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
 
-        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId == divisionId), _token), Times.Exactly(2));
+        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId.Contains(divisionId)), _token), Times.Exactly(2));
         Assert.That(result2, Is.SameAs(result1));
         Assert.That(result2, Is.SameAs(_divisionData));
     }
@@ -308,7 +308,7 @@ public class CachingDivisionServiceTests
         var divisionId = Guid.NewGuid();
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.Get(divisionId, _token);
@@ -317,11 +317,11 @@ public class CachingDivisionServiceTests
 
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.Get(divisionId, _token);
-        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId == divisionId), _token), Times.Exactly(1));
+        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId.Contains(divisionId)), _token), Times.Exactly(1));
         _underlyingService.Verify(s => s.Get(divisionId, _token), Times.Exactly(1));
     }
 
@@ -332,7 +332,7 @@ public class CachingDivisionServiceTests
         var divisionId = Guid.NewGuid();
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.Get(divisionId, _token);
@@ -341,11 +341,11 @@ public class CachingDivisionServiceTests
 
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.Get(divisionId, _token);
-        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId == divisionId), _token), Times.Exactly(2));
+        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId.Contains(divisionId)), _token), Times.Exactly(2));
         _underlyingService.Verify(s => s.Get(divisionId, _token), Times.Exactly(1));
     }
 
@@ -357,12 +357,12 @@ public class CachingDivisionServiceTests
         var divisionId = Guid.NewGuid();
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = anotherSeasonId,
         }, _token);
         await _service.Get(divisionId, _token);
@@ -371,17 +371,17 @@ public class CachingDivisionServiceTests
 
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = anotherSeasonId,
         }, _token);
         await _service.Get(divisionId, _token);
-        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId == divisionId), _token), Times.Exactly(2));
-        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == anotherSeasonId && f.DivisionId == divisionId), _token), Times.Exactly(2));
+        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId.Contains(divisionId)), _token), Times.Exactly(2));
+        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == anotherSeasonId && f.DivisionId.Contains(divisionId)), _token), Times.Exactly(2));
         _underlyingService.Verify(s => s.Get(divisionId, _token), Times.Exactly(1));
     }
 
@@ -392,7 +392,7 @@ public class CachingDivisionServiceTests
         var divisionId = Guid.NewGuid();
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.Get(divisionId, _token);
@@ -401,11 +401,11 @@ public class CachingDivisionServiceTests
 
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.Get(divisionId, _token);
-        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId == divisionId), _token), Times.Exactly(2));
+        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId.Contains(divisionId)), _token), Times.Exactly(2));
         _underlyingService.Verify(s => s.Get(divisionId, _token), Times.Exactly(2));
     }
 
@@ -417,12 +417,12 @@ public class CachingDivisionServiceTests
         var anotherDivisionId = Guid.NewGuid();
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = anotherDivisionId,
+            DivisionId = { anotherDivisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.Get(divisionId, _token);
@@ -432,18 +432,18 @@ public class CachingDivisionServiceTests
 
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = anotherDivisionId,
+            DivisionId = { anotherDivisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.Get(divisionId, _token);
         await _service.Get(anotherDivisionId, _token);
-        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId == divisionId), _token), Times.Exactly(2));
-        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId == anotherDivisionId), _token), Times.Exactly(2));
+        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId.Contains(divisionId)), _token), Times.Exactly(2));
+        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId.Contains(anotherDivisionId)), _token), Times.Exactly(2));
         _underlyingService.Verify(s => s.Get(divisionId, _token), Times.Exactly(2));
         _underlyingService.Verify(s => s.Get(anotherDivisionId, _token), Times.Exactly(2));
     }
@@ -455,7 +455,7 @@ public class CachingDivisionServiceTests
         var divisionId = Guid.NewGuid();
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.Get(divisionId, _token);
@@ -464,11 +464,11 @@ public class CachingDivisionServiceTests
 
         await _service.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = divisionId,
+            DivisionId = { divisionId },
             SeasonId = seasonId,
         }, _token);
         await _service.Get(divisionId, _token);
-        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId == divisionId), _token), Times.Exactly(2));
+        _underlyingService.Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.SeasonId == seasonId && f.DivisionId.Contains(divisionId)), _token), Times.Exactly(2));
         _underlyingService.Verify(s => s.Get(divisionId, _token), Times.Exactly(2));
     }
 }

--- a/CourageScores.Tests/Services/Division/DivisionDataContextTests.cs
+++ b/CourageScores.Tests/Services/Division/DivisionDataContextTests.cs
@@ -152,7 +152,7 @@ public class DivisionDataContextTests
             new Dictionary<Guid, Guid?>(),
             new Dictionary<Guid, DivisionDto>());
 
-        var result = context.AllTournamentGames(Array.Empty<Guid?>());
+        var result = context.AllTournamentGames(Array.Empty<Guid>());
 
         Assert.That(result, Is.EquivalentTo(new[]
         {
@@ -189,7 +189,7 @@ public class DivisionDataContextTests
             new Dictionary<Guid, Guid?>(),
             new Dictionary<Guid, DivisionDto>());
 
-        var result = context.AllTournamentGames(new[] { tournamentInDivision.DivisionId });
+        var result = context.AllTournamentGames(new[] { tournamentInDivision.DivisionId.Value });
 
         Assert.That(result, Is.EquivalentTo(new[]
         {

--- a/CourageScores.Tests/Services/Division/DivisionDataContextTests.cs
+++ b/CourageScores.Tests/Services/Division/DivisionDataContextTests.cs
@@ -148,7 +148,7 @@ public class DivisionDataContextTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = context.AllTournamentGames(null);
+        var result = context.AllTournamentGames(Array.Empty<Guid?>());
 
         Assert.That(result, Is.EquivalentTo(new[]
         {
@@ -184,7 +184,7 @@ public class DivisionDataContextTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = context.AllTournamentGames(tournamentInDivision.DivisionId);
+        var result = context.AllTournamentGames(new[] { tournamentInDivision.DivisionId });
 
         Assert.That(result, Is.EquivalentTo(new[]
         {

--- a/CourageScores.Tests/Services/Division/DivisionDataContextTests.cs
+++ b/CourageScores.Tests/Services/Division/DivisionDataContextTests.cs
@@ -34,7 +34,8 @@ public class DivisionDataContextTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = context.AllGames(divisionId).ToArray();
 
@@ -67,7 +68,8 @@ public class DivisionDataContextTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = context.AllGames(divisionId).ToArray();
 
@@ -113,7 +115,8 @@ public class DivisionDataContextTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = context.AllGames(null).ToArray();
 
@@ -146,7 +149,8 @@ public class DivisionDataContextTests
             },
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = context.AllTournamentGames(Array.Empty<Guid?>());
 
@@ -182,7 +186,8 @@ public class DivisionDataContextTests
             },
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = context.AllTournamentGames(new[] { tournamentInDivision.DivisionId });
 

--- a/CourageScores.Tests/Services/Division/DivisionDataDtoFactoryTests.cs
+++ b/CourageScores.Tests/Services/Division/DivisionDataDtoFactoryTests.cs
@@ -73,7 +73,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
@@ -97,7 +98,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
@@ -108,7 +110,11 @@ public class DivisionDataDtoFactoryTests
     [Test]
     public async Task CreateDivisionDataDto_GivenTeams_SetsTeamsCorrectly()
     {
-        var division = new DivisionDto();
+        var division = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "DIVISION",
+        };
         var team1 = new TeamDto
         {
             Id = Guid.NewGuid(),
@@ -126,6 +132,7 @@ public class DivisionDataDtoFactoryTests
         };
         var game = new CosmosGame
         {
+            DivisionId = division.Id,
             Home = new GameTeam
             {
                 Id = team1.Id,
@@ -171,7 +178,16 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>
+            {
+                { team1.Id, division.Id },
+                { team2.Id, division.Id },
+                { team3.Id, division.Id },
+            },
+            new Dictionary<Guid, DivisionDto>
+            {
+                { division.Id, division },
+            });
 
         var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
@@ -181,6 +197,7 @@ public class DivisionDataDtoFactoryTests
             "Team 1 - Playing",
             "Team 3 - Not Playing",
         }));
+        Assert.That(result.Teams.Select(t => t.Division), Has.All.EqualTo(division));
     }
 
     [Test]
@@ -290,7 +307,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             season,
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
@@ -373,7 +391,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             season,
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
         _user = new UserDto
         {
             Access = new AccessDto
@@ -457,7 +476,8 @@ public class DivisionDataDtoFactoryTests
             },
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
@@ -499,7 +519,8 @@ public class DivisionDataDtoFactoryTests
             },
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
@@ -613,7 +634,8 @@ public class DivisionDataDtoFactoryTests
             new List<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
@@ -699,7 +721,8 @@ public class DivisionDataDtoFactoryTests
             {
                 { team1.Id, division.Id },
                 { team2.Id, Guid.NewGuid() },
-            });
+            },
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
@@ -779,7 +802,8 @@ public class DivisionDataDtoFactoryTests
             new List<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
@@ -901,7 +925,8 @@ public class DivisionDataDtoFactoryTests
             new List<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
@@ -1024,7 +1049,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             season,
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
@@ -1161,7 +1187,8 @@ public class DivisionDataDtoFactoryTests
             },
             Array.Empty<FixtureDateNoteDto>(),
             season,
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
@@ -1297,7 +1324,8 @@ public class DivisionDataDtoFactoryTests
             },
             Array.Empty<FixtureDateNoteDto>(),
             season,
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
@@ -1418,7 +1446,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             season,
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
         // set user as logged in, with correct access to allow errors to be returned
         _user = new UserDto
         {
@@ -1490,7 +1519,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             season,
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
@@ -1554,7 +1584,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             season,
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
         _user = new UserDto
         {
             Access = new AccessDto
@@ -1676,7 +1707,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             season,
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
         _user = new UserDto
         {
             Access = new AccessDto
@@ -1709,7 +1741,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             season,
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
@@ -1793,7 +1826,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
@@ -1870,7 +1904,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
@@ -1952,7 +1987,8 @@ public class DivisionDataDtoFactoryTests
             Array.Empty<TournamentGame>(),
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
-            new Dictionary<Guid, Guid?>());
+            new Dictionary<Guid, Guid?>(),
+            new Dictionary<Guid, DivisionDto>());
 
         var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 

--- a/CourageScores.Tests/Services/Division/DivisionDataDtoFactoryTests.cs
+++ b/CourageScores.Tests/Services/Division/DivisionDataDtoFactoryTests.cs
@@ -81,7 +81,7 @@ public class DivisionDataDtoFactoryTests
             Updated = new DateTime(2001, 02, 03),
         };
 
-        var result = await _factory.CreateDivisionDataDto(context, division, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         Assert.That(result.Id, Is.EqualTo(division.Id));
         Assert.That(result.Name, Is.EqualTo("division 1"));
@@ -99,15 +99,16 @@ public class DivisionDataDtoFactoryTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
         Assert.That(result.Id, Is.EqualTo(Guid.Empty));
-        Assert.That(result.Name, Is.EqualTo("<all divisions>"));
+        Assert.That(result.Name, Is.EqualTo("<0 divisions>"));
     }
 
     [Test]
     public async Task CreateDivisionDataDto_GivenTeams_SetsTeamsCorrectly()
     {
+        var division = new DivisionDto();
         var team1 = new TeamDto
         {
             Id = Guid.NewGuid(),
@@ -172,7 +173,7 @@ public class DivisionDataDtoFactoryTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         Assert.That(result.Teams.Select(t => t.Name), Is.EqualTo(new[]
         {
@@ -291,7 +292,7 @@ public class DivisionDataDtoFactoryTests
             season,
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, division, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         Assert.That(result.Teams.Select(t => t.Name), Is.EqualTo(new[]
         {
@@ -381,7 +382,7 @@ public class DivisionDataDtoFactoryTests
             },
         };
 
-        var result = await _factory.CreateDivisionDataDto(context, division, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         Assert.That(result.DataErrors.Select(de => de.Message), Has.Member($"Potential cross-division team found: {otherDivisionTeam.Id}"));
     }
@@ -458,7 +459,7 @@ public class DivisionDataDtoFactoryTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
         Assert.That(result.Fixtures.Select(f => f.Date), Is.EquivalentTo(new[]
         {
@@ -500,7 +501,7 @@ public class DivisionDataDtoFactoryTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
         Assert.That(result.Fixtures.Select(f => f.Date), Is.EquivalentTo(new[]
         {
@@ -614,7 +615,7 @@ public class DivisionDataDtoFactoryTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, division, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         Assert.That(result.Fixtures.Select(f => f.Date), Is.EquivalentTo(new[]
         {
@@ -700,7 +701,7 @@ public class DivisionDataDtoFactoryTests
                 { team2.Id, Guid.NewGuid() },
             });
 
-        var result = await _factory.CreateDivisionDataDto(context, division, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         Assert.That(result.Fixtures.Select(f => f.Date), Is.EquivalentTo(new[]
         {
@@ -780,7 +781,7 @@ public class DivisionDataDtoFactoryTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, division, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         Assert.That(result.Fixtures.Select(f => f.Date), Is.EquivalentTo(new[]
         {
@@ -902,7 +903,7 @@ public class DivisionDataDtoFactoryTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
         Assert.That(result.Fixtures.Select(f => f.Date), Is.EquivalentTo(new[]
         {
@@ -925,6 +926,7 @@ public class DivisionDataDtoFactoryTests
     [Test]
     public async Task CreateDivisionDataDto_GivenFixtures_SetsPlayersCorrectly()
     {
+        var division = new DivisionDto();
         var season = new SeasonDto
         {
             Id = Guid.NewGuid(),
@@ -1024,7 +1026,7 @@ public class DivisionDataDtoFactoryTests
             season,
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         Assert.That(result.Players.Select(f => f.Name), Is.EquivalentTo(new[]
         {
@@ -1161,7 +1163,7 @@ public class DivisionDataDtoFactoryTests
             season,
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, division, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         Assert.That(result.Players.Select(p => p.Name), Is.EquivalentTo(new[] { thisDivisionPlayer.Name }));
         Assert.That(result.DataErrors, Is.Empty);
@@ -1297,7 +1299,7 @@ public class DivisionDataDtoFactoryTests
             season,
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, division, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         Assert.That(result.Players, Is.Empty);
         Assert.That(result.DataErrors, Is.Empty);
@@ -1426,7 +1428,7 @@ public class DivisionDataDtoFactoryTests
             },
         };
 
-        var result = await _factory.CreateDivisionDataDto(context, division, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         Assert.That(result.DataErrors, Is.Empty);
     }
@@ -1490,7 +1492,7 @@ public class DivisionDataDtoFactoryTests
             season,
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
         Assert.That(result.Players, Is.Empty);
     }
@@ -1561,7 +1563,7 @@ public class DivisionDataDtoFactoryTests
             },
         };
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
         Assert.That(result.Players.Select(p => p.Name), Is.EquivalentTo(new[]
         {
@@ -1683,7 +1685,7 @@ public class DivisionDataDtoFactoryTests
             },
         };
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
         Assert.That(result.Players.Select(f => f.Name), Is.EquivalentTo(new[]
         {
@@ -1709,7 +1711,7 @@ public class DivisionDataDtoFactoryTests
             season,
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
         Assert.That(result.Season!.Id, Is.EqualTo(season.Id));
         Assert.That(result.Season!.Name, Is.EqualTo(season.Name));
@@ -1718,6 +1720,7 @@ public class DivisionDataDtoFactoryTests
     [Test]
     public async Task CreateDivisionDataDto_GivenDataErrors_SetsDataErrorsCorrectly()
     {
+        var division = new DivisionDto();
         _user = new UserDto
         {
             Access = new AccessDto
@@ -1792,7 +1795,7 @@ public class DivisionDataDtoFactoryTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         var dataError = result.DataErrors.Single();
         Assert.That(dataError.Message, Is.EqualTo("Mismatching number of players: Home players (1): [A] vs Away players (2): [B, C]"));
@@ -1869,7 +1872,7 @@ public class DivisionDataDtoFactoryTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
         Assert.That(result.DataErrors, Is.Empty);
     }
@@ -1951,7 +1954,7 @@ public class DivisionDataDtoFactoryTests
             new SeasonDto(),
             new Dictionary<Guid, Guid?>());
 
-        var result = await _factory.CreateDivisionDataDto(context, null, true, _token);
+        var result = await _factory.CreateDivisionDataDto(context, Array.Empty<DivisionDto?>(), true, _token);
 
         Assert.That(result.DataErrors, Is.Empty);
     }
@@ -1974,7 +1977,7 @@ public class DivisionDataDtoFactoryTests
             season1, season2,
         };
 
-        var result = await _factory.SeasonNotFound(null, seasons, _token);
+        var result = await _factory.SeasonNotFound(Array.Empty<DivisionDto?>(), seasons, _token);
 
         Assert.That(result.Id, Is.EqualTo(Guid.Empty));
         Assert.That(result.Name, Is.EqualTo("<all divisions>"));
@@ -2004,7 +2007,7 @@ public class DivisionDataDtoFactoryTests
             Name = "division1",
         };
 
-        var result = await _factory.SeasonNotFound(division, seasons, _token);
+        var result = await _factory.SeasonNotFound(new[] { division }, seasons, _token);
 
         Assert.That(result.Id, Is.EqualTo(division.Id));
         Assert.That(result.Name, Is.EqualTo("division1"));

--- a/CourageScores.Tests/Services/Division/DivisionDataDtoFactoryTests.cs
+++ b/CourageScores.Tests/Services/Division/DivisionDataDtoFactoryTests.cs
@@ -51,10 +51,11 @@ public class DivisionDataDtoFactoryTests
                 It.IsAny<IReadOnlyCollection<TeamDto>>(),
                 It.IsAny<IReadOnlyCollection<CosmosGame>>(),
                 It.IsAny<bool>(),
+                It.IsAny<IReadOnlyDictionary<Guid, DivisionDto?>>(),
                 _token))
             .ReturnsAsync(
                 (DateTime date, IReadOnlyCollection<CosmosGame> _, IReadOnlyCollection<TournamentGame> _,
-                    IReadOnlyCollection<FixtureDateNoteDto> _, IReadOnlyCollection<TeamDto> _, IReadOnlyCollection<CosmosGame> _, bool _, CancellationToken _) => new DivisionFixtureDateDto
+                    IReadOnlyCollection<FixtureDateNoteDto> _, IReadOnlyCollection<TeamDto> _, IReadOnlyCollection<CosmosGame> _, bool _, IReadOnlyDictionary<Guid, DivisionDto?> _, CancellationToken _) => new DivisionFixtureDateDto
                 {
                     Date = date,
                 });
@@ -657,6 +658,7 @@ public class DivisionDataDtoFactoryTests
                 outOfDivisionGame,
             })),
             true,
+            It.IsAny<IReadOnlyDictionary<Guid, DivisionDto?>>(),
             _token));
     }
 
@@ -742,6 +744,7 @@ public class DivisionDataDtoFactoryTests
             It.IsAny<IReadOnlyCollection<TeamDto>>(),
             It.IsAny<CosmosGame[]>(),
             true,
+            It.IsAny<IReadOnlyDictionary<Guid, DivisionDto?>>(),
             _token));
     }
 
@@ -819,6 +822,7 @@ public class DivisionDataDtoFactoryTests
             It.IsAny<IReadOnlyCollection<TeamDto>>(),
             It.IsAny<CosmosGame[]>(),
             true,
+            It.IsAny<IReadOnlyDictionary<Guid, DivisionDto?>>(),
             _token));
     }
 
@@ -945,6 +949,7 @@ public class DivisionDataDtoFactoryTests
             It.IsAny<IReadOnlyCollection<TeamDto>>(),
             It.Is<CosmosGame[]>(games => games.Length == 0),
             true,
+            It.IsAny<IReadOnlyDictionary<Guid, DivisionDto?>>(),
             _token));
     }
 

--- a/CourageScores.Tests/Services/Division/DivisionServiceTests.cs
+++ b/CourageScores.Tests/Services/Division/DivisionServiceTests.cs
@@ -863,7 +863,7 @@ public class DivisionServiceTests
         _tournamentGameRepository.Verify(s => s.GetSome($"t.SeasonId = '{season.Id}'", _token));
         _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division }, true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
-        Assert.That(_divisionDataContext!.AllTournamentGames(new[] { (Guid?)division.Id }), Is.EquivalentTo(new[]
+        Assert.That(_divisionDataContext!.AllTournamentGames(new[] { division.Id }), Is.EquivalentTo(new[]
         {
             inSeasonTournament,
         }));
@@ -921,11 +921,11 @@ public class DivisionServiceTests
         _tournamentGameRepository.Verify(s => s.GetSome($"t.SeasonId = '{season.Id}'", _token));
         _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division1, division2 }, true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
-        Assert.That(_divisionDataContext!.AllTournamentGames(new[] { (Guid?)division1.Id }), Is.EquivalentTo(new[]
+        Assert.That(_divisionDataContext!.AllTournamentGames(new[] { division1.Id }), Is.EquivalentTo(new[]
         {
             division1InSeasonTournament,
         }));
-        Assert.That(_divisionDataContext!.AllTournamentGames(new[] { (Guid?)division2.Id }), Is.EquivalentTo(new[]
+        Assert.That(_divisionDataContext!.AllTournamentGames(new[] { division2.Id }), Is.EquivalentTo(new[]
         {
             division2InSeasonTournament,
         }));

--- a/CourageScores.Tests/Services/Division/DivisionServiceTests.cs
+++ b/CourageScores.Tests/Services/Division/DivisionServiceTests.cs
@@ -72,8 +72,8 @@ public class DivisionServiceTests
         _gameRepository.Setup(s => s.GetSome(It.IsAny<string>(), _token)).Returns(() => TestUtilities.AsyncEnumerable(_someGames.ToArray()));
         _tournamentGameRepository.Setup(s => s.GetSome(It.IsAny<string>(), _token)).Returns(() => TestUtilities.AsyncEnumerable(_someTournaments.ToArray()));
         _divisionDataDtoFactory
-            .Setup(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), It.IsAny<DivisionDto>(), It.IsAny<bool>(), _token))
-            .Callback((DivisionDataContext context, DivisionDto _, bool _, CancellationToken _) =>
+            .Setup(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), It.IsAny<IReadOnlyCollection<DivisionDto>>(), It.IsAny<bool>(), _token))
+            .Callback((DivisionDataContext context, IReadOnlyCollection<DivisionDto> _, bool _, CancellationToken _) =>
             {
                 _divisionDataContext = context;
             });
@@ -98,10 +98,10 @@ public class DivisionServiceTests
         var notFound = new DivisionDataDto();
         var filter = new DivisionDataFilter
         {
-            DivisionId = Guid.NewGuid(),
+            DivisionId = { Guid.NewGuid() },
         };
-        _divisionDataDtoFactory.Setup(f => f.DivisionNotFound(filter.DivisionId.Value, null)).Returns(notFound);
-        _genericService.Setup(s => s.Get(filter.DivisionId.Value, _token)).ReturnsAsync(() => null);
+        _divisionDataDtoFactory.Setup(f => f.DivisionNotFound(filter.DivisionId, It.IsAny<IReadOnlyCollection<DivisionDto>>())).Returns(notFound);
+        _genericService.Setup(s => s.Get(filter.DivisionId.Single(), _token)).ReturnsAsync(() => null);
 
         var result = await _service.GetDivisionData(filter, _token);
 
@@ -114,14 +114,17 @@ public class DivisionServiceTests
         var notFound = new DivisionDataDto();
         var division = new DivisionDto
         {
+            Id = Guid.NewGuid(),
             Deleted = new DateTime(2001, 02, 03),
         };
         var filter = new DivisionDataFilter
         {
-            DivisionId = Guid.NewGuid(),
+            DivisionId = { division.Id },
         };
-        _divisionDataDtoFactory.Setup(f => f.DivisionNotFound(filter.DivisionId.Value, division)).Returns(notFound);
-        _genericService.Setup(s => s.Get(filter.DivisionId.Value, _token)).ReturnsAsync(division);
+        _divisionDataDtoFactory.Setup(f => f.DivisionNotFound(
+            filter.DivisionId,
+            It.Is<IReadOnlyCollection<DivisionDto>>(divs => divs.Select(d => d.Id).SequenceEqual(new[] { division.Id })))).Returns(notFound);
+        _genericService.Setup(s => s.Get(division.Id, _token)).ReturnsAsync(division);
 
         var result = await _service.GetDivisionData(filter, _token);
 
@@ -138,7 +141,7 @@ public class DivisionServiceTests
         };
         var filter = new DivisionDataFilter
         {
-            DivisionId = Guid.NewGuid(),
+            DivisionId = { Guid.NewGuid() },
             SeasonId = Guid.NewGuid(),
         };
         var otherSeason = new SeasonDto
@@ -147,8 +150,8 @@ public class DivisionServiceTests
             StartDate = new DateTime(2001, 01, 01),
             EndDate = new DateTime(2001, 05, 01),
         };
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(seasonNotFound);
-        _genericService.Setup(s => s.Get(filter.DivisionId.Value, _token)).ReturnsAsync(division);
+        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(new[] { division }, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(seasonNotFound);
+        _genericService.Setup(s => s.Get(filter.DivisionId.Single(), _token)).ReturnsAsync(division);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(otherSeason));
 
         var result = await _service.GetDivisionData(filter, _token);
@@ -167,10 +170,10 @@ public class DivisionServiceTests
         };
         var filter = new DivisionDataFilter
         {
-            DivisionId = Guid.NewGuid(),
+            DivisionId = { Guid.NewGuid() },
         };
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(seasonNotFound);
-        _genericService.Setup(s => s.Get(filter.DivisionId.Value, _token)).ReturnsAsync(division);
+        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(new[] { division }, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(seasonNotFound);
+        _genericService.Setup(s => s.Get(filter.DivisionId.Single(), _token)).ReturnsAsync(division);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable<SeasonDto>());
 
         var result = await _service.GetDivisionData(filter, _token);
@@ -189,7 +192,7 @@ public class DivisionServiceTests
         };
         var filter = new DivisionDataFilter
         {
-            DivisionId = Guid.NewGuid(),
+            DivisionId = { Guid.NewGuid() },
         };
         var otherSeason = new SeasonDto
         {
@@ -197,8 +200,8 @@ public class DivisionServiceTests
             StartDate = new DateTime(2001, 01, 01),
             EndDate = new DateTime(2001, 05, 01),
         };
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(seasonNotFound);
-        _genericService.Setup(s => s.Get(filter.DivisionId.Value, _token)).ReturnsAsync(division);
+        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(new[] { division }, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(seasonNotFound);
+        _genericService.Setup(s => s.Get(filter.DivisionId.Single(), _token)).ReturnsAsync(division);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(otherSeason));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 06, 01, 0, 0, 0, TimeSpan.Zero));
 
@@ -211,14 +214,13 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_GivenNoSeasonIdFilterWhenTwoActiveSeasons_UsesSeasonWithGreatestEndDate()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
         };
         var filter = new DivisionDataFilter
         {
-            DivisionId = Guid.NewGuid(),
+            DivisionId = { Guid.NewGuid() },
         };
         var firstSeason = new SeasonDto
         {
@@ -238,14 +240,13 @@ public class DivisionServiceTests
             StartDate = new DateTime(2001, 04, 01),
             EndDate = new DateTime(2001, 07, 01),
         };
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
-        _genericService.Setup(s => s.Get(filter.DivisionId.Value, _token)).ReturnsAsync(division);
+        _genericService.Setup(s => s.Get(filter.DivisionId.Single(), _token)).ReturnsAsync(division);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(firstSeason, secondSeason, thirdSeason));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
 
         await _service.GetDivisionData(filter, _token);
 
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), division, true, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division }, true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.Season, Is.EqualTo(secondSeason));
     }
@@ -253,7 +254,6 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_GivenDivisionIdFilter_ProducesTeamLookupToAnyDivision()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
@@ -264,7 +264,7 @@ public class DivisionServiceTests
         };
         var filter = new DivisionDataFilter
         {
-            DivisionId = division.Id,
+            DivisionId = { division.Id },
         };
         var firstSeason = new SeasonDto
         {
@@ -300,14 +300,13 @@ public class DivisionServiceTests
         {
             team, otherDivisionTeam,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
-        _genericService.Setup(s => s.Get(filter.DivisionId.Value, _token)).ReturnsAsync(division);
+        _genericService.Setup(s => s.Get(division.Id, _token)).ReturnsAsync(division);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(firstSeason));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
 
         await _service.GetDivisionData(filter, _token);
 
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), division, true, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division }, true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.TeamIdToDivisionIdLookup.Keys, Is.EquivalentTo(new[]
         {
@@ -322,14 +321,13 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_GivenDivisionIdFilter_IncludesMatchingTeamsOnly()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
         };
         var filter = new DivisionDataFilter
         {
-            DivisionId = division.Id,
+            DivisionId = { division.Id },
         };
         var firstSeason = new SeasonDto
         {
@@ -365,14 +363,13 @@ public class DivisionServiceTests
         {
             team, otherDivisionTeam,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
-        _genericService.Setup(s => s.Get(filter.DivisionId.Value, _token)).ReturnsAsync(division);
+        _genericService.Setup(s => s.Get(division.Id, _token)).ReturnsAsync(division);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(firstSeason));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
 
         await _service.GetDivisionData(filter, _token);
 
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), division, true, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division }, true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.TeamsInSeasonAndDivision, Is.EquivalentTo(new[]
         {
@@ -383,7 +380,6 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_GivenNoDivisionIdFilter_IncludesAllTeams()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
@@ -426,13 +422,12 @@ public class DivisionServiceTests
         {
             team, otherDivisionTeam,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
 
         await _service.GetDivisionData(filter, _token);
 
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), null, true, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), It.IsAny<IReadOnlyCollection<DivisionDto?>>(), true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.TeamsInSeasonAndDivision, Is.EquivalentTo(_allTeams));
     }
@@ -440,7 +435,6 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_GivenNoDivisionIdFilterAndDeletedTeamSeasons_IncludesAllActiveTeams()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
@@ -484,13 +478,12 @@ public class DivisionServiceTests
         {
             team, otherDivisionTeam,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
 
         await _service.GetDivisionData(filter, _token);
 
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), null, true, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), It.IsAny<IReadOnlyCollection<DivisionDto?>>(), true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.TeamsInSeasonAndDivision, Is.EquivalentTo(new[] { team }));
     }
@@ -498,14 +491,13 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_GivenDivisionIdFilter_IncludesMatchingNotesOnly()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
         };
         var filter = new DivisionDataFilter
         {
-            DivisionId = division.Id,
+            DivisionId = { division.Id },
         };
         var season = new SeasonDto
         {
@@ -534,15 +526,14 @@ public class DivisionServiceTests
             otherDivisionNote,
             allDivisionsNote,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
-        _genericService.Setup(s => s.Get(filter.DivisionId.Value, _token)).ReturnsAsync(division);
+        _genericService.Setup(s => s.Get(division.Id, _token)).ReturnsAsync(division);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
 
         await _service.GetDivisionData(filter, _token);
 
         _noteService.Verify(s => s.GetWhere($"t.SeasonId = '{season.Id}'", _token));
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), division, true, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division }, true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.Notes.Values.SelectMany(n => n), Is.EquivalentTo(new[]
         {
@@ -553,7 +544,6 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_GivenNoDivisionIdFilter_IncludesAllNotes()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
@@ -589,14 +579,13 @@ public class DivisionServiceTests
             otherDivisionNote,
             allDivisionsNote,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
 
         await _service.GetDivisionData(filter, _token);
 
         _noteService.Verify(s => s.GetWhere($"t.SeasonId = '{season.Id}'", _token));
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), null, true, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), It.IsAny<IReadOnlyCollection<DivisionDto?>>(), true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.Notes.Values.SelectMany(n => n), Is.EquivalentTo(_someNotes));
     }
@@ -604,14 +593,13 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_GivenDivisionIdFilter_IncludesMatchingGamesWithinSeason()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
         };
         var filter = new DivisionDataFilter
         {
-            DivisionId = division.Id,
+            DivisionId = { division.Id },
         };
         var season = new SeasonDto
         {
@@ -635,15 +623,14 @@ public class DivisionServiceTests
         {
             givenDivisionGameInSeason, givenDivisionGameOutOfSeason,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
-        _genericService.Setup(s => s.Get(filter.DivisionId.Value, _token)).ReturnsAsync(division);
+        _genericService.Setup(s => s.Get(division.Id, _token)).ReturnsAsync(division);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
 
         await _service.GetDivisionData(filter, _token);
 
-        _gameRepository.Verify(s => s.GetSome($"t.DivisionId = '{division.Id}' or t.IsKnockout = true", _token));
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), division, true, _token));
+        _gameRepository.Verify(s => s.GetSome($"t.DivisionId in ('{division.Id}') or t.IsKnockout = true", _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division }, true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.AllGames(null), Is.EquivalentTo(new[]
         {
@@ -652,9 +639,67 @@ public class DivisionServiceTests
     }
 
     [Test]
+    public async Task GetDivisionData_GivenMultipleDivisionIdFilter_IncludesMatchingGamesWithinSeason()
+    {
+        var division1 = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+        };
+        var division2 = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+        };
+        var filter = new DivisionDataFilter
+        {
+            DivisionId = { division1.Id, division2.Id },
+        };
+        var season = new SeasonDto
+        {
+            Id = Guid.NewGuid(),
+            StartDate = new DateTime(2001, 01, 01),
+            EndDate = new DateTime(2001, 05, 01),
+        };
+        var division1GameInSeason = new CosmosGame
+        {
+            Id = Guid.NewGuid(),
+            DivisionId = division1.Id,
+            Date = new DateTime(2001, 02, 01),
+        };
+        var division1GameOutOfSeason = new CosmosGame
+        {
+            Id = Guid.NewGuid(),
+            DivisionId = division1.Id,
+            Date = new DateTime(2001, 06, 01),
+        };
+        var division2GameInSeason = new CosmosGame
+        {
+            Id = Guid.NewGuid(),
+            DivisionId = division2.Id,
+            Date = new DateTime(2001, 02, 01),
+        };
+        _someGames.AddRange(new[]
+        {
+            division1GameInSeason, division1GameOutOfSeason, division2GameInSeason
+        });
+        _genericService.Setup(s => s.Get(division1.Id, _token)).ReturnsAsync(division1);
+        _genericService.Setup(s => s.Get(division2.Id, _token)).ReturnsAsync(division2);
+        _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
+        _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
+
+        await _service.GetDivisionData(filter, _token);
+
+        _gameRepository.Verify(s => s.GetSome($"t.DivisionId in ('{division1.Id}', '{division2.Id}') or t.IsKnockout = true", _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division1, division2 }, true, _token));
+        Assert.That(_divisionDataContext, Is.Not.Null);
+        Assert.That(_divisionDataContext!.AllGames(null), Is.EquivalentTo(new[]
+        {
+            division1GameInSeason, division2GameInSeason
+        }));
+    }
+
+    [Test]
     public async Task GetDivisionData_GivenNoDivisionIdFilter_IncludesAllGamesWithinSeason()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
@@ -700,14 +745,13 @@ public class DivisionServiceTests
             otherDivisionGameInSeason,
             otherDivisionGameOutOfSeason,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
 
         await _service.GetDivisionData(filter, _token);
 
         _gameRepository.Verify(s => s.GetSome($"t.SeasonId = '{season.Id}'", _token));
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), null, true, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), It.IsAny<IReadOnlyCollection<DivisionDto?>>(), true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.AllGames(null), Is.EquivalentTo(new[]
         {
@@ -718,7 +762,6 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_WhenIgnoringDates_ReturnsFixturesBeforeAndAfterSeasonDates()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
@@ -765,14 +808,13 @@ public class DivisionServiceTests
             otherDivisionGameBeforeStartOfSeason,
             otherDivisionGameAfterEndOfSeason,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
 
         await _service.GetDivisionData(filter, _token);
 
         _gameRepository.Verify(s => s.GetSome($"t.SeasonId = '{season.Id}'", _token));
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), null, true, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), It.IsAny<IReadOnlyCollection<DivisionDto?>>(), true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.AllGames(null), Is.EquivalentTo(new[]
         {
@@ -784,14 +826,13 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_GivenDivisionIdFilter_IncludesMatchingTournamentsWithinSeason()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
         };
         var filter = new DivisionDataFilter
         {
-            DivisionId = division.Id,
+            DivisionId = { division.Id },
         };
         var season = new SeasonDto
         {
@@ -813,26 +854,86 @@ public class DivisionServiceTests
         {
             inSeasonTournament, outOfSeasonTournament,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
-        _genericService.Setup(s => s.Get(filter.DivisionId.Value, _token)).ReturnsAsync(division);
+        _genericService.Setup(s => s.Get(division.Id, _token)).ReturnsAsync(division);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
 
         await _service.GetDivisionData(filter, _token);
 
         _tournamentGameRepository.Verify(s => s.GetSome($"t.SeasonId = '{season.Id}'", _token));
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), division, true, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division }, true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
-        Assert.That(_divisionDataContext!.AllTournamentGames(division.Id), Is.EquivalentTo(new[]
+        Assert.That(_divisionDataContext!.AllTournamentGames(new[] { (Guid?)division.Id }), Is.EquivalentTo(new[]
         {
             inSeasonTournament,
         }));
     }
 
     [Test]
+    public async Task GetDivisionData_GivenMultiDivisionIdFilter_IncludesMatchingTournamentsWithinSeason()
+    {
+        var division1 = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+        };
+        var division2 = new DivisionDto
+        {
+            Id = Guid.NewGuid(),
+        };
+        var filter = new DivisionDataFilter
+        {
+            DivisionId = { division1.Id, division2.Id },
+        };
+        var season = new SeasonDto
+        {
+            Id = Guid.NewGuid(),
+            StartDate = new DateTime(2001, 01, 01),
+            EndDate = new DateTime(2001, 05, 01),
+        };
+        var division1InSeasonTournament = new TournamentGame
+        {
+            Id = Guid.NewGuid(),
+            DivisionId = division1.Id,
+            Date = new DateTime(2001, 02, 01),
+        };
+        var division2InSeasonTournament = new TournamentGame
+        {
+            Id = Guid.NewGuid(),
+            DivisionId = division2.Id,
+            Date = new DateTime(2001, 02, 01),
+        };
+        var outOfSeasonTournament = new TournamentGame
+        {
+            Id = Guid.NewGuid(),
+            Date = new DateTime(2001, 06, 01),
+        };
+        _someTournaments.AddRange(new[]
+        {
+            division1InSeasonTournament, outOfSeasonTournament, division2InSeasonTournament,
+        });
+        _genericService.Setup(s => s.Get(division1.Id, _token)).ReturnsAsync(division1);
+        _genericService.Setup(s => s.Get(division2.Id, _token)).ReturnsAsync(division2);
+        _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
+        _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
+
+        await _service.GetDivisionData(filter, _token);
+
+        _tournamentGameRepository.Verify(s => s.GetSome($"t.SeasonId = '{season.Id}'", _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division1, division2 }, true, _token));
+        Assert.That(_divisionDataContext, Is.Not.Null);
+        Assert.That(_divisionDataContext!.AllTournamentGames(new[] { (Guid?)division1.Id }), Is.EquivalentTo(new[]
+        {
+            division1InSeasonTournament,
+        }));
+        Assert.That(_divisionDataContext!.AllTournamentGames(new[] { (Guid?)division2.Id }), Is.EquivalentTo(new[]
+        {
+            division2InSeasonTournament,
+        }));
+    }
+
+    [Test]
     public async Task GetDivisionData_WhenLoggedInAndCannotManageGames_GetsFixturesForFilterDivisionOnly()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
@@ -846,7 +947,7 @@ public class DivisionServiceTests
         var filter = new DivisionDataFilter
         {
             SeasonId = season.Id,
-            DivisionId = division.Id,
+            DivisionId = { division.Id },
         };
         var givenDivisionGameInSeason = new CosmosGame
         {
@@ -864,7 +965,6 @@ public class DivisionServiceTests
         {
             givenDivisionGameInSeason, givenDivisionGameOutOfSeason,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
         _genericService.Setup(s => s.Get(division.Id, _token)).ReturnsAsync(division);
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
@@ -878,8 +978,8 @@ public class DivisionServiceTests
 
         await _service.GetDivisionData(filter, _token);
 
-        _gameRepository.Verify(s => s.GetSome($"t.DivisionId = '{filter.DivisionId}' or t.IsKnockout = true", _token));
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), division, true, _token));
+        _gameRepository.Verify(s => s.GetSome($"t.DivisionId in ('{division.Id}') or t.IsKnockout = true", _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division }, true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.AllGames(null), Is.EquivalentTo(new[]
         {
@@ -890,7 +990,6 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_WhenLoggedInAndCanManageGames_GetsFixturesForAllDivisions()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
@@ -904,7 +1003,7 @@ public class DivisionServiceTests
         var filter = new DivisionDataFilter
         {
             SeasonId = season.Id,
-            DivisionId = division.Id,
+            DivisionId = { division.Id },
         };
         var givenDivisionGameInSeason = new CosmosGame
         {
@@ -937,7 +1036,6 @@ public class DivisionServiceTests
             otherDivisionGameInSeason,
             otherDivisionGameOutOfSeason,
         });
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
         _genericService.Setup(s => s.Get(division.Id, _token)).ReturnsAsync(division);
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
@@ -952,7 +1050,7 @@ public class DivisionServiceTests
         await _service.GetDivisionData(filter, _token);
 
         _gameRepository.Verify(s => s.GetSome($"t.SeasonId = '{season.Id}'", _token));
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), division, true, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division }, true, _token));
         Assert.That(_divisionDataContext, Is.Not.Null);
         Assert.That(_divisionDataContext!.AllGames(null), Is.EquivalentTo(new[]
         {
@@ -963,7 +1061,6 @@ public class DivisionServiceTests
     [Test]
     public async Task GetDivisionData_WhenExcludingProposals_RequestsDivisionDataWithoutProposals()
     {
-        var data = new DivisionDataDto();
         var division = new DivisionDto
         {
             Id = Guid.NewGuid(),
@@ -977,10 +1074,9 @@ public class DivisionServiceTests
         var filter = new DivisionDataFilter
         {
             SeasonId = season.Id,
-            DivisionId = division.Id,
+            DivisionId = { division.Id },
             ExcludeProposals = true,
         };
-        _divisionDataDtoFactory.Setup(f => f.SeasonNotFound(division, It.IsAny<List<SeasonDto>>(), _token)).ReturnsAsync(data);
         _genericSeasonService.Setup(s => s.GetAll(_token)).Returns(TestUtilities.AsyncEnumerable(season));
         _genericService.Setup(s => s.Get(division.Id, _token)).ReturnsAsync(division);
         _clock.Setup(c => c.UtcNow).Returns(new DateTimeOffset(2001, 03, 01, 0, 0, 0, TimeSpan.Zero));
@@ -994,6 +1090,6 @@ public class DivisionServiceTests
 
         await _service.GetDivisionData(filter, _token);
 
-        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), division, false, _token));
+        _divisionDataDtoFactory.Verify(f => f.CreateDivisionDataDto(It.IsAny<DivisionDataContext>(), new[] { division }, false, _token));
     }
 }

--- a/CourageScores.Tests/Services/Health/HealthCheckServiceTests.cs
+++ b/CourageScores.Tests/Services/Health/HealthCheckServiceTests.cs
@@ -80,10 +80,10 @@ public class HealthCheckServiceTests
         _seasonService.Setup(s => s.Get(_season.Id, _token)).ReturnsAsync(_season);
         _userService.Setup(s => s.GetUser(_token)).ReturnsAsync(() => _user);
         _divisionService
-            .Setup(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId == _division1.Id && f.SeasonId == _season.Id && f.IgnoreDates), _token))
+            .Setup(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId.Contains(_division1.Id) && f.SeasonId == _season.Id && f.IgnoreDates), _token))
             .ReturnsAsync(_division1);
         _divisionService
-            .Setup(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId == _division2.Id && f.SeasonId == _season.Id && f.IgnoreDates), _token))
+            .Setup(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId.Contains(_division2.Id) && f.SeasonId == _season.Id && f.IgnoreDates), _token))
             .ReturnsAsync(_division2);
         _healthCheckFactory.Setup(f => f.GetHealthChecks()).Returns(new[]
         {
@@ -158,7 +158,7 @@ public class HealthCheckServiceTests
         };
         _seasonService.Setup(s => s.Get(seasonWithMissingDivision.Id, _token)).ReturnsAsync(seasonWithMissingDivision);
         _divisionService
-            .Setup(d => d.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId == divisionId), _token))
+            .Setup(d => d.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId.Contains(divisionId)), _token))
             .ReturnsAsync(() => new DivisionDataDto
             {
                 Id = divisionId,

--- a/CourageScores.Tests/Services/Report/FinalsNightReportTests.cs
+++ b/CourageScores.Tests/Services/Report/FinalsNightReportTests.cs
@@ -110,10 +110,10 @@ public class FinalsNightReportTests
 
         _userService.Setup(s => s.GetUser(_token)).ReturnsAsync(() => _user);
         _divisionService
-            .Setup(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId == _division1.Id), _token))
+            .Setup(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId.Contains(_division1.Id)), _token))
             .ReturnsAsync(_divisionData1);
         _divisionService
-            .Setup(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId == _division2.Id), _token))
+            .Setup(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId.Contains(_division2.Id)), _token))
             .ReturnsAsync(_divisionData2);
         _divisionService.Setup(s => s.GetAll(_token)).Returns(() => TestUtilities.AsyncEnumerable(_divisions));
         _manOfTheMatchReport

--- a/CourageScores.Tests/Services/Season/Creation/SeasonTemplateServiceTests.cs
+++ b/CourageScores.Tests/Services/Season/Creation/SeasonTemplateServiceTests.cs
@@ -107,7 +107,7 @@ public class SeasonTemplateServiceTests
         _seasonService.Setup(s => s.Get(_season.Id, _token)).ReturnsAsync(_season);
         _divisionService
             .Setup(s => s.GetDivisionData(
-                It.Is<DivisionDataFilter>(f => f.DivisionId == _division.Id && f.SeasonId == _season.Id), _token))
+                It.Is<DivisionDataFilter>(f => f.DivisionId.Contains(_division.Id) && f.SeasonId == _season.Id), _token))
             .ReturnsAsync(() => _division);
         _checkFactory.Setup(f => f.CreateChecks()).Returns(_check.Object);
         _teamService.Setup(s => s.GetTeamsForSeason(_season.Id, _token))
@@ -175,7 +175,7 @@ public class SeasonTemplateServiceTests
         var result = await _service.GetForSeason(_season.Id, _token);
 
         _divisionService
-            .Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId == _division!.Id && f.SeasonId == _season.Id && f.ExcludeProposals == true), _token));
+            .Verify(s => s.GetDivisionData(It.Is<DivisionDataFilter>(f => f.DivisionId.Contains(_division!.Id) && f.SeasonId == _season.Id && f.ExcludeProposals == true), _token));
         Assert.That(result.Success, Is.True);
     }
 

--- a/CourageScores/Binders/CommaDelimitedModelBinder.cs
+++ b/CourageScores/Binders/CommaDelimitedModelBinder.cs
@@ -78,6 +78,10 @@ public class CommaDelimitedModelBinder : IModelBinder
             {
                 bindingContext.Result = ModelBindingResult.Success(ParseValues(values).ToList());
             }
+            else if (bindingContext.ModelType == typeof(HashSet<T>))
+            {
+                bindingContext.Result = ModelBindingResult.Success(ParseValues(values).ToHashSet());
+            }
             else if (bindingContext.ModelType == typeof(T[]) || bindingContext.ModelType == typeof(IEnumerable<T>) || bindingContext.ModelType == typeof(IReadOnlyCollection<T>))
             {
                 bindingContext.Result = ModelBindingResult.Success(ParseValues(values).ToArray());

--- a/CourageScores/Binders/CommaDelimitedModelBinder.cs
+++ b/CourageScores/Binders/CommaDelimitedModelBinder.cs
@@ -1,0 +1,97 @@
+using System.Collections;
+using System.ComponentModel;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace CourageScores.Binders;
+
+/// <summary>
+/// Adapted from https://gist.github.com/copernicus365/74aff0b560b985f7d2b9c61a608c0a64
+/// </summary>
+public class CommaDelimitedModelBinder : IModelBinder
+{
+    private static readonly Dictionary<Type, IModelBinder> TypedModelBinderCache = new Dictionary<Type, IModelBinder>();
+
+    private static readonly Type[] SupportedElementTypes = {
+        typeof(int), typeof(long), typeof(short), typeof(byte),
+        typeof(uint), typeof(ulong), typeof(ushort), typeof(Guid),
+    };
+
+    public async Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        var elementType = GetElementType(bindingContext.ModelType);
+        if (elementType == null)
+        {
+            return;
+        }
+
+        if (!TypedModelBinderCache.TryGetValue(elementType, out var typedModelBinder))
+        {
+            var typedModelBinderType = typeof(TypedModelBinder<>).MakeGenericType(elementType);
+            typedModelBinder = (IModelBinder)Activator.CreateInstance(typedModelBinderType)!;
+            TypedModelBinderCache.Add(elementType, typedModelBinder);
+        }
+
+        await typedModelBinder.BindModelAsync(bindingContext);
+    }
+
+    public static bool IsSupportedModelType(Type modelType)
+    {
+        var elementType = GetElementType(modelType);
+        return elementType != null && SupportedElementTypes.Contains(elementType);
+    }
+
+    private static Type? GetElementType(Type modelType)
+    {
+        if (modelType != typeof(string) && modelType.IsAssignableTo(typeof(IEnumerable)))
+        {
+            if (modelType.GetGenericArguments().Length == 1)
+            {
+                return modelType.GetGenericArguments()[0];
+            }
+
+            var elementType = modelType.GetElementType();
+            if (elementType != null)
+            {
+                return elementType;
+            }
+        }
+
+        return null;
+    }
+
+    private class TypedModelBinder<T> : IModelBinder
+    {
+        private readonly TypeConverter _converter = TypeDescriptor.GetConverter(typeof(T));
+
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            var providerValue = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+
+            if (providerValue == ValueProviderResult.None)
+            {
+                return Task.CompletedTask;
+            }
+
+            var values = providerValue.Values.SelectMany(s => s.Trim().Split(',', StringSplitOptions.RemoveEmptyEntries)).ToList();
+
+            if (bindingContext.ModelType == typeof(List<T>))
+            {
+                bindingContext.Result = ModelBindingResult.Success(ParseValues(values).ToList());
+            }
+            else if (bindingContext.ModelType == typeof(T[]) || bindingContext.ModelType == typeof(IEnumerable<T>) || bindingContext.ModelType == typeof(IReadOnlyCollection<T>))
+            {
+                bindingContext.Result = ModelBindingResult.Success(ParseValues(values).ToArray());
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private IEnumerable<T?> ParseValues(IReadOnlyCollection<string> sourceArray)
+        {
+            foreach (var str in sourceArray)
+            {
+                yield return (T?)_converter.ConvertFromString(str);
+            }
+        }
+    }
+}

--- a/CourageScores/Binders/CommaDelimitedModelBinderExtensions.cs
+++ b/CourageScores/Binders/CommaDelimitedModelBinderExtensions.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+namespace CourageScores.Binders;
+
+/// <summary>
+/// Copied from https://gist.github.com/copernicus365/74aff0b560b985f7d2b9c61a608c0a64
+/// </summary>
+[ExcludeFromCodeCoverage]
+public static class CommaDelimitedModelBinderExtensions
+{
+	public static void AddCommaSeparatedArrayModelBinderProvider(this MvcOptions options)
+	{
+		var providerToInsert = new CommaDelimitedModelBinderProvider();
+
+		// Find the location of SimpleTypeModelBinder, the CommaDelimitedModelBinder must be inserted before it.
+		var index = options.ModelBinderProviders.FirstIndexOfOrDefault(i => i is SimpleTypeModelBinderProvider);
+
+		if (index != null)
+		{
+			options.ModelBinderProviders.Insert(index.Value, providerToInsert);
+		}
+		else
+		{
+			options.ModelBinderProviders.Add(providerToInsert);
+		}
+	}
+
+	private static int? FirstIndexOfOrDefault<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+	{
+		var result = 0;
+
+		foreach (var item in source)
+		{
+			if (predicate(item))
+			{
+				return result;
+			}
+
+			result++;
+		}
+
+		return null;
+	}
+}

--- a/CourageScores/Binders/CommaDelimitedModelBinderProvider.cs
+++ b/CourageScores/Binders/CommaDelimitedModelBinderProvider.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace CourageScores.Binders;
+
+/// <summary>
+/// Copied from https://gist.github.com/copernicus365/74aff0b560b985f7d2b9c61a608c0a64
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class CommaDelimitedModelBinderProvider : IModelBinderProvider
+{
+    private static readonly CommaDelimitedModelBinder Binder = new CommaDelimitedModelBinder();
+
+    public IModelBinder? GetBinder(ModelBinderProviderContext context)
+    {
+        return CommaDelimitedModelBinder.IsSupportedModelType(context.Metadata.ModelType)
+            ? Binder
+            : null;
+    }
+}

--- a/CourageScores/ClientApp/src/App.tsx
+++ b/CourageScores/ClientApp/src/App.tsx
@@ -4,7 +4,6 @@ import {DataMap, toMap} from "./helpers/collections";
 import {Layout} from "./components/layout/Layout";
 import {Route, Routes} from "react-router-dom";
 import {Home} from "./components/Home";
-import {Division} from "./components/league/Division";
 import {Score} from "./components/scores/Score";
 import {AdminHome} from "./components/admin/AdminHome";
 import {Tournament} from "./components/tournaments/Tournament";
@@ -22,6 +21,7 @@ import {UserDto} from "./interfaces/models/dtos/Identity/UserDto";
 import {Tv} from "./components/Tv";
 import {IBrowserType} from "./components/common/IBrowserType";
 import {PreferencesContainer} from "./components/common/PreferencesContainer";
+import {DivisionUriContainer, UrlStyle} from "./components/league/DivisionUriContainer";
 
 export interface IAppProps {
     embed: boolean;
@@ -140,9 +140,12 @@ export function App({embed, controls, testRoute}: IAppProps) {
                 <Layout>
                     <Routes>
                         <Route path='/' element={<Home/>}/>
-                        <Route path='/division/:divisionId' element={<Division/>}/>
-                        <Route path='/division/:divisionId/:mode' element={<Division/>}/>
-                        <Route path='/division/:divisionId/:mode/:seasonId' element={<Division/>}/>
+                        <Route path='/division/:divisionId' element={<DivisionUriContainer urlStyle={UrlStyle.Single} />} />
+                        <Route path='/division/:divisionId/:mode' element={<DivisionUriContainer urlStyle={UrlStyle.Single} />} />
+                        <Route path='/division/:divisionId/:mode/:seasonId' element={<DivisionUriContainer urlStyle={UrlStyle.Single} />} />
+                        <Route path='/teams/:seasonId' element={<DivisionUriContainer urlStyle={UrlStyle.Multiple} mode="teams" />} />
+                        <Route path='/players/:seasonId' element={<DivisionUriContainer urlStyle={UrlStyle.Multiple} mode="players" />} />
+                        <Route path='/fixtures/:seasonId' element={<DivisionUriContainer urlStyle={UrlStyle.Multiple} mode="fixtures" />} />
                         <Route path='/score/:fixtureId' element={<Score/>}/>
                         <Route path='/admin' element={<AdminHome/>}/>
                         <Route path='/admin/:mode' element={<AdminHome/>}/>

--- a/CourageScores/ClientApp/src/App.tsx
+++ b/CourageScores/ClientApp/src/App.tsx
@@ -146,6 +146,9 @@ export function App({embed, controls, testRoute}: IAppProps) {
                         <Route path='/teams/:seasonId' element={<DivisionUriContainer urlStyle={UrlStyle.Multiple} mode="teams" />} />
                         <Route path='/players/:seasonId' element={<DivisionUriContainer urlStyle={UrlStyle.Multiple} mode="players" />} />
                         <Route path='/fixtures/:seasonId' element={<DivisionUriContainer urlStyle={UrlStyle.Multiple} mode="fixtures" />} />
+                        <Route path='/teams' element={<DivisionUriContainer urlStyle={UrlStyle.Multiple} mode="teams" />} />
+                        <Route path='/players' element={<DivisionUriContainer urlStyle={UrlStyle.Multiple} mode="players" />} />
+                        <Route path='/fixtures' element={<DivisionUriContainer urlStyle={UrlStyle.Multiple} mode="fixtures" />} />
                         <Route path='/score/:fixtureId' element={<Score/>}/>
                         <Route path='/admin' element={<AdminHome/>}/>
                         <Route path='/admin/:mode' element={<AdminHome/>}/>

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
@@ -18,6 +18,7 @@ import {IEditableDivisionFixtureDateDto} from "./IEditableDivisionFixtureDateDto
 import {TeamSeasonDto} from "../../interfaces/models/dtos/Team/TeamSeasonDto";
 import {usePreferences} from "../common/PreferencesContainer";
 import {ToggleFavouriteTeam} from "../common/ToggleFavouriteTeam";
+import {DivisionDto} from "../../interfaces/models/dtos/DivisionDto";
 
 export interface IDivisionFixtureProps {
     fixture: IEditableDivisionFixtureDto;
@@ -286,12 +287,14 @@ export function DivisionFixture({fixture, date, readOnly, onUpdateFixtures, befo
     }
 
     try {
+        const homeDivision: DivisionDto = fixture.homeDivision || { id: divisionId, name: divisionName };
+
         return (<tr className={(deleting ? 'text-decoration-line-through' : '') + (notAFavourite && favouritesEnabled && !isAdmin ? ' opacity-25' : '')}>
             <td className="text-end">
                 {awayTeamId && (fixture.id !== fixture.homeTeam.id)
                     ? (<Link to={`/score/${fixture.id}`}
                                        className="margin-right">{fixture.homeTeam.name}</Link>)
-                    : (<Link to={`/division/${divisionName}/team:${fixture.homeTeam.name}/${season.name}`}
+                    : (<Link to={`/division/${homeDivision.name || homeDivision.id}/team:${fixture.homeTeam.name}/${season.name}`}
                                        className="margin-right">{fixture.homeTeam.name}</Link>)}
                 {isAdmin ? null : <ToggleFavouriteTeam teamId={fixture.homeTeam.id} />}
             </td>

--- a/CourageScores/ClientApp/src/components/division_players/DivisionPlayer.tsx
+++ b/CourageScores/ClientApp/src/components/division_players/DivisionPlayer.tsx
@@ -15,6 +15,7 @@ import {ToggleFavouriteTeam} from "../common/ToggleFavouriteTeam";
 import {usePreferences} from "../common/PreferencesContainer";
 import {any} from "../../helpers/collections";
 import {Link} from "react-router-dom";
+import {DivisionDto} from "../../interfaces/models/dtos/DivisionDto";
 
 export interface IDivisionPlayerProps {
     player: DivisionPlayerDto;
@@ -90,6 +91,8 @@ export function DivisionPlayer({player, hideVenue}: IDivisionPlayerProps) {
         }
     }
 
+    const division: DivisionDto = player.division || { id: divisionId, name: divisionName };
+
     return (<tr className={(notAFavourite && favouritesEnabled && !isAdmin ? ' opacity-25' : '')}>
         <td>{player.rank}</td>
         <td>
@@ -105,7 +108,7 @@ export function DivisionPlayer({player, hideVenue}: IDivisionPlayerProps) {
                 : null}
             {deleting
                 ? (<s>{player.name}</s>)
-                : (<Link to={`/division/${divisionName}/player:${player.name}@${player.team}/${season.name}`}>
+                : (<Link to={`/division/${division.name || division.id}/player:${player.name}@${player.team}/${season.name}`}>
                     {player.captain ? (<span>🤴 </span>) : null}
                     {player.name}
                 </Link>)}
@@ -120,7 +123,7 @@ export function DivisionPlayer({player, hideVenue}: IDivisionPlayerProps) {
                     ? (<span className="text-warning">{player.team}</span>)
                     : (<>
                         {isAdmin ? null : (<ToggleFavouriteTeam teamId={player.teamId} />)}
-                        <Link to={`/division/${divisionName}/team:${team.name}/${season.name}`} className="margin-right">
+                        <Link to={`/division/${division.name || division.id}/team:${team.name}/${season.name}`} className="margin-right">
                             {deleting ? (<s>{player.team}</s>) : player.team}
                         </Link></>)}
             </td>)}

--- a/CourageScores/ClientApp/src/components/division_teams/DivisionTeam.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/DivisionTeam.tsx
@@ -11,6 +11,7 @@ import {ToggleFavouriteTeam} from "../common/ToggleFavouriteTeam";
 import {usePreferences} from "../common/PreferencesContainer";
 import {any} from "../../helpers/collections";
 import {Link} from "react-router-dom";
+import {DivisionDto} from "../../interfaces/models/dtos/DivisionDto";
 
 export interface IDivisionTeamProps {
     team: DivisionTeamDto;
@@ -64,6 +65,8 @@ export function DivisionTeam({team}: IDivisionTeamProps) {
         }
     }
 
+    const division: DivisionDto = team.division || { id: divisionId, name: divisionName };
+
     try {
         return (<tr className={(notAFavourite && favouritesEnabled && !isAdmin ? ' opacity-25' : '')}>
             <td>
@@ -72,7 +75,7 @@ export function DivisionTeam({team}: IDivisionTeamProps) {
                 {isAdmin ? (<button onClick={() => setAddTeamToSeason(true)}
                                     className="btn btn-sm btn-primary margin-right d-print-none">➕</button>) : null}
                 {isAdmin ? null : (<ToggleFavouriteTeam teamId={team.id} />)}
-                <Link to={`/division/${divisionName}/team:${team.name}/${season.name}`}>
+                <Link to={`/division/${division.name || division.id}/team:${team.name}/${season.name}`}>
                     {team.name}
                 </Link>
                 {editTeam && isAdmin ? renderEditTeam() : null}

--- a/CourageScores/ClientApp/src/components/division_teams/TeamOverview.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/TeamOverview.tsx
@@ -77,7 +77,7 @@ export function TeamOverview({teamId}: ITeamOverviewProps) {
         return <div className="content-background p-3">
             <h5 className="text-danger">⚠ Team could not be found</h5>
             <Link className="btn btn-primary"
-                            to={`/division/${divisionName}/teams/${season.name}`}>Teams</Link>
+                            to={`/teams/${season.name}/?division=${divisionName}`}>Teams</Link>
         </div>
     }
 

--- a/CourageScores/ClientApp/src/components/layout/NavMenu.test.tsx
+++ b/CourageScores/ClientApp/src/components/layout/NavMenu.test.tsx
@@ -111,7 +111,7 @@ describe('NavMenu', () => {
             expect(listItems.map(li => li.querySelector('a').href)).toEqual([
                 'https://localhost/BEFORE1',
                 'https://localhost/BEFORE2',
-                'http://localhost/division/' + division.name + '/teams/' + currentSeason.name,
+                'http://localhost/teams/' + currentSeason.name + '/?division=' + division.name,
                 'https://localhost/AFTER1',
                 'https://localhost/AFTER2',
                 'https://localhost/api/Account/Login/?redirectUrl=https://localhost/practice?q=value']);
@@ -331,8 +331,8 @@ describe('NavMenu', () => {
                     clearError,
                 }),
                 null,
-                '/division/:divisionId/:mode/:seasonId',
-                `/division/${division1.id}/teams/${onlyDivision1SeasonCurrent.id}`);
+                '/teams/:seasonId',
+                `/teams/${onlyDivision1SeasonCurrent.id}?division=${division1.id}`);
             expect(context.container.textContent).not.toContain('ERROR:');
 
             const items = getDivisionItems();
@@ -358,8 +358,8 @@ describe('NavMenu', () => {
                     clearError,
                 }),
                 null,
-                '/divisions/:divisionId/teams/:seasonId',
-                `/divisions/${division1.id}/teams/${bothDivisionsSeasonsNotCurrent.id}`);
+                '/teams/:seasonId',
+                `/teams/${bothDivisionsSeasonsNotCurrent.id}/?division=${division1.id}`);
             expect(context.container.textContent).not.toContain('ERROR:');
 
             const items = getDivisionItems();

--- a/CourageScores/ClientApp/src/components/layout/NavMenu.tsx
+++ b/CourageScores/ClientApp/src/components/layout/NavMenu.tsx
@@ -92,7 +92,7 @@ export function NavMenu() {
     }
 
     function getDivisionAddress(division: DivisionDto) {
-        const currentSeasons = seasons
+        const currentSeasons: SeasonDto[] = seasons
             .filter((s: SeasonDto) => s.isCurrent)
             .filter((s: SeasonDto) => any(s.divisions, (d: DivisionDto) => d.id === division.id));
 
@@ -100,8 +100,8 @@ export function NavMenu() {
             return `/division/${division.name}`;
         }
 
-        const season = currentSeasons[0];
-        return `/division/${division.name}/teams/${season.name}`;
+        const season: SeasonDto = currentSeasons[0];
+        return `/teams/${season.name}/?division=${division.name}`;
     }
 
     if (navMenuError) {

--- a/CourageScores/ClientApp/src/components/league/Division.test.tsx
+++ b/CourageScores/ClientApp/src/components/league/Division.test.tsx
@@ -46,9 +46,10 @@ describe('Division', () => {
     let features: ConfiguredFeatureDto[];
 
     const divisionApi = api<IDivisionApi>({
-        data: async (divisionId: string, filter: DivisionDataFilter): Promise<DivisionDataDto> => {
-            const seasonId = filter.seasonId;
-            const key = `${divisionId}${seasonId ? ':' + seasonId : ''}`;
+        data: async (filter: DivisionDataFilter): Promise<DivisionDataDto> => {
+            const seasonId: string = filter.seasonId;
+            const divisionId: string = filter.divisionId.join(',');
+            const key: string = `${divisionId}${seasonId ? ':' + seasonId : ''}`;
 
             if (!any(Object.keys(divisionDataMap), (k: string) => k === key)) {
                 throw new Error(`DivisionData request not expected for ${key}`);

--- a/CourageScores/ClientApp/src/components/league/Division.test.tsx
+++ b/CourageScores/ClientApp/src/components/league/Division.test.tsx
@@ -169,8 +169,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/teams', `/teams/?division=${division.id}`,
+                    { urlStyle: UrlStyle.Multiple });
 
                 reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
@@ -182,8 +182,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/teams`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/teams', `/teams/?division=${division.name}`,
+                    { urlStyle: UrlStyle.Multiple });
 
                 reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
@@ -195,8 +195,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.name}/teams/${season.name}`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/teams/:seasonId', `/teams/${season.name}/?division=${division.name}`,
+                    { urlStyle: UrlStyle.Multiple });
 
                 reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
@@ -208,8 +208,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.id}/teams/${season.id}`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/teams/:seasonId', `/teams/${season.name}/?division=${division.name}`,
+                    { urlStyle: UrlStyle.Multiple });
 
                 reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
@@ -303,8 +303,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/fixtures`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/fixtures', `/fixtures/?division=${division.id}`,
+                    { urlStyle: UrlStyle.Multiple, mode: 'fixtures' });
 
                 reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
@@ -315,8 +315,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/fixtures`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/fixtures', `/fixtures/?division=${division.name}`,
+                    { urlStyle: UrlStyle.Multiple, mode: 'fixtures' });
 
                 reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
@@ -383,8 +383,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.id}/fixtures/${season.id}`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/fixtures/:seasonId', `/fixtures/${season.id}/?division=${division.id}`,
+                    { urlStyle: UrlStyle.Multiple, mode: 'fixtures' });
 
                 reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
@@ -397,8 +397,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/players`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/players', `/players/?division=${division.id}`,
+                    { urlStyle: UrlStyle.Multiple, mode: 'players' });
 
                 reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
@@ -410,8 +410,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/players`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/players', `/players/?division=${division.id}`,
+                    { urlStyle: UrlStyle.Multiple, mode: 'players' });
 
                 reportedError.verifyNoError();
                 const table = context.container.querySelector('.content-background table.table') as HTMLTableElement;
@@ -551,7 +551,7 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
+                }, reportedError), '/division/:divisionId', `/division/${division.id}`,
                     { urlStyle: UrlStyle.Single });
 
                 reportedError.verifyNoError();
@@ -568,7 +568,7 @@ describe('Division', () => {
                             runReports: false,
                         }
                     }
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
+                }, reportedError), '/division/:divisionId', `/division/${division.id}`,
                     { urlStyle: UrlStyle.Single });
 
                 reportedError.verifyNoError();
@@ -586,7 +586,7 @@ describe('Division', () => {
                         }
                     },
                     controls: true,
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
+                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/reports`,
                     { urlStyle: UrlStyle.Single });
 
                 reportedError.verifyNoError();
@@ -634,7 +634,7 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
+                }, reportedError), '/division/:divisionId', `/division/${division.id}`,
                     { urlStyle: UrlStyle.Single });
 
                 reportedError.verifyNoError();
@@ -651,7 +651,7 @@ describe('Division', () => {
                             runHealthChecks: false,
                         }
                     }
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
+                }, reportedError), '/division/:divisionId', `/division/${division.id}`,
                     { urlStyle: UrlStyle.Single });
 
                 reportedError.verifyNoError();
@@ -669,7 +669,7 @@ describe('Division', () => {
                         }
                     },
                     controls: true,
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
+                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/health`,
                     { urlStyle: UrlStyle.Single });
 
                 reportedError.verifyNoError();
@@ -730,7 +730,7 @@ describe('Division', () => {
                     divisions: [division],
                     seasons: [season],
                     account: {},
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
+                }, reportedError), '/division/:divisionId', `/division/${division.id}`,
                     { urlStyle: UrlStyle.Single });
 
                 reportedError.verifyNoError();
@@ -743,7 +743,7 @@ describe('Division', () => {
                     divisions: [division],
                     seasons: [season],
                     account: {},
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
+                }, reportedError), '/division/:divisionId', `/division/${division.id}`,
                     { urlStyle: UrlStyle.Single });
                 const heading = context.container.querySelector('h3') as HTMLHeadingElement;
                 expect(heading.textContent).toEqual('⚠ Errors in division data');
@@ -757,7 +757,7 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
+                }, reportedError), '/division/:divisionId', `/division/${division.id}`,
                     { urlStyle: UrlStyle.Single });
 
                 reportedError.verifyNoError();
@@ -780,8 +780,8 @@ describe('Division', () => {
                     divisions: [division],
                     seasons: [season],
                     account: {},
-                }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.id}/teams/${season.id}`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/teams/:seasonId', `/teams/${season.id}/?division=${division.id}`,
+                    { urlStyle: UrlStyle.Multiple });
 
                 expect(reportedError.error).toEqual(`Data for a different season returned, requested: ${season.id}`);
             });
@@ -797,8 +797,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/unknown/teams`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/teams', `/teams/?division=unknown`,
+                    { urlStyle: UrlStyle.Multiple });
 
                 reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
@@ -809,8 +809,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode/:seasonId', `/division/${division.id}/teams/UNKNOWN`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/teams/:seasonId', `/teams/UNKNOWN/?division=${division.id}`,
+                    { urlStyle: UrlStyle.Multiple });
 
                 reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
@@ -821,8 +821,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.name}/teams`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/teams', `/teams/?division=${division.name}`,
+                    { urlStyle: UrlStyle.Multiple });
 
                 reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
@@ -843,8 +843,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/teams', `/teams/?division=${division.id}`,
+                    { urlStyle: UrlStyle.Multiple });
 
                 expect(reportedError.error).toEqual('Error accessing division: Code: 500 -- key1: some error1, key2: some error2');
             });
@@ -858,8 +858,8 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/teams', `/teams/?division=${division.id}`,
+                    { urlStyle: UrlStyle.Multiple });
 
                 expect(reportedError.error).toEqual('Error accessing division: Code: 500');
             });
@@ -884,8 +884,8 @@ describe('Division', () => {
                         }
                     },
                     teams: [homeTeam, awayTeam],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/fixtures`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/fixtures', `/fixtures/?division=${division.id}`,
+                    { urlStyle: UrlStyle.Multiple, mode: 'fixtures' });
                 expect(dataRequested).toEqual([
                     {divisionId: division.id},
                 ]); // data loaded once
@@ -922,8 +922,8 @@ describe('Division', () => {
                         }
                     },
                     teams: [homeTeam, awayTeam],
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/fixtures`,
-                    { urlStyle: UrlStyle.Single });
+                }, reportedError), '/fixtures', `/fixtures/?division=${division.id}`,
+                    { urlStyle: UrlStyle.Multiple, mode: 'fixtures' });
                 expect(dataRequested).toEqual([
                     {divisionId: division.id},
                 ]); // data loaded once
@@ -964,8 +964,8 @@ describe('Division', () => {
                 divisions: [division],
                 seasons: [season],
                 controls: true,
-            }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
-                { urlStyle: UrlStyle.Single });
+            }, reportedError), '/teams', `/teams/?division=${division.id}`,
+                { urlStyle: UrlStyle.Multiple });
 
             reportedError.verifyNoError();
             expect(context.container.querySelector('.btn-group')).toBeTruthy();
@@ -978,8 +978,8 @@ describe('Division', () => {
                 divisions: [division],
                 seasons: [season],
                 controls: true,
-            }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
-                { urlStyle: UrlStyle.Single });
+            }, reportedError), '/teams', `/teams/?division=${division.id}`,
+                { urlStyle: UrlStyle.Multiple });
 
             reportedError.verifyNoError();
             expect(context.container.querySelector('.nav-tabs')).toBeTruthy();
@@ -993,8 +993,8 @@ describe('Division', () => {
                 divisions: [division],
                 seasons: [season],
                 controls: false,
-            }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
-                { urlStyle: UrlStyle.Single });
+            }, reportedError), '/teams', `/teams/?division=${division.id}`,
+                { urlStyle: UrlStyle.Multiple });
 
             reportedError.verifyNoError();
             expect(context.container.querySelector('.btn-group')).toBeFalsy();
@@ -1005,8 +1005,8 @@ describe('Division', () => {
                 divisions: [division],
                 seasons: [season],
                 controls: false,
-            }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
-                { urlStyle: UrlStyle.Single });
+            }, reportedError), '/teams', `/teams/?division=${division.id}`,
+                { urlStyle: UrlStyle.Multiple });
 
             reportedError.verifyNoError();
             expect(context.container.querySelector('.nav-tabs')).toBeFalsy();

--- a/CourageScores/ClientApp/src/components/league/Division.test.tsx
+++ b/CourageScores/ClientApp/src/components/league/Division.test.tsx
@@ -767,23 +767,6 @@ describe('Division', () => {
         });
 
         describe('edge cases', () => {
-            it('when a different division id is returned to requested', async () => {
-                divisionDataMap[division.id] = divisionDataBuilder()  // different id to requested
-                    .season(season)
-                    .name(division.name)
-                    .build();
-                console.log = noop;
-
-                await renderComponent(appProps({
-                    divisions: [division],
-                    seasons: [season],
-                    account: {},
-                }, reportedError), '/division/:divisionId/:mode', `/division/${division.id}/teams`,
-                    { urlStyle: UrlStyle.Single });
-
-                expect(reportedError.error).toEqual(`Data for a different division returned, requested: ${division.id}`);
-            });
-
             it('when a different season id is returned to requested', async () => {
                 divisionDataMap[division.id + ':' + season.id] = ({
                     season: seasonBuilder('ANOTHER SEASON').build(),
@@ -843,7 +826,7 @@ describe('Division', () => {
 
                 reportedError.verifyNoError();
                 const content = context.container.querySelector('.content-background') as HTMLElement;
-                expect(content.className).toContain('loading-background');
+                expect(content.innerHTML).toContain('No data found');
             });
 
             it('renders error when data returns with a status code with errors', async () => {

--- a/CourageScores/ClientApp/src/components/league/Division.test.tsx
+++ b/CourageScores/ClientApp/src/components/league/Division.test.tsx
@@ -221,7 +221,7 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/teams/:seasonId', `/teams/${season.name}?divisionId=${division.name}`,
+                }, reportedError), '/teams/:seasonId', `/teams/${season.name}?division=${division.name}`,
                     { urlStyle: UrlStyle.Multiple, mode: 'teams' });
 
                 reportedError.verifyNoError();
@@ -234,7 +234,7 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/teams/:seasonId', `/teams/${season.id}?divisionId=${division.id}`,
+                }, reportedError), '/teams/:seasonId', `/teams/${season.id}?division=${division.id}`,
                     { urlStyle: UrlStyle.Multiple, mode: 'teams' });
 
                 reportedError.verifyNoError();
@@ -351,7 +351,7 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/fixtures/:seasonId', `/fixtures/${season.name}?divisionId=${division.name}`,
+                }, reportedError), '/fixtures/:seasonId', `/fixtures/${season.name}?division=${division.name}`,
                     { urlStyle: UrlStyle.Multiple, mode: 'fixtures' });
 
                 reportedError.verifyNoError();
@@ -363,7 +363,7 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/fixtures/:seasonId', `/fixtures/${season.id}?divisionId=${division.id}`,
+                }, reportedError), '/fixtures/:seasonId', `/fixtures/${season.id}?division=${division.id}`,
                     { urlStyle: UrlStyle.Multiple, mode: 'fixtures' });
 
                 reportedError.verifyNoError();
@@ -449,7 +449,7 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/players/:seasonId', `/players/${season.name}?divisionId=${division.name}`,
+                }, reportedError), '/players/:seasonId', `/players/${season.name}?division=${division.name}`,
                     { urlStyle: UrlStyle.Multiple, mode: 'players' });
 
                 reportedError.verifyNoError();
@@ -462,7 +462,7 @@ describe('Division', () => {
                 await renderComponent(appProps({
                     divisions: [division],
                     seasons: [season],
-                }, reportedError), '/players/:seasonId', `/players/${season.id}?divisionId=${division.id}`,
+                }, reportedError), '/players/:seasonId', `/players/${season.id}?division=${division.id}`,
                     { urlStyle: UrlStyle.Multiple, mode: 'players' });
 
                 reportedError.verifyNoError();

--- a/CourageScores/ClientApp/src/components/league/Division.tsx
+++ b/CourageScores/ClientApp/src/components/league/Division.tsx
@@ -9,7 +9,7 @@ import {DivisionReports} from "../division_reports/DivisionReports";
 import {TeamOverview} from "../division_teams/TeamOverview";
 import {IPlayerOverviewProps, PlayerOverview} from "../division_players/PlayerOverview";
 import {Loading} from "../common/Loading";
-import {any} from "../../helpers/collections";
+import {all, any} from "../../helpers/collections";
 import {propChanged} from "../../helpers/events";
 import {useDependencies} from "../common/IocContainer";
 import {useApp} from "../common/AppContainer";
@@ -202,13 +202,20 @@ export function Division() {
                     return;
                 }
                 if (divisionData.status) {
-                    // dont reload if there was a previous 'status' - representing an issue loading the data
+                    // don't reload if there was a previous 'status' - representing an issue loading the data
                     return;
                 }
 
-                const requestedDivisionIds: string[] = any(requestedDivisions || []) ? requestedDivisions.map(d => d.id) : null;
+                const requestedDivisionIds: string[] = any(requestedDivisions || []) ? requestedDivisions.map((d: IIdish) => d.id) : null;
                 const requestedSeasonId: string = requestedSeason ? requestedSeason.id : null;
-                if (!any(requestedDivisionIds, d => d === divisionData.id) || (requestedSeason && (divisionData.season || {}).id !== requestedSeasonId)) {
+                const dataLoadedForSameSeason: boolean = divisionData.requested && divisionData.requested.seasonId === requestedSeasonId;
+                const dataLoadedForSameDivisions: boolean = divisionData.requested && all(
+                    requestedDivisionIds || [],
+                    (requestedDivisionId: string) => any(
+                        divisionData.requested.divisionId,
+                        (loadedDivisionId: string) => loadedDivisionId === requestedDivisionId));
+
+                if (!dataLoadedForSameSeason || !dataLoadedForSameDivisions) {
                     beginReload();
                 }
             } catch (e) {

--- a/CourageScores/ClientApp/src/components/league/Division.tsx
+++ b/CourageScores/ClientApp/src/components/league/Division.tsx
@@ -219,6 +219,10 @@ export function Division() {
         // eslint-disable-next-line
         [divisionData, loading, requestedDivisions, requestedSeason, error, seasons]);
 
+    function toQueryString(ids: IIdish[]) {
+        return '?' + ids.map(id => `divisionId=${id}`).join('&');
+    }
+
     if (loading || !dataRequested) {
         return (<Loading/>);
     }
@@ -244,7 +248,7 @@ export function Division() {
                 <li className="nav-item">
                     <NavLink tag={Link}
                              className={effectiveTab === 'teams' ? 'active' : ''}
-                             to={`/division/${requestedDivisions}/teams${requestedSeason ? '/' + requestedSeason : ''}`}>Teams</NavLink>
+                             to={`/teams${requestedSeason ? '/' + requestedSeason : ''}/${toQueryString(requestedDivisions)}`}>Teams</NavLink>
                 </li>
                 {effectiveTab.startsWith('team:') ? (<li className="nav-item">
                     <NavLink tag={Link}
@@ -255,12 +259,12 @@ export function Division() {
                 </li>) : null}
                 <li className="nav-item">
                     <NavLink tag={Link} className={effectiveTab === 'fixtures' ? 'active' : ''}
-                             to={`/division/${requestedDivisions}/fixtures${requestedSeason ? '/' + requestedSeason : ''}`}>Fixtures</NavLink>
+                             to={`/fixtures${requestedSeason ? '/' + requestedSeason : ''}/${toQueryString(requestedDivisions)}`}>Fixtures</NavLink>
                 </li>
                 <li className="nav-item">
                     <NavLink tag={Link}
                              className={effectiveTab === 'players' ? 'active' : ''}
-                             to={`/division/${requestedDivisions}/players${requestedSeason ? '/' + requestedSeason : ''}`}>Players</NavLink>
+                             to={`/players${requestedSeason ? '/' + requestedSeason : ''}/${toQueryString(requestedDivisions)}`}>Players</NavLink>
                 </li>
                 {effectiveTab.startsWith('player:') ? (<li className="nav-item">
                     <NavLink tag={Link}
@@ -269,11 +273,11 @@ export function Division() {
                         {getPlayerProps(effectiveTab.substring('player:'.length)).playerName || 'Player Details'}
                     </NavLink>
                 </li>) : null}
-                {account && account.access && account.access.runReports ? (<li className="nav-item">
+                {account && account.access && account.access.runReports && requestedDivisions.length === 1 ? (<li className="nav-item">
                     <NavLink tag={Link} className={effectiveTab === 'reports' ? 'active' : ''}
                              to={`/division/${requestedDivisions}/reports${requestedSeason ? '/' + requestedSeason : ''}`}>Reports</NavLink>
                 </li>) : null}
-                {account && account.access && account.access.runHealthChecks ? (<li className="nav-item">
+                {account && account.access && account.access.runHealthChecks && requestedDivisions.length === 1 ? (<li className="nav-item">
                     <NavLink tag={Link} className={effectiveTab === 'health' ? 'active' : ''}
                              to={`/division/${requestedDivisions}/health${requestedSeason ? '/' + requestedSeason : ''}`}>Health</NavLink>
                 </li>) : null}

--- a/CourageScores/ClientApp/src/components/league/Division.tsx
+++ b/CourageScores/ClientApp/src/components/league/Division.tsx
@@ -260,7 +260,7 @@ export function Division() {
                 {effectiveTab.startsWith('team:') ? (<li className="nav-item">
                     <NavLink tag={Link}
                              className="active"
-                             to={`/division/${requestedDivisions}/teams${requestedSeason ? '/' + requestedSeason : ''}`}>
+                             to={`/teams${requestedSeason ? '/' + requestedSeason : ''}/${toQueryString(requestedDivisions)}`}>
                         Team Details
                     </NavLink>
                 </li>) : null}
@@ -276,7 +276,7 @@ export function Division() {
                 {effectiveTab.startsWith('player:') ? (<li className="nav-item">
                     <NavLink tag={Link}
                              className="active"
-                             to={`/division/${requestedDivisions}/teams${requestedSeason ? '/' + requestedSeason : ''}`}>
+                             to={`/teams${requestedSeason ? '/' + requestedSeason : ''}/${toQueryString(requestedDivisions)}`}>
                         {getPlayerProps(effectiveTab.substring('player:'.length)).playerName || 'Player Details'}
                     </NavLink>
                 </li>) : null}

--- a/CourageScores/ClientApp/src/components/league/Division.tsx
+++ b/CourageScores/ClientApp/src/components/league/Division.tsx
@@ -108,12 +108,14 @@ export function Division() {
                 }
             }
 
-            const filter: DivisionDataFilter = {};
+            const filter: DivisionDataFilter = {
+                divisionId: [ requestedDivisionId ],
+            };
             if (requestedSeasonId) {
                 filter.seasonId = requestedSeasonId;
             }
 
-            const newDivisionData: IRequestedDivisionDataDto = await divisionApi.data(requestedDivisionId, filter);
+            const newDivisionData: IRequestedDivisionDataDto = await divisionApi.data(filter);
             newDivisionData.requested = {
                 divisionId: requestedDivisionId,
                 seasonId: requestedSeasonId,

--- a/CourageScores/ClientApp/src/components/league/Division.tsx
+++ b/CourageScores/ClientApp/src/components/league/Division.tsx
@@ -226,8 +226,8 @@ export function Division() {
         // eslint-disable-next-line
         [divisionData, loading, requestedDivisions, requestedSeason, error, seasons]);
 
-    function toQueryString(ids: IIdish[]) {
-        return '?' + ids.map(id => `divisionId=${id}`).join('&');
+    function toQueryString(ids: IIdish[]): string {
+        return '?' + ids.map((id: IIdish) => `division=${id}`).join('&');
     }
 
     if (loading || !dataRequested) {

--- a/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
@@ -510,7 +510,7 @@ describe('DivisionControls', () => {
 
                 await doClick(findButton(group, `Season 5 ${seasonDates(season5)}`));
 
-                expect(mockedUsedNavigate).toHaveBeenCalledWith(`/division/${division5.name}/teams/${season5.name}`);
+                expect(mockedUsedNavigate).toHaveBeenCalledWith(`/teams/${season5.name}/?division=${division5.name}`);
             });
 
             it('navigates correctly when on player overview page', async () => {
@@ -530,7 +530,7 @@ describe('DivisionControls', () => {
 
                 await doClick(findButton(group, 'Season 5 ' + seasonDates(season5)));
 
-                expect(mockedUsedNavigate).toHaveBeenCalledWith(`/division/${division5.name}/players/${season5.name}`);
+                expect(mockedUsedNavigate).toHaveBeenCalledWith(`/players/${season5.name}/?division=${division5.name}`);
             });
 
             it('navigates to first division in other season when current division not in other season', async () => {

--- a/CourageScores/ClientApp/src/components/league/DivisionControls.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionControls.tsx
@@ -121,14 +121,17 @@ export function DivisionControls({originalSeasonData, onDivisionOrSeasonChanged,
     }
 
     function navigateToSeason() {
-        navigate(`/division/${originalDivisionData.name}/${overrideMode || stripIdFromMode(mode) || 'teams'}/${originalSeasonData.name}`);
+        const url: string = getDivisionUrl(originalDivisionData.name, originalSeasonData.name, stripIdFromMode(mode));
+        navigate(url);
     }
 
     function renderSeasonOption(season: SeasonDto) {
+        const url: string = getDivisionUrl(firstValidDivisionNameForSeason(season), season.name, mode);
+
         return (<Link
             key={season.id}
             className={`dropdown-item ${originalSeasonData && originalSeasonData.id === season.id ? ' active' : ''}`}
-            to={`/division/${firstValidDivisionNameForSeason(season)}/${overrideMode || mode || 'teams'}/${season.name}${location.search}`}>
+            to={url + location.search}>
             {season.name} ({renderDate(season.startDate)} - {renderDate(season.endDate)})
         </Link>);
     }
@@ -140,6 +143,19 @@ export function DivisionControls({originalSeasonData, onDivisionOrSeasonChanged,
             to={`/division/${division.name}/${overrideMode || stripIdFromMode(mode) || 'teams'}/${originalSeasonData.name}${location.search}`}>
             {division.name}
         </Link>);
+    }
+
+    function getDivisionUrl(divisionName: string, seasonName: string, mode: string): string {
+        const navigateToMode: string = overrideMode || mode || 'teams';
+
+        switch (navigateToMode) {
+            case 'teams':
+            case 'players':
+            case 'fixtures':
+                return `/${navigateToMode}/${seasonName}/?division=${divisionName}`;
+            default:
+                return `/division/${divisionName}/${navigateToMode}/${seasonName}`;
+        }
     }
 
     try {

--- a/CourageScores/ClientApp/src/components/league/DivisionUriContainer.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionUriContainer.tsx
@@ -49,26 +49,22 @@ export function DivisionUriContainer({ urlStyle, mode: overrideMode }: IDivision
         }
 
         if (!divisions || !any(divisions) || !idish) {
-            return null;
+            return INVALID;
         }
 
         const division: DivisionDto = divisions.filter((d: DivisionDto) => d.name.toLowerCase() === idish.toLowerCase())[0];
         return division ? makeIdish(division) : INVALID;
     }
 
-    function getDivisionIdsFromUrl(): IIdish {
+    function getDivisionIdsFromUrl(): IIdish[] {
         const search = new URLSearchParams(location.search);
 
         if (!search.has('divisionId')) {
-            return INVALID;
+            return [ INVALID ];
         }
 
         const divisionIds: string[] = search.getAll('divisionId');
-        if (divisionIds.length === 1) {
-            return getDivisionId(divisionIds[0]);
-        } else {
-            throw new Error('Multiple divisions are not supported yet');
-        }
+        return divisionIds.map(getDivisionId);
     }
 
     function getSeasonId(idish?: string): IIdish {
@@ -86,8 +82,8 @@ export function DivisionUriContainer({ urlStyle, mode: overrideMode }: IDivision
 
     const data: IDivisionUri = {
         requestedMode: overrideMode || mode,
-        requestedDivision: urlStyle === 'single-division'
-            ? getDivisionId(divisionId)
+        requestedDivisions: urlStyle === 'single-division'
+            ? [ getDivisionId(divisionId) ]
             : getDivisionIdsFromUrl(),
         requestedSeason: getSeasonId(seasonId),
     };

--- a/CourageScores/ClientApp/src/components/league/DivisionUriContainer.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionUriContainer.tsx
@@ -43,7 +43,7 @@ export function DivisionUriContainer({ urlStyle, mode: overrideMode }: IDivision
     const location = useLocation();
     const {onError} = useApp();
 
-    function getDivisionId(idish?: string): IIdish {
+    function getDivisionIdIsh(idish?: string): IIdish {
         if (isGuid(idish)) {
             return makeIdish({ id: idish });
         }
@@ -59,12 +59,12 @@ export function DivisionUriContainer({ urlStyle, mode: overrideMode }: IDivision
     function getDivisionIdsFromUrl(): IIdish[] {
         const search = new URLSearchParams(location.search);
 
-        if (!search.has('divisionId')) {
+        if (!search.has('division')) {
             return [ INVALID ];
         }
 
-        const divisionIds: string[] = search.getAll('divisionId');
-        return divisionIds.map(getDivisionId);
+        const divisions: string[] = search.getAll('division');
+        return divisions.map(getDivisionIdIsh);
     }
 
     function getSeasonId(idish?: string): IIdish {
@@ -83,7 +83,7 @@ export function DivisionUriContainer({ urlStyle, mode: overrideMode }: IDivision
     const data: IDivisionUri = {
         requestedMode: overrideMode || mode,
         requestedDivisions: urlStyle === 'single-division'
-            ? [ getDivisionId(divisionId) ]
+            ? [ getDivisionIdIsh(divisionId) ]
             : getDivisionIdsFromUrl(),
         requestedSeason: getSeasonId(seasonId),
     };

--- a/CourageScores/ClientApp/src/components/league/DivisionUriContainer.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionUriContainer.tsx
@@ -1,0 +1,102 @@
+import {createContext, useContext} from "react";
+import {IDivisionUri, IIdish} from "./IDivisionUri";
+import {isGuid} from "../../helpers/projection";
+import {any} from "../../helpers/collections";
+import {DivisionDto} from "../../interfaces/models/dtos/DivisionDto";
+import {SeasonDto} from "../../interfaces/models/dtos/Season/SeasonDto";
+import {useApp} from "../common/AppContainer";
+import {useLocation, useParams} from "react-router-dom";
+import {Division} from "./Division";
+
+function makeIdish(item: { id: string, name?: string}): IIdish {
+    return {
+        id: item.id,
+        name: item.name,
+        toString: () => {
+            return item.name || item.id;
+        }
+    };
+}
+
+export const INVALID: IIdish = makeIdish({ id: 'INVALID' });
+
+const DivisionUriContext = createContext({});
+
+export function useDivisionUri(): IDivisionUri {
+    return useContext(DivisionUriContext) as IDivisionUri;
+}
+
+export enum UrlStyle {
+    Single = 'single-division',
+    Multiple = 'multi-division',
+}
+
+export interface IDivisionUriContainerProps {
+    urlStyle: UrlStyle;
+    mode?: string;
+}
+
+/* istanbul ignore next */
+export function DivisionUriContainer({ urlStyle, mode: overrideMode }: IDivisionUriContainerProps) {
+    const {divisions, seasons} = useApp();
+    const {divisionId, mode, seasonId} = useParams();
+    const location = useLocation();
+    const {onError} = useApp();
+
+    function getDivisionId(idish?: string): IIdish {
+        if (isGuid(idish)) {
+            return makeIdish({ id: idish });
+        }
+
+        if (!divisions || !any(divisions) || !idish) {
+            return null;
+        }
+
+        const division: DivisionDto = divisions.filter((d: DivisionDto) => d.name.toLowerCase() === idish.toLowerCase())[0];
+        return division ? makeIdish(division) : INVALID;
+    }
+
+    function getDivisionIdsFromUrl(): IIdish {
+        const search = new URLSearchParams(location.search);
+
+        if (!search.has('divisionId')) {
+            return INVALID;
+        }
+
+        const divisionIds: string[] = search.getAll('divisionId');
+        if (divisionIds.length === 1) {
+            return getDivisionId(divisionIds[0]);
+        } else {
+            throw new Error('Multiple divisions are not supported yet');
+        }
+    }
+
+    function getSeasonId(idish?: string): IIdish {
+        if (isGuid(idish)) {
+            return makeIdish({ id: idish });
+        }
+
+        if (!seasons || !any(seasons) || !idish) {
+            return null;
+        }
+
+        const season: SeasonDto = seasons.filter((s: SeasonDto) => s.name.toLowerCase() === idish.toLowerCase())[0];
+        return season ? makeIdish(season) : INVALID;
+    }
+
+    const data: IDivisionUri = {
+        requestedMode: overrideMode || mode,
+        requestedDivision: urlStyle === 'single-division'
+            ? getDivisionId(divisionId)
+            : getDivisionIdsFromUrl(),
+        requestedSeason: getSeasonId(seasonId),
+    };
+
+    try {
+        return (<DivisionUriContext.Provider value={data}>
+            <Division/>
+        </DivisionUriContext.Provider>);
+    } catch (e) {
+        onError(e);
+    }
+}

--- a/CourageScores/ClientApp/src/components/league/IDivisionUri.ts
+++ b/CourageScores/ClientApp/src/components/league/IDivisionUri.ts
@@ -1,6 +1,6 @@
 export interface IDivisionUri {
     requestedMode?: string;
-    requestedDivision?: IIdish;
+    requestedDivisions?: IIdish[];
     requestedSeason?: IIdish;
 }
 

--- a/CourageScores/ClientApp/src/components/league/IDivisionUri.ts
+++ b/CourageScores/ClientApp/src/components/league/IDivisionUri.ts
@@ -1,0 +1,11 @@
+export interface IDivisionUri {
+    requestedMode?: string;
+    requestedDivision?: IIdish;
+    requestedSeason?: IIdish;
+}
+
+export interface IIdish {
+    id: string;
+    name?: string;
+    toString(): string;
+}

--- a/CourageScores/ClientApp/src/components/scores/Score.tsx
+++ b/CourageScores/ClientApp/src/components/scores/Score.tsx
@@ -590,18 +590,18 @@ export function Score() {
                 overrideMode="fixtures"/>
             <ul className="nav nav-tabs">
                 <li className="nav-item">
-                    <NavLink tag={Link} to={`/division/${data.divisionId}/teams/${season.id}`}>Teams</NavLink>
+                    <NavLink tag={Link} to={`/teams/${season.id}/?division=${data.divisionId}`}>Teams</NavLink>
                 </li>
                 <li className="nav-item">
                     <NavLink tag={Link}
-                             to={`/division/${data.divisionId}/fixtures/${season.id}`}>Fixtures</NavLink>
+                             to={`/fixtures/${season.id}/?division=${data.divisionId}`}>Fixtures</NavLink>
                 </li>
                 <li className="nav-item">
                     <NavLink tag={Link} className="active" to={`/score/${fixtureId}`}>{renderDate(data.date)}</NavLink>
                 </li>
                 <li className="nav-item">
                     <NavLink tag={Link}
-                             to={`/division/${data.divisionId}/players/${season.id}`}>Players</NavLink>
+                             to={`/players/${season.id}/?division=${data.divisionId}`}>Players</NavLink>
                 </li>
             </ul>
             <LeagueFixtureContainer {...leagueFixtureData}>

--- a/CourageScores/ClientApp/src/components/tournaments/Tournament.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/Tournament.test.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../helpers/tests";
 import {Tournament} from "./Tournament";
 import {any, DataMap, toMap} from "../../helpers/collections";
-import {createTemporaryId, EMPTY_ID} from "../../helpers/projection";
+import {createTemporaryId} from "../../helpers/projection";
 import {DivisionDataDto} from "../../interfaces/models/dtos/Division/DivisionDataDto";
 import {TournamentGameDto} from "../../interfaces/models/dtos/Game/TournamentGameDto";
 import {EditTournamentGameDto} from "../../interfaces/models/dtos/Game/EditTournamentGameDto";
@@ -73,8 +73,9 @@ describe('Tournament', () => {
     let deletePhotoResponse: IClientActionResultDto<TournamentGameDto>;
 
     const divisionApi = api<IDivisionApi>({
-        data: async (divisionId: string, filter: DivisionDataFilter) => {
+        data: async (filter: DivisionDataFilter) => {
             const seasonId = filter.seasonId;
+            const divisionId: string = filter.divisionId.join(',');
             const key: string = `${divisionId}_${seasonId}`;
             if (any(Object.keys(divisionDataLookup), k => k === key)) {
                 return divisionDataLookup[key];
@@ -328,7 +329,7 @@ describe('Tournament', () => {
                     .addTo(tournamentDataLookup)
                     .build();
                 const divisionData = divisionDataBuilder().build();
-                expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+                expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
 
                 await renderComponent(tournamentData.id, {
                     account,
@@ -360,7 +361,7 @@ describe('Tournament', () => {
                     .addTo(tournamentDataLookup)
                     .build();
                 const divisionData = divisionDataBuilder().build();
-                expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+                expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
 
                 await renderComponent(tournamentData.id, {
                     account,
@@ -395,7 +396,7 @@ describe('Tournament', () => {
                     .addTo(tournamentDataLookup)
                     .build();
                 const divisionData = divisionDataBuilder().build();
-                expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+                expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
 
                 await renderComponent(tournamentData.id, {
                     account,
@@ -541,7 +542,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
 
             await renderComponent(tournamentData.id, {
                 account,
@@ -608,7 +609,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account,
                 seasons: toMap([season]),
@@ -637,7 +638,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account,
                 seasons: toMap([season]),
@@ -667,7 +668,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
 
             await renderComponent(tournamentData.id, {
                 account,
@@ -693,7 +694,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account,
                 seasons: toMap([season]),
@@ -720,7 +721,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account,
                 seasons: toMap([season]),
@@ -751,7 +752,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account,
                 seasons: toMap([season]),
@@ -786,7 +787,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account,
                 seasons: toMap([season]),
@@ -821,7 +822,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account,
                 seasons: toMap([season]),
@@ -858,7 +859,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account,
                 seasons: toMap([season]),
@@ -1154,7 +1155,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ playerA, playerB ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1196,7 +1197,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ playerA, playerB ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1240,7 +1241,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ playerA, playerB, playerC ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1292,7 +1293,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ playerA, playerB, playerC ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1338,7 +1339,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1375,7 +1376,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1417,7 +1418,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ playerA, playerB, playerC ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1469,7 +1470,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ playerA, playerB, playerC ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1512,7 +1513,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: null,
                 seasons: toMap([season]),
@@ -1545,7 +1546,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: notPermittedAccount,
                 seasons: toMap([season]),
@@ -1572,7 +1573,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1601,7 +1602,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1636,7 +1637,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: null,
                 seasons: toMap([season]),
@@ -1670,7 +1671,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: notPermittedAccount,
                 seasons: toMap([season]),
@@ -1698,7 +1699,7 @@ describe('Tournament', () => {
                 .forSeason(season, division, [ ])
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1731,7 +1732,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1767,7 +1768,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: account,
                 seasons: toMap([season]),
@@ -1803,7 +1804,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
 
             await renderComponent(tournamentData.id, {
                 account: account,
@@ -1829,7 +1830,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: permitted,
                 seasons: toMap([season]),
@@ -1858,7 +1859,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: permitted,
                 seasons: toMap([season]),
@@ -1887,7 +1888,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: permitted,
                 seasons: toMap([season]),
@@ -1926,7 +1927,7 @@ describe('Tournament', () => {
                 .addTo(tournamentDataLookup)
                 .build();
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: permitted,
                 seasons: toMap([season]),
@@ -1968,7 +1969,7 @@ describe('Tournament', () => {
             };
             tournamentData.photos = [photo];
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: permitted,
                 seasons: toMap([season]),
@@ -2012,7 +2013,7 @@ describe('Tournament', () => {
             };
             tournamentData.photos = [photo];
             const divisionData = divisionDataBuilder().build();
-            expectDivisionDataRequest(EMPTY_ID, tournamentData.seasonId, divisionData);
+            expectDivisionDataRequest('', tournamentData.seasonId, divisionData);
             await renderComponent(tournamentData.id, {
                 account: permitted,
                 seasons: toMap([season]),

--- a/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
@@ -116,9 +116,10 @@ export function Tournament() {
             if (canManageTournaments) {
                 const filter: DivisionDataFilter = {
                     seasonId: tournamentData.seasonId,
+                    divisionId: [ tournamentData.divisionId ].filter((id: string) => !!id),
                 };
 
-                const divisionData: DivisionDataDto = await divisionApi.data(tournamentData.divisionId || EMPTY_ID, filter);
+                const divisionData: DivisionDataDto = await divisionApi.data(filter);
                 const fixtureDate: DivisionFixtureDateDto = divisionData.fixtures.filter(f => f.date === tournamentData.date)[0];
                 if (fixtureDate) {
                     const tournamentFixtures: DivisionTournamentFixtureDetailsDto[] = fixtureDate.tournamentFixtures

--- a/CourageScores/Controllers/DivisionController.cs
+++ b/CourageScores/Controllers/DivisionController.cs
@@ -31,7 +31,7 @@ public class DivisionController : Controller
     public async Task<DivisionDataDto> Data(Guid divisionId, [FromQuery] DivisionDataFilter? filter, CancellationToken token)
     {
         filter ??= new DivisionDataFilter();
-        filter.DivisionId = divisionId;
+        filter.DivisionId.Add(divisionId);
 
         return await _divisionService.GetDivisionData(filter, token);
     }
@@ -41,9 +41,10 @@ public class DivisionController : Controller
     public async Task<DivisionDataDto> Data(Guid? divisionId, Guid seasonId, [FromQuery] DivisionDataFilter? filter, CancellationToken token)
     {
         filter ??= new DivisionDataFilter();
-        filter.DivisionId = divisionId == null || divisionId == Guid.Empty
-            ? null
-            : divisionId;
+        if (divisionId != null && divisionId != Guid.Empty)
+        {
+            filter.DivisionId.Add(divisionId.Value);
+        }
         filter.SeasonId = seasonId;
 
         return await _divisionService.GetDivisionData(filter, token);

--- a/CourageScores/Controllers/DivisionController.cs
+++ b/CourageScores/Controllers/DivisionController.cs
@@ -27,24 +27,16 @@ public class DivisionController : Controller
         return await _divisionService.Get(id, token);
     }
 
-    [HttpGet("/api/Division/{divisionId}/Data")]
-    public async Task<DivisionDataDto> Data(Guid divisionId, [FromQuery] DivisionDataFilter? filter, CancellationToken token)
+    [HttpGet("/api/Division/Data")]
+    public async Task<DivisionDataDto> Data([FromQuery] DivisionDataFilter filter, CancellationToken token)
     {
-        filter ??= new DivisionDataFilter();
-        filter.DivisionId.Add(divisionId);
-
         return await _divisionService.GetDivisionData(filter, token);
     }
 
     [ExcludeFromTypeScript]
-    [HttpGet("/api/Division/{divisionId}/{seasonId}/Data")]
-    public async Task<DivisionDataDto> Data(Guid? divisionId, Guid seasonId, [FromQuery] DivisionDataFilter? filter, CancellationToken token)
+    [HttpGet("/api/Division/{seasonId}/Data")]
+    public async Task<DivisionDataDto> Data(Guid seasonId, [FromQuery] DivisionDataFilter filter, CancellationToken token)
     {
-        filter ??= new DivisionDataFilter();
-        if (divisionId != null && divisionId != Guid.Empty)
-        {
-            filter.DivisionId.Add(divisionId.Value);
-        }
         filter.SeasonId = seasonId;
 
         return await _divisionService.GetDivisionData(filter, token);

--- a/CourageScores/Models/Adapters/Division/DivisionFixtureAdapter.cs
+++ b/CourageScores/Models/Adapters/Division/DivisionFixtureAdapter.cs
@@ -1,3 +1,4 @@
+using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Game;
 using CourageScores.Models.Dtos.Team;
@@ -14,7 +15,7 @@ public class DivisionFixtureAdapter : IDivisionFixtureAdapter
         _divisionFixtureTeamAdapter = divisionFixtureTeamAdapter;
     }
 
-    public async Task<DivisionFixtureDto> Adapt(CosmosGame game, TeamDto? homeTeam, TeamDto? awayTeam, CancellationToken token)
+    public async Task<DivisionFixtureDto> Adapt(CosmosGame game, TeamDto? homeTeam, TeamDto? awayTeam, DivisionDto? homeDivision, DivisionDto? awayDivision, CancellationToken token)
     {
         var matches = game.Matches.Where(m => m.Deleted == null).ToArray();
         var numberOfMatchesWithPlayers = matches.Count(m => m.HomePlayers.Any() && m.AwayPlayers.Any());
@@ -36,10 +37,12 @@ public class DivisionFixtureAdapter : IDivisionFixtureAdapter
             Postponed = game.Postponed,
             IsKnockout = game.IsKnockout,
             AccoladesCount = game.AccoladesCount,
+            HomeDivision = homeDivision,
+            AwayDivision = awayDivision,
         };
     }
 
-    public async Task<DivisionFixtureDto> ForUnselectedTeam(TeamDto team, bool isKnockout, IReadOnlyCollection<CosmosGame> fixturesUsingAddress, CancellationToken token)
+    public async Task<DivisionFixtureDto> ForUnselectedTeam(TeamDto team, bool isKnockout, IReadOnlyCollection<CosmosGame> fixturesUsingAddress, DivisionDto? division, CancellationToken token)
     {
         return new DivisionFixtureDto
         {
@@ -53,6 +56,7 @@ public class DivisionFixtureAdapter : IDivisionFixtureAdapter
             Proposal = false,
             AccoladesCount = true,
             FixturesUsingAddress = fixturesUsingAddress.Select(OtherDivisionFixtureDto).ToList(),
+            HomeDivision = division,
         };
     }
 

--- a/CourageScores/Models/Adapters/Division/DivisionPlayerAdapter.cs
+++ b/CourageScores/Models/Adapters/Division/DivisionPlayerAdapter.cs
@@ -1,3 +1,4 @@
+using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Team;
 using CourageScores.Services.Division;
@@ -14,7 +15,7 @@ public class DivisionPlayerAdapter : IDivisionPlayerAdapter
     }
 
     public async Task<DivisionPlayerDto> Adapt(DivisionData.PlayerScore score, DivisionData.TeamPlayerTuple playerTuple,
-        Dictionary<DateTime, Guid> fixtures, CancellationToken token)
+        Dictionary<DateTime, Guid> fixtures, DivisionDto? division, CancellationToken token)
     {
         return new DivisionPlayerDto
         {
@@ -32,10 +33,11 @@ public class DivisionPlayerAdapter : IDivisionPlayerAdapter
             WinPercentage = score.PlayerWinPercentage,
             Fixtures = fixtures,
             Updated = playerTuple.Player.Updated,
+            Division = division,
         };
     }
 
-    public Task<DivisionPlayerDto> Adapt(TeamDto team, TeamPlayerDto player, CancellationToken token)
+    public Task<DivisionPlayerDto> Adapt(TeamDto team, TeamPlayerDto player, DivisionDto? division, CancellationToken token)
     {
         return Task.FromResult(new DivisionPlayerDto
         {
@@ -54,6 +56,7 @@ public class DivisionPlayerAdapter : IDivisionPlayerAdapter
             Triples = new PlayerPerformanceDto(),
             Rank = -1,
             Updated = player.Updated,
+            Division = division,
         });
     }
 }

--- a/CourageScores/Models/Adapters/Division/DivisionTeamAdapter.cs
+++ b/CourageScores/Models/Adapters/Division/DivisionTeamAdapter.cs
@@ -1,3 +1,4 @@
+using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Team;
 using CourageScores.Services.Division;
@@ -6,7 +7,7 @@ namespace CourageScores.Models.Adapters.Division;
 
 public class DivisionTeamAdapter : IDivisionTeamAdapter
 {
-    public Task<DivisionTeamDto> Adapt(TeamDto team, DivisionData.TeamScore score, IReadOnlyCollection<DivisionPlayerDto> players, CancellationToken token)
+    public Task<DivisionTeamDto> Adapt(TeamDto team, DivisionData.TeamScore score, IReadOnlyCollection<DivisionPlayerDto> players, DivisionDto? division, CancellationToken token)
     {
         var winRate = players.Sum(p => p.Singles.TeamWinRate + p.Pairs.TeamWinRate + p.Triples.TeamWinRate);
         var lossRate = players.Sum(p => p.Singles.TeamLossRate + p.Pairs.TeamLossRate + p.Triples.TeamLossRate);
@@ -27,10 +28,11 @@ public class DivisionTeamAdapter : IDivisionTeamAdapter
             WinRate = winRate,
             LossRate = lossRate,
             Updated = team.Updated,
+            Division = division,
         });
     }
 
-    public Task<DivisionTeamDto> WithoutFixtures(TeamDto team, CancellationToken token)
+    public Task<DivisionTeamDto> WithoutFixtures(TeamDto team, DivisionDto? division, CancellationToken token)
     {
         return Task.FromResult(new DivisionTeamDto
         {
@@ -40,6 +42,7 @@ public class DivisionTeamAdapter : IDivisionTeamAdapter
             Name = team.Name,
             Points = 0,
             Updated = team.Updated,
+            Division = division,
         });
     }
 }

--- a/CourageScores/Models/Adapters/Division/IDivisionFixtureAdapter.cs
+++ b/CourageScores/Models/Adapters/Division/IDivisionFixtureAdapter.cs
@@ -1,10 +1,23 @@
+using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Team;
+using CosmosGame = CourageScores.Models.Cosmos.Game.Game;
 
 namespace CourageScores.Models.Adapters.Division;
 
 public interface IDivisionFixtureAdapter
 {
-    Task<DivisionFixtureDto> Adapt(Models.Cosmos.Game.Game game, TeamDto? homeTeam, TeamDto? awayTeam, CancellationToken token);
-    Task<DivisionFixtureDto> ForUnselectedTeam(TeamDto team, bool isKnockout, IReadOnlyCollection<Cosmos.Game.Game> fixturesUsingAddress, CancellationToken token);
+    Task<DivisionFixtureDto> Adapt(
+        CosmosGame game,
+        TeamDto? homeTeam,
+        TeamDto? awayTeam,
+        DivisionDto? homeDivision,
+        DivisionDto? awayDivision,
+        CancellationToken token);
+    Task<DivisionFixtureDto> ForUnselectedTeam(
+        TeamDto team,
+        bool isKnockout,
+        IReadOnlyCollection<CosmosGame> fixturesUsingAddress,
+        DivisionDto? division,
+        CancellationToken token);
 }

--- a/CourageScores/Models/Adapters/Division/IDivisionFixtureDateAdapter.cs
+++ b/CourageScores/Models/Adapters/Division/IDivisionFixtureDateAdapter.cs
@@ -14,5 +14,6 @@ public interface IDivisionFixtureDateAdapter
         IReadOnlyCollection<TeamDto> teams,
         IReadOnlyCollection<Cosmos.Game.Game> otherFixturesForDate,
         bool includeProposals,
+        IReadOnlyDictionary<Guid, DivisionDto?> teamIdToDivisionLookup,
         CancellationToken token);
 }

--- a/CourageScores/Models/Adapters/Division/IDivisionPlayerAdapter.cs
+++ b/CourageScores/Models/Adapters/Division/IDivisionPlayerAdapter.cs
@@ -1,3 +1,4 @@
+using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Team;
 using CourageScores.Services.Division;
@@ -9,7 +10,8 @@ public interface IDivisionPlayerAdapter
     Task<DivisionPlayerDto> Adapt(DivisionData.PlayerScore score,
         DivisionData.TeamPlayerTuple playerTuple,
         Dictionary<DateTime, Guid> fixtures,
+        DivisionDto? division,
         CancellationToken token);
 
-    Task<DivisionPlayerDto> Adapt(TeamDto team, TeamPlayerDto player, CancellationToken token);
+    Task<DivisionPlayerDto> Adapt(TeamDto team, TeamPlayerDto player, DivisionDto? division, CancellationToken token);
 }

--- a/CourageScores/Models/Adapters/Division/IDivisionTeamAdapter.cs
+++ b/CourageScores/Models/Adapters/Division/IDivisionTeamAdapter.cs
@@ -1,3 +1,4 @@
+using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Team;
 using CourageScores.Services.Division;
@@ -6,6 +7,6 @@ namespace CourageScores.Models.Adapters.Division;
 
 public interface IDivisionTeamAdapter
 {
-    Task<DivisionTeamDto> Adapt(TeamDto team, DivisionData.TeamScore score, IReadOnlyCollection<DivisionPlayerDto> players, CancellationToken token);
-    Task<DivisionTeamDto> WithoutFixtures(TeamDto team, CancellationToken token);
+    Task<DivisionTeamDto> Adapt(TeamDto team, DivisionData.TeamScore score, IReadOnlyCollection<DivisionPlayerDto> players, DivisionDto? division, CancellationToken token);
+    Task<DivisionTeamDto> WithoutFixtures(TeamDto team, DivisionDto? division, CancellationToken token);
 }

--- a/CourageScores/Models/Adapters/Season/Creation/TemplateToHealthCheckAdapter.cs
+++ b/CourageScores/Models/Adapters/Season/Creation/TemplateToHealthCheckAdapter.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using CourageScores.Models.Cosmos.Season.Creation;
+using CourageScores.Models.Dtos;
 using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Health;
 
@@ -14,7 +15,7 @@ public class TemplateToHealthCheckAdapter : ISimpleOnewayAdapter<Template, Seaso
         {
             Name = model.Name,
             StartDate = startDate,
-            Divisions = model.Divisions.Select((d, index) => AdaptDivision(d, $"Division {index + 1}", startDate, GetTeams(model))).ToList(),
+            Divisions = model.Divisions.Select((d, index) => AdaptDivision(d, $"Division {index + 1}", startDate, GetTeams(model, index))).ToList(),
         };
         var dates = dto.Divisions.SelectMany(d => d.Dates).ToArray();
         if (dates.Any())
@@ -48,7 +49,7 @@ public class TemplateToHealthCheckAdapter : ISimpleOnewayAdapter<Template, Seaso
         }
     }
 
-    private static IReadOnlyDictionary<string, DivisionTeamDto> GetTeams(Template model)
+    private static IReadOnlyDictionary<string, DivisionTeamDto> GetTeams(Template model, int index)
     {
         var allPlaceholders = model.Divisions
             .SelectMany(GetPlaceholdersForDivision)
@@ -56,6 +57,7 @@ public class TemplateToHealthCheckAdapter : ISimpleOnewayAdapter<Template, Seaso
             .Select(p => new DivisionTeamDto
             {
                 Name = p,
+                Division = new DivisionDto{ Name = $"Division ${index + 1}" },
                 Id = Guid.NewGuid(),
             })
             .ToDictionary(t => t.Name);

--- a/CourageScores/Models/Dtos/Division/DivisionDataFilter.cs
+++ b/CourageScores/Models/Dtos/Division/DivisionDataFilter.cs
@@ -8,7 +8,7 @@ public class DivisionDataFilter : IEquatable<DivisionDataFilter>
     // ReSharper disable MemberCanBePrivate.Global
     // ReSharper disable UnusedAutoPropertyAccessor.Global
     public DateTime? Date { get; set; }
-    public List<Guid> DivisionId { get; set; } = new();
+    public HashSet<Guid> DivisionId { get; set; } = new();
     public Guid? SeasonId { get; set; }
     public Guid? TeamId { get; set; }
     public bool ExcludeProposals { get; set; }

--- a/CourageScores/Models/Dtos/Division/DivisionDataFilter.cs
+++ b/CourageScores/Models/Dtos/Division/DivisionDataFilter.cs
@@ -8,7 +8,7 @@ public class DivisionDataFilter : IEquatable<DivisionDataFilter>
     // ReSharper disable MemberCanBePrivate.Global
     // ReSharper disable UnusedAutoPropertyAccessor.Global
     public DateTime? Date { get; set; }
-    public Guid? DivisionId { get; set; }
+    public List<Guid> DivisionId { get; set; } = new();
     public Guid? SeasonId { get; set; }
     public Guid? TeamId { get; set; }
     public bool ExcludeProposals { get; set; }
@@ -37,7 +37,7 @@ public class DivisionDataFilter : IEquatable<DivisionDataFilter>
     {
         return other != null
                && Nullable.Equals(Date, other.Date)
-               && Nullable.Equals(DivisionId, other.DivisionId)
+               && DivisionId.ToHashSet().SetEquals(other.DivisionId.ToHashSet())
                && Nullable.Equals(SeasonId, other.SeasonId)
                && Nullable.Equals(TeamId, other.TeamId);
     }
@@ -51,7 +51,23 @@ public class DivisionDataFilter : IEquatable<DivisionDataFilter>
     public override int GetHashCode()
     {
         // ReSharper disable NonReadonlyMemberInGetHashCode
-        return HashCode.Combine(Date, DivisionId, SeasonId, TeamId);
+        return HashCode.Combine(
+            Date,
+            HashCodeOfArrayContents(DivisionId),
+            SeasonId,
+            TeamId);
         // ReSharper restore NonReadonlyMemberInGetHashCode
+    }
+
+    private static int HashCodeOfArrayContents<T>(IEnumerable<T> array)
+    {
+        var hashCode = 0;
+
+        foreach (var item in array)
+        {
+            hashCode ^= item?.GetHashCode() ?? 0;
+        }
+
+        return hashCode;
     }
 }

--- a/CourageScores/Models/Dtos/Division/DivisionFixtureDto.cs
+++ b/CourageScores/Models/Dtos/Division/DivisionFixtureDto.cs
@@ -15,4 +15,6 @@ public class DivisionFixtureDto
     public bool IsKnockout { get; set; }
     public bool AccoladesCount { get; set; }
     public List<OtherDivisionFixtureDto> FixturesUsingAddress { get; set; } = new();
+    public DivisionDto? HomeDivision { get; set; }
+    public DivisionDto? AwayDivision { get; set; }
 }

--- a/CourageScores/Models/Dtos/Division/DivisionPlayerDto.cs
+++ b/CourageScores/Models/Dtos/Division/DivisionPlayerDto.cs
@@ -22,4 +22,5 @@ public class DivisionPlayerDto : IRankedDto
 
     public DateTime? Updated { get; set; }
     public int Rank { get; set; }
+    public DivisionDto? Division { get; set; }
 }

--- a/CourageScores/Models/Dtos/Division/DivisionTeamDto.cs
+++ b/CourageScores/Models/Dtos/Division/DivisionTeamDto.cs
@@ -7,6 +7,7 @@ public class DivisionTeamDto : IRankedDto
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = null!;
+    public DivisionDto? Division { get; set; }
     public int Played { get; set; }
     public int Points { get; set; }
     public int FixturesWon { get; set; }

--- a/CourageScores/Program.cs
+++ b/CourageScores/Program.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using CourageScores;
+using CourageScores.Binders;
 using CourageScores.Filters;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Newtonsoft.Json.Converters;
@@ -22,7 +23,11 @@ builder.Services
 
 // Add services to the container.
 builder.Services
-    .AddControllersWithViews(options => { options.Filters.Add<CacheManagementFilter>(); })
+    .AddControllersWithViews(options =>
+    {
+        options.Filters.Add<CacheManagementFilter>();
+        options.AddCommaSeparatedArrayModelBinderProvider();
+    })
     .AddNewtonsoftJson(options =>
     {
         options.SerializerSettings.Converters.Add(new StringEnumConverter());

--- a/CourageScores/Services/Division/CachingDivisionService.cs
+++ b/CourageScores/Services/Division/CachingDivisionService.cs
@@ -35,8 +35,8 @@ public class CachingDivisionService : ICachingDivisionService
         {
             // invalidate caches where division id matches, any season id
             var keys = CacheKeys.Keys.Where(key =>
-                key.Filter.DivisionId == divisionId.Value ||
-                divisionId == Guid.Empty && key.Filter.DivisionId != null).ToArray();
+                key.Filter.DivisionId.Contains(divisionId.Value) ||
+                divisionId == Guid.Empty && key.Filter.DivisionId.Any()).ToArray();
             InvalidateCaches(keys);
         }
 
@@ -70,7 +70,7 @@ public class CachingDivisionService : ICachingDivisionService
     {
         var key = new DivisionDataCacheKey(new DivisionDataFilter
         {
-            DivisionId = id,
+            DivisionId = { id },
         }, "Get");
         InvalidateCacheIfCacheControlHeaderPresent(key);
         CacheKeys.TryAdd(key, new object());
@@ -138,7 +138,7 @@ public class CachingDivisionService : ICachingDivisionService
     private void InvalidateCaches(Guid divisionId, string? type)
     {
         var cacheKeys = CacheKeys.Keys.Where(k =>
-                (k.Filter.DivisionId == divisionId || k.Filter.DivisionId == null) && (k.Type == type || type == null))
+                (k.Filter.DivisionId.Contains(divisionId) || !k.Filter.DivisionId.Any()) && (k.Type == type || type == null))
             .ToArray();
         InvalidateCaches(cacheKeys);
     }

--- a/CourageScores/Services/Division/DivisionDataContext.cs
+++ b/CourageScores/Services/Division/DivisionDataContext.cs
@@ -37,16 +37,18 @@ public class DivisionDataContext
         return GamesForDate.SelectMany(pair => pair.Value).Where(g => divisionId == null || g.IsKnockout || g.DivisionId == divisionId);
     }
 
-    public IEnumerable<TournamentGame> AllTournamentGames(Guid? divisionId)
+    public IEnumerable<TournamentGame> AllTournamentGames(IReadOnlyCollection<Guid?> divisionIds)
     {
+        var anyDivision = divisionIds.Count == 0;
+
         return _tournamentGames
-            .Where(tournament => divisionId == null || tournament.DivisionId == null || tournament.DivisionId == divisionId);
+            .Where(tournament => anyDivision || tournament.DivisionId == null || divisionIds.Contains(tournament.DivisionId));
     }
 
-    public IEnumerable<DateTime> GetDates(Guid? divisionId)
+    public IEnumerable<DateTime> GetDates(IReadOnlyCollection<Guid?> divisionIds)
     {
         return GamesForDate.Keys
-            .Union(AllTournamentGames(divisionId).Select(g => g.Date))
+            .Union(AllTournamentGames(divisionIds).Select(g => g.Date))
             .Union(Notes.Keys)
             .OrderBy(d => d);
     }

--- a/CourageScores/Services/Division/DivisionDataContext.cs
+++ b/CourageScores/Services/Division/DivisionDataContext.cs
@@ -16,7 +16,8 @@ public class DivisionDataContext
         IReadOnlyCollection<TournamentGame> tournamentGames,
         IEnumerable<FixtureDateNoteDto> notes,
         SeasonDto season,
-        IReadOnlyDictionary<Guid, Guid?> teamIdToDivisionIdLookup)
+        IReadOnlyDictionary<Guid, Guid?> teamIdToDivisionIdLookup,
+        IReadOnlyDictionary<Guid, DivisionDto> divisions)
     {
         GamesForDate = games.GroupBy(g => g.Date).ToDictionary(g => g.Key, g => g.ToArray());
         TeamsInSeasonAndDivision = teamsInSeasonAndDivision;
@@ -24,6 +25,7 @@ public class DivisionDataContext
         TeamIdToDivisionIdLookup = teamIdToDivisionIdLookup;
         Notes = notes.GroupBy(n => n.Date).ToDictionary(g => g.Key, g => g.ToArray());
         _tournamentGames = tournamentGames;
+        Divisions = divisions;
     }
 
     public IReadOnlyCollection<TeamDto> TeamsInSeasonAndDivision { get; }
@@ -31,6 +33,7 @@ public class DivisionDataContext
     public IReadOnlyDictionary<Guid, Guid?> TeamIdToDivisionIdLookup { get; }
     public Dictionary<DateTime, FixtureDateNoteDto[]> Notes { get; }
     public Dictionary<DateTime, CosmosGame[]> GamesForDate { get; }
+    public IReadOnlyDictionary<Guid, DivisionDto> Divisions { get; }
 
     public IEnumerable<CosmosGame> AllGames(Guid? divisionId)
     {

--- a/CourageScores/Services/Division/DivisionDataContext.cs
+++ b/CourageScores/Services/Division/DivisionDataContext.cs
@@ -40,15 +40,15 @@ public class DivisionDataContext
         return GamesForDate.SelectMany(pair => pair.Value).Where(g => divisionId == null || g.IsKnockout || g.DivisionId == divisionId);
     }
 
-    public IEnumerable<TournamentGame> AllTournamentGames(IReadOnlyCollection<Guid?> divisionIds)
+    public IEnumerable<TournamentGame> AllTournamentGames(IReadOnlyCollection<Guid> divisionIds)
     {
         var anyDivision = divisionIds.Count == 0;
 
         return _tournamentGames
-            .Where(tournament => anyDivision || tournament.DivisionId == null || divisionIds.Contains(tournament.DivisionId));
+            .Where(tournament => anyDivision || tournament.DivisionId == null || divisionIds.Contains(tournament.DivisionId.Value));
     }
 
-    public IEnumerable<DateTime> GetDates(IReadOnlyCollection<Guid?> divisionIds)
+    public IEnumerable<DateTime> GetDates(IReadOnlyCollection<Guid> divisionIds)
     {
         return GamesForDate.Keys
             .Union(AllTournamentGames(divisionIds).Select(g => g.Date))

--- a/CourageScores/Services/Division/DivisionDataDtoFactory.cs
+++ b/CourageScores/Services/Division/DivisionDataDtoFactory.cs
@@ -61,7 +61,7 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
         return new DivisionDataDto
         {
             Id = (divisions.Count == 1 ? divisions.ElementAt(0)?.Id : null) ?? Guid.Empty,
-            Name = (divisions.Count == 1 ? divisions.ElementAt(0)?.Name ?? "<unnamed division>" : null) ?? $"<{divisions.Count} divisions>",
+            Name = GetDivisionName(divisions),
             Teams = teamResults
                 .OrderByDescending(t => t.FixturesWon)
                 .ThenByDescending(t => t.Difference)
@@ -123,6 +123,19 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
     public DivisionDataDto DivisionIdAndSeasonIdNotSupplied(Guid? divisionId)
     {
         return DataError(divisionId ?? Guid.Empty, "SeasonId and/or DivisionId must be supplied");
+    }
+
+    private static string GetDivisionName(IReadOnlyCollection<DivisionDto?> divisions)
+    {
+        switch (divisions.Count)
+        {
+            case 0:
+                return "<0 divisions>";
+            case 1:
+                return divisions.ElementAt(0)?.Name ?? "<unnamed division>";
+            default:
+                return string.Join(" & ", divisions.OrderBy(d => d?.Name).Select(d => d?.Name ?? "<unnamed division>"));
+        }
     }
 
     private async Task<IReadOnlyCollection<DivisionPlayerDto>> AddAllPlayersIfAdmin(IReadOnlyCollection<DivisionPlayerDto> players,

--- a/CourageScores/Services/Division/DivisionDataDtoFactory.cs
+++ b/CourageScores/Services/Division/DivisionDataDtoFactory.cs
@@ -35,16 +35,19 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
         _userService = userService;
     }
 
-    public async Task<DivisionDataDto> CreateDivisionDataDto(DivisionDataContext context, DivisionDto? division, bool includeProposals, CancellationToken token)
+    public async Task<DivisionDataDto> CreateDivisionDataDto(DivisionDataContext context, IReadOnlyCollection<DivisionDto?> divisions, bool includeProposals, CancellationToken token)
     {
         var divisionData = new DivisionData();
         var gameVisitor = new DivisionDataGameVisitor(divisionData);
         var visitorScope = new VisitorScope();
-        foreach (var game in context.AllGames(division?.Id))
+        foreach (var division in divisions)
         {
-            game.Accept(visitorScope, gameVisitor);
+            foreach (var game in context.AllGames(division?.Id))
+            {
+                game.Accept(visitorScope, gameVisitor);
+            }
         }
-        foreach (var tournamentGame in context.AllTournamentGames(division?.Id))
+        foreach (var tournamentGame in context.AllTournamentGames(divisions.Select(d => d?.Id).ToArray()))
         {
             tournamentGame.Accept(visitorScope, gameVisitor);
         }
@@ -57,15 +60,15 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
 
         return new DivisionDataDto
         {
-            Id = division?.Id ?? Guid.Empty,
-            Name = division?.Name ?? "<all divisions>",
+            Id = (divisions.Count == 1 ? divisions.ElementAt(0)?.Id : null) ?? Guid.Empty,
+            Name = (divisions.Count == 1 ? divisions.ElementAt(0)?.Name ?? "<unnamed division>" : null) ?? $"<{divisions.Count} divisions>",
             Teams = teamResults
                 .OrderByDescending(t => t.FixturesWon)
                 .ThenByDescending(t => t.Difference)
                 .ThenBy(t => t.Name)
                 .ApplyRanks()
                 .ToList(),
-            Fixtures = await GetFixtures(context, division?.Id, includeProposals, token)
+            Fixtures = await GetFixtures(context, divisions, includeProposals, token)
                 .OrderByAsync(d => d.Date)
                 .ToList(),
             Players = (await AddAllPlayersIfAdmin(playerResults, user, context, token))
@@ -80,29 +83,40 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
                 .ToList(),
             Season = await _divisionDataSeasonAdapter.Adapt(context.Season, token),
             DataErrors = canShowDataErrors ? divisionData.DataErrors.ToList() : new List<DataErrorDto>(),
-            Updated = division?.Updated,
+            Updated = divisions.Count == 1 ? divisions.ElementAt(0)?.Updated : null,
         };
     }
 
-    public Task<DivisionDataDto> SeasonNotFound(DivisionDto? division, IEnumerable<SeasonDto> allSeasons,
+    public Task<DivisionDataDto> SeasonNotFound(IReadOnlyCollection<DivisionDto?> divisions, IEnumerable<SeasonDto> allSeasons,
         CancellationToken token)
     {
         return Task.FromResult(new DivisionDataDto
         {
-            Id = division?.Id ?? Guid.Empty,
-            Name = division?.Name ?? "<all divisions>",
+            Id = (divisions.Count == 1 ? divisions.ElementAt(0)?.Id : null) ?? Guid.Empty,
+            Name = (divisions.Count == 1 ? divisions.ElementAt(0)?.Name ?? "<unnamed division>" : null) ?? "<all divisions>",
         });
     }
 
     [ExcludeFromCodeCoverage]
-    public DivisionDataDto DivisionNotFound(Guid divisionId, DivisionDto? deleted)
+    public DivisionDataDto DivisionNotFound(IReadOnlyCollection<Guid> divisionIds, IReadOnlyCollection<DivisionDto> deletedDivisions)
     {
-        if (deleted != null)
+        return new DivisionDataDto
         {
-            return DataError(divisionId, $"Requested division ({deleted.Name} / {deleted.Id}) has been deleted {deleted.Deleted:d MMM yyyy HH:mm:ss})");
-        }
-
-        return DataError(divisionId, $"Requested division ({divisionId}) was not found");
+            Id = divisionIds.Count == 1 ? divisionIds.ElementAt(0) : Guid.Empty,
+            DataErrors =
+            {
+                new DataErrorDto
+                {
+                    Message = string.Join(", ", divisionIds.Select(divisionId =>
+                    {
+                        var deleted = deletedDivisions.SingleOrDefault(d => d.Id == divisionId);
+                        return deleted != null
+                            ? $"Requested division ({deleted.Name} / {deleted.Id}) has been deleted {deleted.Deleted:d MMM yyyy HH:mm:ss})"
+                            : $"Requested division ({divisionId}) was not found";
+                    })),
+                }
+            },
+        };
     }
 
     [ExcludeFromCodeCoverage]
@@ -137,7 +151,7 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
     }
 
     private async IAsyncEnumerable<DivisionTeamDto> GetTeams(DivisionData divisionData, IReadOnlyCollection<TeamDto> teamsInSeasonAndDivision,
-        List<DivisionPlayerDto> playerResults, [EnumeratorCancellation] CancellationToken token)
+        IReadOnlyCollection<DivisionPlayerDto> playerResults, [EnumeratorCancellation] CancellationToken token)
     {
         foreach (var (id, score) in divisionData.Teams)
         {
@@ -162,18 +176,20 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
         }
     }
 
-    private async IAsyncEnumerable<DivisionFixtureDateDto> GetFixtures(DivisionDataContext context, Guid? divisionId, bool includeProposals, [EnumeratorCancellation] CancellationToken token)
+    private async IAsyncEnumerable<DivisionFixtureDateDto> GetFixtures(DivisionDataContext context, IReadOnlyCollection<DivisionDto?> divisions, bool includeProposals, [EnumeratorCancellation] CancellationToken token)
     {
-        foreach (var date in context.GetDates(divisionId))
+        var divisionIds = divisions.Select(d => d?.Id).Where(id => id != null).ToArray(); // should NOT contain null, an empty list means return all divisional data
+
+        foreach (var date in context.GetDates(divisionIds))
         {
             if (!context.GamesForDate.TryGetValue(date, out var gamesForDate))
             {
                 gamesForDate = Array.Empty<CosmosGame>();
             }
-            var tournamentGamesForDate = context.AllTournamentGames(divisionId).Where(g => g.Date == date).ToArray();
+            var tournamentGamesForDate = context.AllTournamentGames(divisionIds).Where(g => g.Date == date).ToArray();
             context.Notes.TryGetValue(date, out var notesForDate);
 
-            var inDivisionGames = gamesForDate.Where(g => ShouldShowLeagueFixture(g, divisionId, context.TeamIdToDivisionIdLookup)).ToArray();
+            var inDivisionGames = gamesForDate.Where(g => ShouldShowLeagueFixture(g, divisionIds, context.TeamIdToDivisionIdLookup)).ToArray();
 
             yield return await _divisionFixtureDateAdapter.Adapt(
                 date,
@@ -214,19 +230,19 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
         }
     }
 
-    private static bool ShouldShowLeagueFixture(CosmosGame g, Guid? divisionId, IReadOnlyDictionary<Guid, Guid?> teamIdToDivisionIdLookup)
+    private static bool ShouldShowLeagueFixture(CosmosGame g, IReadOnlyCollection<Guid?> divisionIds, IReadOnlyDictionary<Guid, Guid?> teamIdToDivisionIdLookup)
     {
-        if (divisionId == null || g.DivisionId == divisionId)
+        if (!divisionIds.Any() || divisionIds.Contains(g.DivisionId))
         {
             return true;
         }
 
-        if (teamIdToDivisionIdLookup.TryGetValue(g.Home.Id, out var homeTeamDivisionId) && homeTeamDivisionId == divisionId)
+        if (teamIdToDivisionIdLookup.TryGetValue(g.Home.Id, out var homeTeamDivisionId) && divisionIds.Contains(homeTeamDivisionId))
         {
             return true;
         }
 
-        if (teamIdToDivisionIdLookup.TryGetValue(g.Away.Id, out var awayTeamDivisionId) && awayTeamDivisionId == divisionId)
+        if (teamIdToDivisionIdLookup.TryGetValue(g.Away.Id, out var awayTeamDivisionId) && divisionIds.Contains(awayTeamDivisionId))
         {
             return true;
         }

--- a/CourageScores/Services/Division/DivisionDataDtoFactory.cs
+++ b/CourageScores/Services/Division/DivisionDataDtoFactory.cs
@@ -97,7 +97,6 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
         });
     }
 
-    [ExcludeFromCodeCoverage]
     public DivisionDataDto DivisionNotFound(IReadOnlyCollection<Guid> divisionIds, IReadOnlyCollection<DivisionDto> deletedDivisions)
     {
         return new DivisionDataDto
@@ -111,7 +110,7 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
                     {
                         var deleted = deletedDivisions.SingleOrDefault(d => d.Id == divisionId);
                         return deleted != null
-                            ? $"Requested division ({deleted.Name} / {deleted.Id}) has been deleted {deleted.Deleted:d MMM yyyy HH:mm:ss})"
+                            ? $"Requested division ({deleted.Name} / {deleted.Id}) has been deleted {deleted.Deleted:d MMM yyyy HH:mm:ss}"
                             : $"Requested division ({divisionId}) was not found";
                     })),
                 }
@@ -131,10 +130,8 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
         {
             case 0:
                 return "<0 divisions>";
-            case 1:
-                return divisions.ElementAt(0)?.Name ?? "<unnamed division>";
             default:
-                return string.Join(" & ", divisions.OrderBy(d => d?.Name).Select(d => d?.Name ?? "<unnamed division>"));
+                return string.Join(" & ", divisions.OrderBy(d => d?.Name).Select(d => d?.Name ?? d?.Id.ToString()));
         }
     }
 

--- a/CourageScores/Services/Division/DivisionService.cs
+++ b/CourageScores/Services/Division/DivisionService.cs
@@ -49,17 +49,31 @@ public class DivisionService : IDivisionService
 
     public async Task<DivisionDataDto> GetDivisionData(DivisionDataFilter filter, CancellationToken token)
     {
-        if (filter.DivisionId == null && filter.SeasonId == null)
+        if (!filter.DivisionId.Any() && filter.SeasonId == null)
         {
-            return _divisionDataDtoFactory.DivisionIdAndSeasonIdNotSupplied(filter.DivisionId);
+            return _divisionDataDtoFactory.DivisionIdAndSeasonIdNotSupplied(null);
         }
 
-        var division = filter.DivisionId == null
-            ? null
-            : await _genericDivisionService.Get(filter.DivisionId.Value, token);
-        if (filter.DivisionId != null && (division == null || division.Deleted != null))
+        var divisions = await filter.DivisionId.SelectAsync(async divisionId =>
         {
-            return _divisionDataDtoFactory.DivisionNotFound(filter.DivisionId.Value, division);
+            var division = await _genericDivisionService.Get(divisionId, token);
+            if (filter.DivisionId.Any() && (division == null || division.Deleted != null))
+            {
+                return new DivisionNotFound
+                {
+                    Id = divisionId,
+                    Deleted = division?.Deleted,
+                };
+            }
+
+            return division;
+        }).ToList();
+
+        var notFoundDivisions = divisions.OfType<DivisionNotFound>().ToList();
+        if (notFoundDivisions.Any())
+        {
+            var deletedDivisions = notFoundDivisions.Where(d => d.Deleted != null).OfType<DivisionDto>().ToList();
+            return _divisionDataDtoFactory.DivisionNotFound(notFoundDivisions.Select(d => d.Id).ToList(), deletedDivisions);
         }
 
         var allSeasons = await _genericSeasonService.GetAll(token).ToList();
@@ -70,13 +84,13 @@ public class DivisionService : IDivisionService
 
         if (season == null)
         {
-            return await _divisionDataDtoFactory.SeasonNotFound(division, allSeasons, token);
+            return await _divisionDataDtoFactory.SeasonNotFound(divisions, allSeasons, token);
         }
 
         var allTeamsInSeason = await _genericTeamService.GetAll(token)
             .WhereAsync(t => t.Seasons.Any(ts => ts.SeasonId == season.Id && ts.Deleted == null) || !t.Seasons.Any()).ToList();
         var context = await CreateDivisionDataContext(filter, season, allTeamsInSeason, token);
-        return await _divisionDataDtoFactory.CreateDivisionDataDto(context, division, !filter.ExcludeProposals, token);
+        return await _divisionDataDtoFactory.CreateDivisionDataDto(context, divisions, !filter.ExcludeProposals, token);
     }
 
     private static Guid? GetDivisionIdForTeam(TeamDto teamInSeason, SeasonDto season)
@@ -89,11 +103,11 @@ public class DivisionService : IDivisionService
         SeasonDto season, IReadOnlyCollection<TeamDto> allTeamsInSeason, CancellationToken token)
     {
         var teamsInSeasonAndDivision = allTeamsInSeason
-            .Where(t => filter.DivisionId == null || GetDivisionIdForTeam(t, season) == filter.DivisionId)
+            .Where(t => !filter.DivisionId.Any() || filter.DivisionId.Contains(GetDivisionIdForTeam(t, season).GetValueOrDefault()))
             .ToList();
 
         var notes = await _noteService.GetWhere($"t.SeasonId = '{season.Id}'", token)
-            .WhereAsync(n => filter.DivisionId == null || n.DivisionId == null || n.DivisionId == filter.DivisionId)
+            .WhereAsync(n => !filter.DivisionId.Any() || n.DivisionId == null || filter.DivisionId.Contains(n.DivisionId.Value))
             .ToList();
         var games = await GetGames(filter, season, token);
         var tournamentGames = await _tournamentGameRepository
@@ -121,8 +135,8 @@ public class DivisionService : IDivisionService
 
         return await _gameRepository
             .GetSome(
-                filter.DivisionId != null
-                    ? $"t.DivisionId = '{filter.DivisionId}' or t.IsKnockout = true"
+                filter.DivisionId.Any()
+                    ? $"t.DivisionId in ({string.Join(", ", filter.DivisionId.Select(id => $"'{id}'"))}) or t.IsKnockout = true"
                     : $"t.SeasonId = '{season.Id}'",
                 token)
             .WhereAsync(g => filter.IncludeDate(g.Date, season) && filter.IncludeGame(g))
@@ -163,4 +177,7 @@ public class DivisionService : IDivisionService
     }
 
     #endregion
+
+    private class DivisionNotFound : DivisionDto
+    { }
 }

--- a/CourageScores/Services/Division/IDivisionDataDtoFactory.cs
+++ b/CourageScores/Services/Division/IDivisionDataDtoFactory.cs
@@ -6,9 +6,9 @@ namespace CourageScores.Services.Division;
 
 public interface IDivisionDataDtoFactory
 {
-    Task<DivisionDataDto> CreateDivisionDataDto(DivisionDataContext context, DivisionDto? division, bool includeProposals, CancellationToken token);
-    DivisionDataDto DivisionNotFound(Guid divisionId, DivisionDto? deleted);
+    Task<DivisionDataDto> CreateDivisionDataDto(DivisionDataContext context, IReadOnlyCollection<DivisionDto?> divisions, bool includeProposals, CancellationToken token);
+    DivisionDataDto DivisionNotFound(IReadOnlyCollection<Guid> divisionIds, IReadOnlyCollection<DivisionDto> deletedDivisions);
     DivisionDataDto DivisionIdAndSeasonIdNotSupplied(Guid? divisionId);
 
-    Task<DivisionDataDto> SeasonNotFound(DivisionDto? division, IEnumerable<SeasonDto> allSeasons, CancellationToken token);
+    Task<DivisionDataDto> SeasonNotFound(IReadOnlyCollection<DivisionDto?> divisions, IEnumerable<SeasonDto> allSeasons, CancellationToken token);
 }

--- a/CourageScores/Services/Health/HealthCheckService.cs
+++ b/CourageScores/Services/Health/HealthCheckService.cs
@@ -61,7 +61,7 @@ public class HealthCheckService : IHealthCheckService
             .SelectAsync(d => _divisionService.GetDivisionData(
                 new DivisionDataFilter
                 {
-                    DivisionId = d.Id,
+                    DivisionId = { d.Id },
                     SeasonId = season.Id,
                     IgnoreDates = true,
                 },

--- a/CourageScores/Services/Report/FinalsNightReport.cs
+++ b/CourageScores/Services/Report/FinalsNightReport.cs
@@ -240,7 +240,7 @@ public class FinalsNightReport : CompositeReport
     {
         var divisions = await _divisionService.GetAll(token).ToList();
         var divisionData = await divisions
-            .SelectAsync(d => _divisionService.GetDivisionData(new DivisionDataFilter { SeasonId = _season.Id, DivisionId = d.Id }, token))
+            .SelectAsync(d => _divisionService.GetDivisionData(new DivisionDataFilter { SeasonId = _season.Id, DivisionId = { d.Id } }, token))
             .ToList();
 
         if (divisionData.Count == 0)

--- a/CourageScores/Services/Season/Creation/SeasonTemplateService.cs
+++ b/CourageScores/Services/Season/Creation/SeasonTemplateService.cs
@@ -143,7 +143,7 @@ public class SeasonTemplateService : ISeasonTemplateService
     {
         var divisions = await season.Divisions.SelectAsync(d => _divisionService.GetDivisionData(new DivisionDataFilter
         {
-            DivisionId = d.Id,
+            DivisionId = { d.Id },
             SeasonId = season.Id,
             ExcludeProposals = true,
         }, token)).ToList();


### PR DESCRIPTION
Resolves #878 
Resolves #879 

Example url:
https://couragescoresdev.azurewebsites.net/fixtures/Winter23/?division=Div%20One&division=Div%20Two

- [x] Add tests for `DivisionUriContainer`
- [x] Protect against duplicate division id in filter
- [x] Comma delimit division names in division name (rather than "<N divisions>")
- [x] update link to division component from `DivisionControls`
- [x] address drop in code coverage 