### PR TITLE
#1296 incorrect fixture loss

### DIFF
--- a/CourageScores.Tests/Models/Cosmos/Game/GameMatchTests.cs
+++ b/CourageScores.Tests/Models/Cosmos/Game/GameMatchTests.cs
@@ -23,10 +23,12 @@ public class GameMatchTests
         };
         _game = new CosmosGame
         {
+            Home = new GameTeam { Name = "HOME TEAM" },
+            Away = new GameTeam { Name = "AWAY TEAM" },
             MatchOptions =
             {
                 _matchOptions
-            }
+            },
         };
         _visitorScope = new VisitorScope
         {
@@ -129,7 +131,7 @@ public class GameMatchTests
 
         visitor.Verify(v => v.VisitMatchWin(It.IsAny<IVisitorScope>(), It.IsAny<List<GamePlayer>>(), It.IsAny<TeamDesignation>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
         visitor.Verify(v => v.VisitMatchLost(It.IsAny<IVisitorScope>(), It.IsAny<List<GamePlayer>>(), It.IsAny<TeamDesignation>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
-        visitor.Verify(v => v.VisitDataError(_visitorScope, "Match between HOME and AWAY is a 1-1 draw, scores won't count on players table"));
+        visitor.Verify(v => v.VisitDataError(_visitorScope, $"Singles match 1 between HOME TEAM and AWAY TEAM is a 1-1 draw, scores won't count on players table"));
     }
 
     [TestCase(null, 3)]
@@ -148,7 +150,7 @@ public class GameMatchTests
 
         visitor.Verify(v => v.VisitMatchWin(It.IsAny<IVisitorScope>(), It.IsAny<List<GamePlayer>>(), It.IsAny<TeamDesignation>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
         visitor.Verify(v => v.VisitMatchLost(It.IsAny<IVisitorScope>(), It.IsAny<List<GamePlayer>>(), It.IsAny<TeamDesignation>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
-        visitor.Verify(v => v.VisitDataError(_visitorScope, $"Match between HOME and AWAY has only one score {home}-{away}, both are required to ensure the team/players table are rendered correctly"));
+        visitor.Verify(v => v.VisitDataError(_visitorScope, $"Singles match 1 between HOME TEAM and AWAY TEAM has only one score {home}-{away}, both are required to ensure the team/players table are rendered correctly"));
     }
 
     [Test]
@@ -166,7 +168,7 @@ public class GameMatchTests
 
         visitor.Verify(v => v.VisitMatchWin(It.IsAny<IVisitorScope>(), It.IsAny<List<GamePlayer>>(), It.IsAny<TeamDesignation>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
         visitor.Verify(v => v.VisitMatchLost(It.IsAny<IVisitorScope>(), It.IsAny<List<GamePlayer>>(), It.IsAny<TeamDesignation>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
-        visitor.Verify(v => v.VisitDataError(_visitorScope, "Match between HOME and AWAY is a 1-1 draw, scores won't count on players table"));
+        visitor.Verify(v => v.VisitDataError(_visitorScope, "Singles match 1 between HOME TEAM and AWAY TEAM is a 1-1 draw, scores won't count on players table"));
     }
 
     [Test]

--- a/CourageScores.Tests/Models/Cosmos/Game/GameMatchTests.cs
+++ b/CourageScores.Tests/Models/Cosmos/Game/GameMatchTests.cs
@@ -9,10 +9,6 @@ public class GameMatchTests
 {
     private GameMatch _match = null!;
     private static readonly IVisitorScope VisitorScope = new VisitorScope();
-    private static readonly IVisitorScope ObscureScoresVisitorScope = new VisitorScope
-    {
-        ObscureScores = true,
-    };
 
     [SetUp]
     public void SetupEachTest()
@@ -121,11 +117,11 @@ public class GameMatchTests
         _match.HomeScore = 1;
         _match.AwayScore = 1;
 
-        _match.Accept(ObscureScoresVisitorScope, visitor.Object);
+        _match.Accept(VisitorScope, visitor.Object);
 
         visitor.Verify(v => v.VisitMatchWin(It.IsAny<IVisitorScope>(), It.IsAny<List<GamePlayer>>(), It.IsAny<TeamDesignation>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
         visitor.Verify(v => v.VisitMatchLost(It.IsAny<IVisitorScope>(), It.IsAny<List<GamePlayer>>(), It.IsAny<TeamDesignation>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
-        visitor.Verify(v => v.VisitDataError(ObscureScoresVisitorScope, "Match between HOME and AWAY is a 1-1 draw, scores won't count on players table"));
+        visitor.Verify(v => v.VisitDataError(VisitorScope, "Match between HOME and AWAY is a 1-1 draw, scores won't count on players table"));
     }
 
     [Test]

--- a/CourageScores.Tests/Models/Cosmos/Game/GameMatchTests.cs
+++ b/CourageScores.Tests/Models/Cosmos/Game/GameMatchTests.cs
@@ -132,6 +132,25 @@ public class GameMatchTests
         visitor.Verify(v => v.VisitDataError(_visitorScope, "Match between HOME and AWAY is a 1-1 draw, scores won't count on players table"));
     }
 
+    [TestCase(null, 3)]
+    [TestCase(3, null)]
+    public void Accept_GivenEqualPlayerCountsAndOneScoreEntered_VisitsDataError(int? home, int? away)
+    {
+        var visitor = new Mock<IGameVisitor>();
+        var homePlayer = new GamePlayer { Name = "HOME" };
+        var awayPlayer = new GamePlayer { Name = "AWAY" };
+        _match.HomePlayers.Add(homePlayer);
+        _match.AwayPlayers.Add(awayPlayer);
+        _match.HomeScore = home;
+        _match.AwayScore = away;
+
+        _match.Accept(_visitorScope, visitor.Object);
+
+        visitor.Verify(v => v.VisitMatchWin(It.IsAny<IVisitorScope>(), It.IsAny<List<GamePlayer>>(), It.IsAny<TeamDesignation>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+        visitor.Verify(v => v.VisitMatchLost(It.IsAny<IVisitorScope>(), It.IsAny<List<GamePlayer>>(), It.IsAny<TeamDesignation>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+        visitor.Verify(v => v.VisitDataError(_visitorScope, $"Match between HOME and AWAY has only one score {home}-{away}, both are required to ensure the team/players table are rendered correctly"));
+    }
+
     [Test]
     public void Accept_GivenObscureScoresAndEqualPlayerCountsAndDraw_VisitsDataError()
     {

--- a/CourageScores.Tests/Models/Cosmos/Game/TournamentRoundTests.cs
+++ b/CourageScores.Tests/Models/Cosmos/Game/TournamentRoundTests.cs
@@ -35,7 +35,7 @@ public class TournamentRoundTests
 
         _round.Accept(VisitorScope, visitor.Object);
 
-        visitor.Verify(v => v.VisitMatch(VisitorScope, match));
+        visitor.Verify(v => v.VisitMatch(It.IsAny<IVisitorScope>(), match));
     }
 
     [Test]

--- a/CourageScores.Tests/Services/Division/DivisionDataContextBuilder.cs
+++ b/CourageScores.Tests/Services/Division/DivisionDataContextBuilder.cs
@@ -1,5 +1,6 @@
 using CourageScores.Models.Cosmos.Game;
 using CourageScores.Models.Dtos;
+using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Season;
 using CourageScores.Models.Dtos.Team;
 using CourageScores.Services.Division;
@@ -13,9 +14,10 @@ public class DivisionDataContextBuilder
     private readonly List<TeamDto> _teams = new List<TeamDto>();
     private readonly List<TournamentGame> _tournamentGames = new List<TournamentGame>();
     private readonly List<FixtureDateNoteDto> _notes = new List<FixtureDateNoteDto>();
-    private SeasonDto _season = new SeasonDto();
     private readonly Dictionary<Guid, Guid?> _teamIdToDivisionIdLookup = new Dictionary<Guid, Guid?>();
     private readonly Dictionary<Guid, DivisionDto> _divisionLookup = new Dictionary<Guid, DivisionDto>();
+    private readonly DivisionDataFilter _filter = new DivisionDataFilter();
+    private SeasonDto _season = new SeasonDto();
 
     public DivisionDataContextBuilder WithGame(params CosmosGame[] games)
     {
@@ -77,6 +79,7 @@ public class DivisionDataContextBuilder
             _notes,
             _season,
             _teamIdToDivisionIdLookup,
-            _divisionLookup);
+            _divisionLookup,
+            _filter);
     }
 }

--- a/CourageScores.Tests/Services/Division/DivisionDataContextTests.cs
+++ b/CourageScores.Tests/Services/Division/DivisionDataContextTests.cs
@@ -1,5 +1,6 @@
 using CourageScores.Models.Cosmos.Game;
 using CourageScores.Models.Dtos;
+using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Season;
 using CourageScores.Models.Dtos.Team;
 using CourageScores.Services.Division;
@@ -35,7 +36,8 @@ public class DivisionDataContextTests
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
             new Dictionary<Guid, Guid?>(),
-            new Dictionary<Guid, DivisionDto>());
+            new Dictionary<Guid, DivisionDto>(),
+            new DivisionDataFilter());
 
         var result = context.AllGames(divisionId).ToArray();
 
@@ -69,7 +71,8 @@ public class DivisionDataContextTests
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
             new Dictionary<Guid, Guid?>(),
-            new Dictionary<Guid, DivisionDto>());
+            new Dictionary<Guid, DivisionDto>(),
+            new DivisionDataFilter());
 
         var result = context.AllGames(divisionId).ToArray();
 
@@ -116,7 +119,8 @@ public class DivisionDataContextTests
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
             new Dictionary<Guid, Guid?>(),
-            new Dictionary<Guid, DivisionDto>());
+            new Dictionary<Guid, DivisionDto>(),
+            new DivisionDataFilter());
 
         var result = context.AllGames(null).ToArray();
 
@@ -150,7 +154,8 @@ public class DivisionDataContextTests
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
             new Dictionary<Guid, Guid?>(),
-            new Dictionary<Guid, DivisionDto>());
+            new Dictionary<Guid, DivisionDto>(),
+            new DivisionDataFilter());
 
         var result = context.AllTournamentGames(Array.Empty<Guid>());
 
@@ -187,7 +192,8 @@ public class DivisionDataContextTests
             Array.Empty<FixtureDateNoteDto>(),
             new SeasonDto(),
             new Dictionary<Guid, Guid?>(),
-            new Dictionary<Guid, DivisionDto>());
+            new Dictionary<Guid, DivisionDto>(),
+            new DivisionDataFilter());
 
         var result = context.AllTournamentGames(new[] { tournamentInDivision.DivisionId.Value });
 

--- a/CourageScores.Tests/Services/Division/DivisionDataDtoFactoryTests.cs
+++ b/CourageScores.Tests/Services/Division/DivisionDataDtoFactoryTests.cs
@@ -424,7 +424,7 @@ public class DivisionDataDtoFactoryTests
         var result = await _factory.CreateDivisionDataDto(context, new[] { division }, true, _token);
 
         var dataError = result.DataErrors.Single();
-        Assert.That(dataError.Message, Is.EqualTo($"Mismatching number of players: Home players (1): [{Player1.Name}] vs Away players (2): [{Player2.Name}, {NotPlaying.Name}]"));
+        Assert.That(dataError.Message, Is.EqualTo($"Singles match 1 between Team 1 - Playing and Team 2 - Playing has mis-matching number of players: Home players (1): [{Player1.Name}] vs Away players (2): [{Player2.Name}, {NotPlaying.Name}]"));
         Assert.That(dataError.GameId, Is.EqualTo(GameWith2AwayPlayers.Id));
     }
 

--- a/CourageScores/ClientApp/src/components/scores/MatchPlayerSelection.tsx
+++ b/CourageScores/ClientApp/src/components/scores/MatchPlayerSelection.tsx
@@ -37,6 +37,7 @@ export function MatchPlayerSelection({match, onMatchChanged, onMatchOptionsChang
     const {matchOptions, otherMatches, setCreatePlayerFor} = useMatchType();
     const [matchOptionsDialogOpen, setMatchOptionsDialogOpen] = useState<boolean>(false);
     const [saygOpen, setSaygOpen] = useState<boolean>(false);
+    const hasBothScores = hasScore(match.homeScore) && hasScore(match.awayScore);
 
     function player(index: number, side: 'home' | 'away'): GamePlayerDto {
         const matchPlayers: GamePlayerDto[] = match[side + 'Players'];
@@ -217,9 +218,13 @@ export function MatchPlayerSelection({match, onMatchChanged, onMatchOptionsChang
             && score > (numberOfLegs / 2.0);
     }
 
+    function hasScore(score?: number): boolean {
+        return score !== null && score !== undefined;
+    }
+
     try {
         return (<tr>
-            <td className={`${isWinner(match.homeScore || 0, matchOptions.numberOfLegs || 0) ? 'bg-winner ' : ''}text-end width-50-pc position-relative`}>
+            <td className={`${isWinner(match.homeScore || 0, matchOptions.numberOfLegs || 0) ? 'bg-winner ' : ''}${hasBothScores || disabled ? '' : 'bg-warning '}text-end width-50-pc position-relative`}>
                 {canOpenSayg() ? (<button tabIndex={-1} className="btn btn-sm position-absolute left-0"
                                           onClick={() => setSaygOpen(!saygOpen)}>📊</button>) : null}
                 {saygOpen ? renderSaygDialog() : null}
@@ -233,7 +238,7 @@ export function MatchPlayerSelection({match, onMatchChanged, onMatchOptionsChang
                         except={exceptPlayers(index, 'home')}
                         onChange={(_, player: ISelectablePlayer) => playerChanged(index, player, 'home')}/></div>))}
             </td>
-            <td className={`narrow-column align-middle text-end ${isWinner(match.homeScore || 0, matchOptions.numberOfLegs || 0) ? 'bg-winner' : ''}`}>
+            <td className={`narrow-column align-middle text-end ${isWinner(match.homeScore || 0, matchOptions.numberOfLegs || 0) ? 'bg-winner' : ''}${hasBothScores || disabled ? '' : ' bg-warning'}`}>
                 {disabled
                     ? (<strong>{match.homeScore}</strong>)
                     : (<input
@@ -245,7 +250,7 @@ export function MatchPlayerSelection({match, onMatchChanged, onMatchOptionsChang
                         onChange={stateChanged(async (newScore: string) => await scoreChanged(newScore, 'home'))}/>)}
             </td>
             <td className="align-middle text-center width-1 middle-vertical-line p-0"></td>
-            <td className={`narrow-column align-middle text-start ${isWinner(match.awayScore || 0, matchOptions.numberOfLegs || 0) ? 'bg-winner' : ''}`}>
+            <td className={`narrow-column align-middle text-start ${isWinner(match.awayScore || 0, matchOptions.numberOfLegs || 0) ? 'bg-winner' : ''}${hasBothScores || disabled ? '' : ' bg-warning'}`}>
                 {disabled
                     ? (<strong>{match.awayScore}</strong>)
                     : (<input
@@ -256,7 +261,7 @@ export function MatchPlayerSelection({match, onMatchChanged, onMatchOptionsChang
                         value={match.awayScore === null || match.homeScore === undefined ? '' : match.awayScore}
                         onChange={stateChanged(async (newScore: string) => scoreChanged(newScore, 'away'))}/>)}
             </td>
-            <td className={`${isWinner(match.awayScore || 0, matchOptions.numberOfLegs || 0) ? 'bg-winner ' : ''}width-50-pc position-relative`}>
+            <td className={`${isWinner(match.awayScore || 0, matchOptions.numberOfLegs || 0) ? 'bg-winner ' : ''}width-50-pc position-relative${hasBothScores || disabled ? '' : ' bg-warning'}`}>
                 {matchOptionsDialogOpen ? renderMatchSettingsDialog() : null}
                 {readOnly ? null : (
                     <button tabIndex={-1} title={`${matchOptions.numberOfLegs} leg/s. Starting score: ${matchOptions.startingScore}`}

--- a/CourageScores/ClientApp/src/components/scores/ScoreCardHeading.tsx
+++ b/CourageScores/ClientApp/src/components/scores/ScoreCardHeading.tsx
@@ -4,6 +4,7 @@ import {renderDate} from "../../helpers/rendering";
 import {count} from "../../helpers/collections";
 import {GameDto} from "../../interfaces/models/dtos/Game/GameDto";
 import {GameMatchDto} from "../../interfaces/models/dtos/Game/GameMatchDto";
+import {GameMatchOptionDto} from "../../interfaces/models/dtos/Game/GameMatchOptionDto";
 import {Link} from "react-router";
 import {TeamDto} from "../../interfaces/models/dtos/Team/TeamDto";
 import {UntypedPromise} from "../../interfaces/UntypedPromise";
@@ -58,18 +59,22 @@ export function ScoreCardHeading({data, access, submission, setSubmission, setFi
     }
 
     function getScore(data: GameDto | undefined, side: string): number {
-        function sideWonMatch(match: GameMatchDto | undefined): boolean {
+        function sideWonMatch(match: GameMatchDto | undefined, index?: number): boolean {
             const hasBothScores: boolean = hasScore(match?.homeScore) && hasScore(match?.awayScore);
 
             if (!hasBothScores) {
                 return false;
             }
 
+            const matchOptions: GameMatchOptionDto | undefined = data?.matchOptions![index!];
+            const defaultNumberOfLegs: number = 5;
+            const numberOfLegs: number = matchOptions ? matchOptions.numberOfLegs! : defaultNumberOfLegs;
+
             switch (side) {
                 case 'home':
-                    return (match?.homeScore || 0) > (match?.awayScore || 0);
+                    return (match?.homeScore || 0) > (numberOfLegs / 2.0);
                 case 'away':
-                    return (match?.awayScore || 0) > (match?.homeScore || 0);
+                    return (match?.awayScore || 0) > (numberOfLegs / 2.0);
                 default:
                     /* istanbul ignore next */
                     return false;

--- a/CourageScores/ClientApp/src/components/scores/ScoreCardHeading.tsx
+++ b/CourageScores/ClientApp/src/components/scores/ScoreCardHeading.tsx
@@ -4,7 +4,6 @@ import {renderDate} from "../../helpers/rendering";
 import {count} from "../../helpers/collections";
 import {GameDto} from "../../interfaces/models/dtos/Game/GameDto";
 import {GameMatchDto} from "../../interfaces/models/dtos/Game/GameMatchDto";
-import {GameMatchOptionDto} from "../../interfaces/models/dtos/Game/GameMatchOptionDto";
 import {Link} from "react-router";
 import {TeamDto} from "../../interfaces/models/dtos/Team/TeamDto";
 import {UntypedPromise} from "../../interfaces/UntypedPromise";
@@ -54,17 +53,23 @@ export function ScoreCardHeading({data, access, submission, setSubmission, setFi
             && (access === 'admin' || (account && submission && account.teamId === submission.id && access === 'clerk'));
     }
 
+    function hasScore(score?: number): boolean {
+        return score !== null && score !== undefined;
+    }
+
     function getScore(data: GameDto | undefined, side: string): number {
-        function sideWonMatch(match: GameMatchDto | undefined, index?: number): boolean {
-            const matchOptions: GameMatchOptionDto | undefined = data?.matchOptions![index!];
-            const defaultNumberOfLegs: number = 5;
-            const numberOfLegs: number = matchOptions ? matchOptions.numberOfLegs! : defaultNumberOfLegs;
+        function sideWonMatch(match: GameMatchDto | undefined): boolean {
+            const hasBothScores: boolean = hasScore(match?.homeScore) && hasScore(match?.awayScore);
+
+            if (!hasBothScores) {
+                return false;
+            }
 
             switch (side) {
                 case 'home':
-                    return (match?.homeScore || 0) > (numberOfLegs / 2.0);
+                    return (match?.homeScore || 0) > (match?.awayScore || 0);
                 case 'away':
-                    return (match?.awayScore || 0) > (numberOfLegs / 2.0);
+                    return (match?.awayScore || 0) > (match?.homeScore || 0);
                 default:
                     /* istanbul ignore next */
                     return false;

--- a/CourageScores/Models/Cosmos/Game/Game.cs
+++ b/CourageScores/Models/Cosmos/Game/Game.cs
@@ -119,10 +119,15 @@ public class Game : AuditedEntity, IPermissionedEntity, IGameVisitable, IPhotoEn
         }
 
         var gameScore = new GameScoreVisitor(Home, Away);
+        var index = 0;
         foreach (var match in Matches)
         {
-            match.Accept(scope, gameScore);
-            match.Accept(scope, visitor);
+            var indexedScope = scope.With(new VisitorScope
+            {
+                Index = index++,
+            });
+            match.Accept(indexedScope, gameScore);
+            match.Accept(indexedScope, visitor);
         }
 
         gameScore.Accept(scope, visitor);

--- a/CourageScores/Models/Cosmos/Game/GameMatch.cs
+++ b/CourageScores/Models/Cosmos/Game/GameMatch.cs
@@ -58,12 +58,18 @@ public class GameMatch : AuditedEntity, IGameVisitable
 
         if (HomeScore.HasValue && AwayScore.HasValue)
         {
-            if (HomeScore > AwayScore)
+            var matchOptions = scope.Game != null && scope.Index != null
+                ? scope.Game.MatchOptions.ElementAtOrDefault(scope.Index.Value)
+                : null;
+            var homeWinningNumberOfLegs = (matchOptions?.NumberOfLegs / 2.0) ?? AwayScore;
+            var awayWinningNumberOfLegs = (matchOptions?.NumberOfLegs / 2.0) ?? HomeScore;
+
+            if (HomeScore > homeWinningNumberOfLegs)
             {
                 visitor.VisitMatchWin(scope, HomePlayers, TeamDesignation.Home, HomeScore.Value, AwayScore.Value);
                 visitor.VisitMatchLost(scope, AwayPlayers, TeamDesignation.Away, AwayScore.Value, HomeScore.Value);
             }
-            if (AwayScore > HomeScore)
+            if (AwayScore > awayWinningNumberOfLegs)
             {
                 visitor.VisitMatchWin(scope, AwayPlayers, TeamDesignation.Away, AwayScore.Value, HomeScore.Value);
                 visitor.VisitMatchLost(scope, HomePlayers, TeamDesignation.Home, HomeScore.Value, AwayScore.Value);

--- a/CourageScores/Models/Cosmos/Game/GameMatch.cs
+++ b/CourageScores/Models/Cosmos/Game/GameMatch.cs
@@ -76,8 +76,19 @@ public class GameMatch : AuditedEntity, IGameVisitable
             }
             if (AwayScore == HomeScore)
             {
-                visitor.VisitDataError(scope, $"Match between {string.Join(", ", HomePlayers.Select(p => p.Name))} and {string.Join(", ", AwayPlayers.Select(p => p.Name))} is a {HomeScore}-{AwayScore} draw, scores won't count on players table");
+                visitor.VisitDataError(
+                    scope,
+                    $"Match between {string.Join(", ", HomePlayers.Select(p => p.Name))} and {string.Join(", ", AwayPlayers.Select(p => p.Name))} is a {HomeScore}-{AwayScore} draw, scores won't count on players table");
             }
+
+            return;
+        }
+
+        if (HomeScore.HasValue || AwayScore.HasValue)
+        {
+            visitor.VisitDataError(
+                scope,
+                $"Match between {string.Join(", ", HomePlayers.Select(p => p.Name))} and {string.Join(", ", AwayPlayers.Select(p => p.Name))} has only one score {HomeScore}-{AwayScore}, both are required to ensure the team/players table are rendered correctly");
         }
     }
 }

--- a/CourageScores/Models/Cosmos/Game/GameMatch.cs
+++ b/CourageScores/Models/Cosmos/Game/GameMatch.cs
@@ -69,7 +69,7 @@ public class GameMatch : AuditedEntity, IGameVisitable
                 visitor.VisitMatchWin(scope, HomePlayers, TeamDesignation.Home, HomeScore.Value, AwayScore.Value);
                 visitor.VisitMatchLost(scope, AwayPlayers, TeamDesignation.Away, AwayScore.Value, HomeScore.Value);
             }
-            if (AwayScore > awayWinningNumberOfLegs)
+            else if (AwayScore > awayWinningNumberOfLegs)
             {
                 visitor.VisitMatchWin(scope, AwayPlayers, TeamDesignation.Away, AwayScore.Value, HomeScore.Value);
                 visitor.VisitMatchLost(scope, HomePlayers, TeamDesignation.Home, HomeScore.Value, AwayScore.Value);

--- a/CourageScores/Models/Cosmos/Game/IVisitorScope.cs
+++ b/CourageScores/Models/Cosmos/Game/IVisitorScope.cs
@@ -5,5 +5,6 @@ public interface IVisitorScope
     Game? Game { get; }
     TournamentGame? Tournament { get; }
     bool ObscureScores { get; }
+    int? Index { get; }
     IVisitorScope With(IVisitorScope visitorScope);
 }

--- a/CourageScores/Models/Cosmos/Game/TournamentGame.cs
+++ b/CourageScores/Models/Cosmos/Game/TournamentGame.cs
@@ -46,9 +46,10 @@ public class TournamentGame : AuditedEntity, IPermissionedEntity, IGameVisitable
             }
         }
 
+        var index = 0;
         foreach (var side in Sides)
         {
-            side.Accept(scope, visitor);
+            side.Accept(scope.With(new VisitorScope { Index = index++ }), visitor);
         }
 
         Round?.Accept(scope, visitor);

--- a/CourageScores/Models/Cosmos/Game/TournamentRound.cs
+++ b/CourageScores/Models/Cosmos/Game/TournamentRound.cs
@@ -34,9 +34,10 @@ public class TournamentRound : AuditedEntity, IGameVisitable
     {
         visitor.VisitRound(scope, this);
 
+        var index = 0;
         foreach (var match in Matches)
         {
-            match.Accept(scope, visitor);
+            match.Accept(scope.With(new VisitorScope { Index = index++ }), visitor);
         }
 
         NextRound?.Accept(scope, visitor);

--- a/CourageScores/Models/Cosmos/Game/VisitorScope.cs
+++ b/CourageScores/Models/Cosmos/Game/VisitorScope.cs
@@ -5,6 +5,7 @@ public class VisitorScope : IVisitorScope
     public Game? Game { get; init; }
     public TournamentGame? Tournament { get; init; }
     public bool ObscureScores { get; init; }
+    public int? Index { get; init; }
 
     public IVisitorScope With(IVisitorScope visitorScope)
     {
@@ -13,6 +14,7 @@ public class VisitorScope : IVisitorScope
             Game = visitorScope.Game ?? Game,
             Tournament = visitorScope.Tournament ?? Tournament,
             ObscureScores = ObscureScores || visitorScope.ObscureScores,
+            Index = visitorScope.Index ?? Index,
         };
     }
 }

--- a/CourageScores/Models/Dtos/Division/DivisionDataFilter.cs
+++ b/CourageScores/Models/Dtos/Division/DivisionDataFilter.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using CourageScores.Models.Cosmos.Game;
 using CourageScores.Models.Dtos.Season;
+using CosmosGame = CourageScores.Models.Cosmos.Game.Game;
 
 namespace CourageScores.Models.Dtos.Division;
 
@@ -16,7 +18,7 @@ public class DivisionDataFilter : IEquatable<DivisionDataFilter>
     // ReSharper restore UnusedAutoPropertyAccessor.Global
     // ReSharper restore MemberCanBePrivate.Global
 
-    public bool IncludeGame(Cosmos.Game.Game game)
+    public bool IncludeGame(CosmosGame game)
     {
         return (Date == null || game.Date == Date.Value)
                && (TeamId == null || game.Home.Id == TeamId.Value || game.Away.Id == TeamId);
@@ -27,7 +29,7 @@ public class DivisionDataFilter : IEquatable<DivisionDataFilter>
         return IgnoreDates || (eventDate >= season.StartDate && eventDate <= season.EndDate);
     }
 
-    public bool IncludeTournament(Cosmos.Game.TournamentGame game)
+    public bool IncludeTournament(TournamentGame game)
     {
         return (Date == null || game.Date == Date.Value)
                && (TeamId == null || game.Sides.Any(s => s.TeamId != null && s.TeamId == TeamId));

--- a/CourageScores/Models/Dtos/Division/DivisionDataFilter.cs
+++ b/CourageScores/Models/Dtos/Division/DivisionDataFilter.cs
@@ -40,6 +40,11 @@ public class DivisionDataFilter : IEquatable<DivisionDataFilter>
         return (Date == null || note.Date == Date.Value);
     }
 
+    public bool IncludeTeam(Guid teamId)
+    {
+        return TeamId == null || teamId == TeamId.Value;
+    }
+
     public bool Equals(DivisionDataFilter? other)
     {
         return other != null

--- a/CourageScores/Services/Division/DivisionDataContext.cs
+++ b/CourageScores/Services/Division/DivisionDataContext.cs
@@ -1,5 +1,6 @@
 using CourageScores.Models.Cosmos.Game;
 using CourageScores.Models.Dtos;
+using CourageScores.Models.Dtos.Division;
 using CourageScores.Models.Dtos.Season;
 using CourageScores.Models.Dtos.Team;
 using CosmosGame = CourageScores.Models.Cosmos.Game.Game;
@@ -17,7 +18,8 @@ public class DivisionDataContext
         IEnumerable<FixtureDateNoteDto> notes,
         SeasonDto season,
         IReadOnlyDictionary<Guid, Guid?> teamIdToDivisionIdLookup,
-        IReadOnlyDictionary<Guid, DivisionDto> divisions)
+        IReadOnlyDictionary<Guid, DivisionDto> divisions,
+        DivisionDataFilter filter)
     {
         GamesForDate = games.GroupBy(g => g.Date).ToDictionary(g => g.Key, g => g.ToArray());
         TeamsInSeasonAndDivision = teamsInSeasonAndDivision;
@@ -26,6 +28,7 @@ public class DivisionDataContext
         Notes = notes.GroupBy(n => n.Date).ToDictionary(g => g.Key, g => g.ToArray());
         _tournamentGames = tournamentGames;
         Divisions = divisions;
+        Filter = filter;
     }
 
     public IReadOnlyCollection<TeamDto> TeamsInSeasonAndDivision { get; }
@@ -34,6 +37,7 @@ public class DivisionDataContext
     public Dictionary<DateTime, FixtureDateNoteDto[]> Notes { get; }
     public Dictionary<DateTime, CosmosGame[]> GamesForDate { get; }
     public IReadOnlyDictionary<Guid, DivisionDto> Divisions { get; }
+    public DivisionDataFilter Filter { get; }
 
     public IEnumerable<CosmosGame> AllGames(Guid? divisionId)
     {

--- a/CourageScores/Services/Division/DivisionDataDtoFactory.cs
+++ b/CourageScores/Services/Division/DivisionDataDtoFactory.cs
@@ -77,6 +77,7 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
             Name = GetDivisionName(divisions),
             Superleague = divisions.All(d => d?.Superleague == true),
             Teams = teamResults
+                .Where(t => context.Filter.IncludeTeam(t.Id))
                 .OrderByDescending(t => t.Points)
                 .ThenByDescending(t => t.Difference)
                 .ThenBy(t => t.Name)
@@ -86,6 +87,7 @@ public class DivisionDataDtoFactory : IDivisionDataDtoFactory
                 .OrderByAsync(d => d.Date)
                 .ToList(),
             Players = (await AddAllPlayersIfAdmin(playerResults, user, context, token))
+                .Where(p => context.Filter.IncludeTeam(p.TeamId))
                 .OrderByDescending(p => p.Points)
                 .ThenByDescending(p => p.WinPercentage)
                 .ThenByDescending(p => p.Pairs.MatchesPlayed)

--- a/CourageScores/Services/Division/DivisionService.cs
+++ b/CourageScores/Services/Division/DivisionService.cs
@@ -134,7 +134,8 @@ public class DivisionService : IDivisionService
             notes,
             season,
             teamIdToDivisionIdLookup,
-            divisions.ToDictionary(d => d.Id));
+            divisions.ToDictionary(d => d.Id),
+            filter);
     }
 
     private async Task<List<Models.Cosmos.Game.Game>> GetGames(DivisionDataFilter filter, SeasonDto season, CancellationToken token)


### PR DESCRIPTION
Resolves #1296

- [x] restore winner check using number of legs (front end)
- [x] use number of legs to calculate winner (back end)
- [x] add data error for missing match score (home xor away)
- [x] add back end tests for winner/ loser
- [x] add back end tests for data error 