### PR TITLE
#1376: Superleague UI improvements

### DIFF
--- a/CourageScores/ClientApp/src/components/tournaments/EditSide.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditSide.test.tsx
@@ -32,7 +32,7 @@ import {ITournamentPlayerMap} from "./Tournament";
 import {
     DivisionTournamentFixtureDetailsDto
 } from "../../interfaces/models/dtos/Division/DivisionTournamentFixtureDetailsDto";
-import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
+import {tournamentContainerPropsBuilder} from "./tournamentContainerPropsBuilder";
 
 describe('EditSide', () => {
     let context: TestContext;
@@ -49,7 +49,6 @@ describe('EditSide', () => {
         teamId: string,
         playerDetails: EditTeamPlayerDto,
     } | null;
-    let preventScroll: boolean;
     let divisions: DivisionDto[];
     const playerApi = api<IPlayerApi>({
         create: async (divisionId: string, seasonId: string, teamId: string, playerDetails: EditTeamPlayerDto): Promise<IClientActionResultDto<TeamDto>> => {
@@ -90,7 +89,6 @@ describe('EditSide', () => {
         applyOptions = null;
         teamsReloaded = false;
         createdPlayer = null;
-        preventScroll = false;
         divisions = [];
     });
 
@@ -115,15 +113,6 @@ describe('EditSide', () => {
         teamsReloaded = true;
     }
 
-    function setPreventScroll(_: boolean) {
-    }
-
-    async function setDraggingSide(_: TournamentSideDto) {
-    }
-
-    async function setNewMatch(_: TournamentMatchDto) {
-    }
-
     async function renderComponent(containerProps: ITournamentContainerProps, props: IEditSideProps, teams?: TeamDto[], account?: UserDto) {
         context = await renderApp(
             iocProps({playerApi}),
@@ -137,6 +126,8 @@ describe('EditSide', () => {
             (<TournamentContainer {...containerProps}>
                 <EditSide {...props} />
             </TournamentContainer>));
+
+        reportedError.verifyNoError();
     }
 
     function alreadyPlaying(player: TeamPlayerDto, tournament: DivisionTournamentFixtureDetailsDto): ITournamentPlayerMap {
@@ -166,19 +157,6 @@ describe('EditSide', () => {
         };
     }
 
-    function containerProps(tournamentData: TournamentGameDto, season: SeasonDto): ITournamentContainerProps {
-        return {
-            tournamentData,
-            season,
-            alreadyPlaying: {},
-            preventScroll,
-            setPreventScroll,
-            setDraggingSide,
-            newMatch: {},
-            setNewMatch,
-        };
-    }
-
     describe('renders', () => {
         const player: TeamPlayerDto = playerBuilder('PLAYER').build();
         const anotherPlayer: TeamPlayerDto = playerBuilder('ANOTHER PLAYER').build();
@@ -204,28 +182,25 @@ describe('EditSide', () => {
         const teamSide: TournamentSideDto = sideBuilder('SIDE NAME')
             .teamId(team.id)
             .build();
+        const containerProps = new tournamentContainerPropsBuilder({
+            tournamentData,
+            season,
+            alreadyPlaying: {},
+        });
 
         it('new side', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideBuilder().build()));
+            await renderComponent(containerProps.build(), props(sideBuilder().build()));
 
-            reportedError.verifyNoError();
             const nameInput = context.container.querySelector('input[name="name"]') as HTMLInputElement;
             expect(nameInput.value).toEqual('');
         });
 
         it('side with players', async () => {
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(sideWithPlayer), [team]);
+            await renderComponent(
+                containerProps.withAlreadyPlaying({}).build(),
+                props(sideWithPlayer),
+                [team]);
 
-            reportedError.verifyNoError();
             const nameInput = context.container.querySelector('input[name="name"]') as HTMLInputElement;
             expect(nameInput.value).toEqual('SIDE NAME');
             expect(context.container.querySelector('.dropdown-menu')).toBeNull();
@@ -239,9 +214,8 @@ describe('EditSide', () => {
                 .forSeason(season, tournamentData.divisionId, [ deletedPlayer ], true)
                 .build();
 
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [deletedTeam, team]);
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [deletedTeam, team]);
 
-            reportedError.verifyNoError();
             const nameInput = context.container.querySelector('input[name="name"]') as HTMLInputElement;
             expect(nameInput.value).toEqual('SIDE NAME');
             expect(context.container.querySelector('.dropdown-menu')).toBeNull();
@@ -250,7 +224,7 @@ describe('EditSide', () => {
         });
 
         it('players filtered by player name', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team, anotherTeam]);
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team, anotherTeam]);
 
             await doChange(context.container, 'input[name="playerFilter"]', 'ANOTHER player', context.user);
 
@@ -260,7 +234,7 @@ describe('EditSide', () => {
         });
 
         it('players filtered by team name', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team, anotherTeam]);
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team, anotherTeam]);
 
             await doChange(context.container, 'input[name="playerFilter"]', 'ANOTHER team', context.user);
 
@@ -275,7 +249,7 @@ describe('EditSide', () => {
                 .forSeason(season, tournamentData.divisionId, [ playerWithSameNameInDifferentTeam ])
                 .build();
 
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team, anotherTeam, differentTeam]);
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team, anotherTeam, differentTeam]);
 
             expect(context.container.querySelector('ol.list-group')).not.toBeNull();
             const playerItems = Array.from(context.container.querySelectorAll('ol.list-group li.list-group-item'));
@@ -290,9 +264,8 @@ describe('EditSide', () => {
                 .forDivision(division)
                 .build();
 
-            await renderComponent(containerProps(emptyTournamentData, season), props(teamSide), [team]);
+            await renderComponent(containerProps.withTournament(emptyTournamentData).build(), props(teamSide), [team]);
 
-            reportedError.verifyNoError();
             const nameInput = context.container.querySelector('input[name="name"]') as HTMLInputElement;
             expect(nameInput.value).toEqual('SIDE NAME');
             expect(context.container.querySelector('.dropdown-menu .active')).not.toBeNull();
@@ -305,26 +278,18 @@ describe('EditSide', () => {
                 .noShow()
                 .build();
 
-            await renderComponent(containerProps(tournamentData, season), props(side), [team]);
+            await renderComponent(
+                containerProps.build(),
+                props(side),
+                [team]);
 
-            reportedError.verifyNoError();
             const noShowInput = context.container.querySelector('input[name="noShow"]') as HTMLInputElement;
             expect(noShowInput.checked).toEqual(true);
         });
 
         it('side which did show', async () => {
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(sideWithPlayer), [team]);
+            await renderComponent(containerProps.withAlreadyPlaying({}).build(), props(sideWithPlayer), [team]);
 
-            reportedError.verifyNoError();
             const noShowInput = context.container.querySelector('input[name="noShow"]') as HTMLInputElement;
             expect(noShowInput.checked).toEqual(false);
         });
@@ -340,9 +305,8 @@ describe('EditSide', () => {
                 .teamId(teamNotInSeason.id)
                 .build();
 
-            await renderComponent(containerProps(tournamentData, season), props(side), [teamNotInSeason]);
+            await renderComponent(containerProps.build(), props(side), [teamNotInSeason]);
 
-            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).not.toContain('NOT IN SEASON PLAYER');
             const dropdownItems = Array.from(context.container.querySelectorAll('.dropdown-menu .dropdown-item'));
@@ -361,9 +325,8 @@ describe('EditSide', () => {
                 .teamId(deletedTeam.id)
                 .build();
 
-            await renderComponent(containerProps(tournamentData, season), props(side), [deletedTeam]);
+            await renderComponent(containerProps.build(), props(side), [deletedTeam]);
 
-            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).not.toContain('DELETED PLAYER');
             const dropdownItems = Array.from(context.container.querySelectorAll('.dropdown-menu .dropdown-item'));
@@ -378,18 +341,11 @@ describe('EditSide', () => {
                     [playerBuilder('OTHER DIVISION PLAYER').build()])
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: alreadyPlaying(player, anotherTournament),
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(sideWithPlayer), [otherDivisionTeam, team]);
+            await renderComponent(
+                containerProps.withAlreadyPlaying(alreadyPlaying(player, anotherTournament)).build(),
+                props(sideWithPlayer),
+                [otherDivisionTeam, team]);
 
-            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).not.toContain('OTHER DIVISION PLAYER');
         });
@@ -403,59 +359,42 @@ describe('EditSide', () => {
                 .build();
             const crossDivisionalTournamentData = tournamentBuilder().build();
 
-            await renderComponent({
-                tournamentData: crossDivisionalTournamentData,
-                season,
-                alreadyPlaying: alreadyPlaying(player, anotherTournament),
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(sideWithPlayer), [otherDivisionTeam, team]);
+            await renderComponent(
+                containerProps.withTournament(crossDivisionalTournamentData).withAlreadyPlaying(alreadyPlaying(player, anotherTournament)).build(),
+                props(sideWithPlayer),
+                [otherDivisionTeam, team]);
 
-            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).toContain('OTHER DIVISION PLAYER');
         });
 
         it('warning about players that are selected in another tournament', async () => {
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: alreadyPlaying(player, anotherTournament),
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(sideWithPlayer), [team]);
+            await renderComponent(
+                containerProps.withAlreadyPlaying(alreadyPlaying(player, anotherTournament)).build(),
+                props(sideWithPlayer),
+                [team]);
 
-            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).toContain('PLAYER (⚠ Playing in ANOTHER TOURNAMENT)');
         });
 
         it('unselectable players when selected in another side', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [anotherTeam]);
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [anotherTeam]);
 
-            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).toContain('ANOTHER PLAYER (🚫 Selected in "ANOTHER SIDE")');
         });
 
         it('selectable players when selected in this side', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(tournamentData.sides![0]), [anotherTeam]);
+            await renderComponent(containerProps.build(), props(tournamentData.sides![0]), [anotherTeam]);
 
-            reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             expect(playerItems.map(li => li.textContent)).toContain('ANOTHER PLAYER');
         });
 
         it('delete button when side exists', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(teamSide), [team]);
+            await renderComponent(containerProps.build(), props(teamSide), [team]);
 
-            reportedError.verifyNoError();
             expect(context.container.querySelector('.btn-danger')).toBeTruthy();
             expect(context.container.querySelector('.btn-danger')!.textContent).toEqual('Delete side');
         });
@@ -463,9 +402,8 @@ describe('EditSide', () => {
         it('no delete button when side is new', async () => {
             const side: TournamentSideDto = sideBuilder('SIDE NAME').noId().build();
 
-            await renderComponent(containerProps(tournamentData, season), props(side), [team]);
+            await renderComponent(containerProps.build(), props(side), [team]);
 
-            reportedError.verifyNoError();
             expect(context.container.querySelector('.btn-danger')).toBeFalsy();
         });
 
@@ -474,36 +412,32 @@ describe('EditSide', () => {
                 .noId()
                 .build();
 
-            await renderComponent(containerProps(tournamentData, season), props(side), [team], user(true));
+            await renderComponent(containerProps.build(), props(side), [team], user(true));
 
-            reportedError.verifyNoError();
             const buttons = Array.from(context.container.querySelectorAll('.btn'));
             const buttonText = buttons.map(btn => btn.textContent);
             expect(buttonText).toContain('New player/s');
         });
 
         it('add player button when permitted and editing side', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team], user(true));
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team], user(true));
 
-            reportedError.verifyNoError();
             const buttons = Array.from(context.container.querySelectorAll('.btn'));
             const buttonText = buttons.map(btn => btn.textContent);
             expect(buttonText).toContain('New player/s');
         });
 
         it('no add player button when not permitted', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(teamSide), [team], user(false));
+            await renderComponent(containerProps.build(), props(teamSide), [team], user(false));
 
-            reportedError.verifyNoError();
             const buttons = Array.from(context.container.querySelectorAll('.btn'));
             const buttonText = buttons.map(btn => btn.textContent);
             expect(buttonText).not.toContain('Add player');
         });
 
         it('no add player button when permitted and team side', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(teamSide), [team], user(false));
+            await renderComponent(containerProps.build(), props(teamSide), [team], user(false));
 
-            reportedError.verifyNoError();
             const buttons = Array.from(context.container.querySelectorAll('.btn'));
             const buttonText = buttons.map(btn => btn.textContent);
             expect(buttonText).not.toContain('Add player');
@@ -535,9 +469,14 @@ describe('EditSide', () => {
         const otherDivisionTournament: TournamentGameDto = tournamentBuilder()
             .forDivision(divisionBuilder('DIVISION').build())
             .build();
+        const containerProps = new tournamentContainerPropsBuilder({
+            tournamentData,
+            season,
+            alreadyPlaying: {},
+        });
 
         it('can change side name', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team]);
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team]);
 
             await doChange(context.container, 'input[name="name"]', 'NEW NAME', context.user);
 
@@ -550,7 +489,7 @@ describe('EditSide', () => {
         });
 
         it('can change noShow', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team]);
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team]);
 
             await doClick(context.container, 'input[name="noShow"]');
 
@@ -572,7 +511,7 @@ describe('EditSide', () => {
                 .forDivision(division)
                 .withSide((s: ITournamentSideBuilder) => s.name('ANOTHER SIDE').teamId(anotherTeam.id))
                 .build();
-            await renderComponent(containerProps(teamTournamentData, season), props(side), [team, anotherTeam]);
+            await renderComponent(containerProps.withTournament(teamTournamentData).build(), props(side), [team, anotherTeam]);
 
             await doSelectOption(context.container.querySelector('.dropdown-menu'), 'TEAM');
 
@@ -593,7 +532,7 @@ describe('EditSide', () => {
                 .forDivision(division)
                 .withSide((s: ITournamentSideBuilder) => s.name('ANOTHER SIDE').teamId(anotherTeam.id))
                 .build();
-            await renderComponent(containerProps(teamTournamentData, season), props(teamSide), [team, anotherTeam]);
+            await renderComponent(containerProps.withTournament(teamTournamentData).build(), props(teamSide), [team, anotherTeam]);
 
             await doSelectOption(context.container.querySelector('.dropdown-menu'), 'Select team');
 
@@ -607,7 +546,7 @@ describe('EditSide', () => {
 
         it('can select player', async () => {
             const side: TournamentSideDto = sideBuilder('').build();
-            await renderComponent(containerProps(tournamentData, season), props(side), [team]);
+            await renderComponent(containerProps.build(), props(side), [team]);
             const players = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
 
             await doClick(players.filter(p => p.textContent === 'PLAYER')[0]);
@@ -625,7 +564,7 @@ describe('EditSide', () => {
 
         it('sets side name to player name when player selected for new side', async () => {
             const side: TournamentSideDto = sideBuilder().build();
-            await renderComponent(containerProps(tournamentData, season), props(side), [team]);
+            await renderComponent(containerProps.build(), props(side), [team]);
             const players = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
 
             await doClick(players.filter(p => p.textContent === 'PLAYER')[0]);
@@ -643,7 +582,7 @@ describe('EditSide', () => {
 
         it('can select player and team name does not change', async () => {
             const side: TournamentSideDto = sideBuilder('OTHER NAME').build();
-            await renderComponent(containerProps(tournamentData, season), props(side), [team]);
+            await renderComponent(containerProps.build(), props(side), [team]);
             const players = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
 
             await doClick(players.filter(p => p.textContent === 'PLAYER')[0]);
@@ -666,7 +605,7 @@ describe('EditSide', () => {
             const noSidesTournamentData: TournamentGameDto = tournamentBuilder()
                 .forDivision(tournamentData.divisionId)
                 .build();
-            await renderComponent(containerProps(noSidesTournamentData, season), props(sideWithPlayerName), [team]);
+            await renderComponent(containerProps.withTournament(noSidesTournamentData).build(), props(sideWithPlayerName), [team]);
             const players = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
 
             await doClick(players.filter(p => p.textContent === 'ANOTHER PLAYER')[0]);
@@ -689,7 +628,7 @@ describe('EditSide', () => {
             const noSidesTournamentData: TournamentGameDto = tournamentBuilder()
                 .forDivision(tournamentData.divisionId)
                 .build();
-            await renderComponent(containerProps(noSidesTournamentData, season), props(sideWithPlayer), [team]);
+            await renderComponent(containerProps.withTournament(noSidesTournamentData).build(), props(sideWithPlayer), [team]);
             const players = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
 
             await doClick(players.filter(p => p.textContent === 'ANOTHER PLAYER')[0]);
@@ -716,7 +655,7 @@ describe('EditSide', () => {
             const noSidesTournamentData: TournamentGameDto = tournamentBuilder()
                 .forDivision(tournamentData.divisionId)
                 .build();
-            await renderComponent(containerProps(noSidesTournamentData, season), props(side), [team]);
+            await renderComponent(containerProps.withTournament(noSidesTournamentData).build(), props(side), [team]);
             const players = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
 
             await doClick(players.filter(p => p.textContent === 'ANOTHER PLAYER')[0]);
@@ -730,7 +669,7 @@ describe('EditSide', () => {
         });
 
         it('can delete side', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team]);
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team]);
             context.prompts.respondToConfirm('Are you sure you want to remove SIDE NAME?', true);
 
             await doClick(findButton(context.container, 'Delete side'));
@@ -741,7 +680,7 @@ describe('EditSide', () => {
         });
 
         it('does not delete side when rejected', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team]);
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team]);
             context.prompts.respondToConfirm('Are you sure you want to remove SIDE NAME?', false);
 
             await doClick(findButton(context.container, 'Delete side'));
@@ -753,7 +692,7 @@ describe('EditSide', () => {
 
         it('cannot save side if no name', async () => {
             const side: TournamentSideDto = sideBuilder('').teamId(team.id).build();
-            await renderComponent(containerProps(tournamentData, season), props(side), [team]);
+            await renderComponent(containerProps.build(), props(side), [team]);
 
             await doClick(findButton(context.container, 'Update'));
 
@@ -764,7 +703,7 @@ describe('EditSide', () => {
 
         it('can save side when no teamId and no players', async () => {
             const side: TournamentSideDto = sideBuilder('NAME').build();
-            await renderComponent(containerProps(tournamentData, season), props(side), [team]);
+            await renderComponent(containerProps.build(), props(side), [team]);
 
             await doClick(findButton(context.container, 'Update'));
 
@@ -773,7 +712,7 @@ describe('EditSide', () => {
         });
 
         it('can save side', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team]);
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team]);
 
             await doClick(findButton(context.container, 'Update'));
 
@@ -785,7 +724,7 @@ describe('EditSide', () => {
         });
 
         it('can close', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team]);
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team]);
 
             await doClick(findButton(context.container, 'Close'));
 
@@ -796,17 +735,10 @@ describe('EditSide', () => {
 
         it('can select players that are selected in another tournament', async () => {
             const side: TournamentSideDto = sideBuilder('SIDE NAME').build();
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: alreadyPlaying(player, anotherTournament),
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(side), [team]);
-            reportedError.verifyNoError();
+            await renderComponent(
+                containerProps.withAlreadyPlaying(alreadyPlaying(player, anotherTournament)).build(),
+                props(side),
+                [team]);
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             const playerItem = playerItems.filter(li => li.textContent === 'PLAYER (⚠ Playing in ANOTHER TOURNAMENT)')[0];
             expect(playerItem.className).not.toContain('disabled');
@@ -826,8 +758,7 @@ describe('EditSide', () => {
 
         it('cannot select players that are selected in another side', async () => {
             const side: TournamentSideDto = sideBuilder('SIDE NAME').build();
-            await renderComponent(containerProps(tournamentData, season), props(side), [team]);
-            reportedError.verifyNoError();
+            await renderComponent(containerProps.build(), props(side), [team]);
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
             const playerItem = playerItems.filter(li => li.textContent === 'ANOTHER PLAYER (🚫 Selected in "ANOTHER SIDE")')[0];
             expect(playerItem.className).toContain('disabled');
@@ -839,16 +770,11 @@ describe('EditSide', () => {
         });
 
         it('can open add player dialog', async () => {
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(sideWithPlayer), [team], user(true));
+            await renderComponent(
+                containerProps.withAlreadyPlaying({}).build(),
+                props(sideWithPlayer),
+                [team],
+                user(true));
 
             await doClick(findButton(context.container, 'New player/s'));
 
@@ -858,7 +784,7 @@ describe('EditSide', () => {
         });
 
         it('can close add player dialog', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team], user(true));
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team], user(true));
             await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog');
@@ -869,7 +795,7 @@ describe('EditSide', () => {
         });
 
         it('can add player', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team], user(true));
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team], user(true));
             await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog')!;
@@ -891,7 +817,7 @@ describe('EditSide', () => {
                 .withSide((s: ITournamentSideBuilder) => s.name('ANOTHER SIDE').withPlayer(anotherPlayer))
                 .build();
             divisions = [ division ];
-            await renderComponent(containerProps(multiDivisionTournament, season), props(sideWithPlayer), [team], user(true));
+            await renderComponent(containerProps.withTournament(multiDivisionTournament).build(), props(sideWithPlayer), [team], user(true));
             await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog')!;
@@ -909,7 +835,7 @@ describe('EditSide', () => {
         });
 
         it('selects newly created player', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team], user(true));
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team], user(true));
             await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog')!;
@@ -931,7 +857,7 @@ describe('EditSide', () => {
         });
 
         it('reloads teams after player added', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team], user(true));
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team], user(true));
             await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog')!;
@@ -944,7 +870,7 @@ describe('EditSide', () => {
         });
 
         it('closes dialog after adding a player', async () => {
-            await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team], user(true));
+            await renderComponent(containerProps.build(), props(sideWithPlayer), [team], user(true));
             await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog')!;
@@ -957,31 +883,19 @@ describe('EditSide', () => {
         });
 
         it('can select team when no other sides', async () => {
-            await renderComponent({
-                tournamentData: otherDivisionTournament,
-                season,
-                alreadyPlaying: alreadyPlaying(player, anotherTournament),
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(teamSide), [team]);
+            await renderComponent(
+                containerProps.withTournament(otherDivisionTournament).withAlreadyPlaying(alreadyPlaying(player, anotherTournament)).build(),
+                props(teamSide),
+                [team]);
 
             expect(context.container.querySelector('.dropdown-menu')).toBeTruthy();
         });
 
         it('can select players when no other sides', async () => {
-            await renderComponent({
-                tournamentData: otherDivisionTournament,
-                season,
-                alreadyPlaying: alreadyPlaying(player, anotherTournament),
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(sideWithPlayer), [team]);
+            await renderComponent(
+                containerProps.withTournament(otherDivisionTournament).withAlreadyPlaying(alreadyPlaying(player, anotherTournament)).build(),
+                props(sideWithPlayer),
+                [team]);
 
             expect(context.container.querySelector('.list-group')).toBeTruthy();
         });
@@ -992,16 +906,10 @@ describe('EditSide', () => {
                 .withSide((s: ITournamentSideBuilder) => s.name('TEAM').teamId(team.id))
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: alreadyPlaying(player, anotherTournament),
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(teamSide), [team]);
+            await renderComponent(
+                containerProps.withTournament(tournamentData).withAlreadyPlaying(alreadyPlaying(player, anotherTournament)).build(),
+                props(teamSide),
+                [team]);
 
             expect(context.container.querySelector('.dropdown-menu')).toBeTruthy();
         });
@@ -1012,16 +920,10 @@ describe('EditSide', () => {
                 .withSide((s: ITournamentSideBuilder) => s.name('PLAYER').withPlayer(player))
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: alreadyPlaying(player, anotherTournament),
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(sideWithPlayer), [team]);
+            await renderComponent(
+                containerProps.withTournament(tournamentData).withAlreadyPlaying(alreadyPlaying(player, anotherTournament)).build(),
+                props(sideWithPlayer),
+                [team]);
 
             expect(context.container.querySelector('.list-group')).toBeTruthy();
         });
@@ -1032,16 +934,10 @@ describe('EditSide', () => {
                 .withSide((s: ITournamentSideBuilder) => s.name('PLAYER').withPlayer(player))
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: alreadyPlaying(player, anotherTournament),
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(sideWithPlayer), [team]);
+            await renderComponent(
+                containerProps.withTournament(tournamentData).withAlreadyPlaying(alreadyPlaying(player, anotherTournament)).build(),
+                props(sideWithPlayer),
+                [team]);
 
             expect(context.container.querySelector('.dropdown-menu')).toBeFalsy();
         });
@@ -1052,16 +948,10 @@ describe('EditSide', () => {
                 .withSide((s: ITournamentSideBuilder) => s.name('TEAM').teamId(team.id))
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: alreadyPlaying(player, anotherTournament),
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, props(sideWithPlayer), [team]);
+            await renderComponent(
+                containerProps.withTournament(tournamentData).withAlreadyPlaying(alreadyPlaying(player, anotherTournament)).build(),
+                props(sideWithPlayer),
+                [team]);
 
             expect(context.container.querySelector('.list-group')).toBeFalsy();
         });

--- a/CourageScores/ClientApp/src/components/tournaments/EditSide.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditSide.test.tsx
@@ -117,6 +117,9 @@ describe('EditSide', () => {
     function setPreventScroll(_: boolean) {
     }
 
+    async function setDraggingSide(_: TournamentSideDto) {
+    }
+
     async function renderComponent(containerProps: ITournamentContainerProps, props: IEditSideProps, teams?: TeamDto[], account?: UserDto) {
         context = await renderApp(
             iocProps({playerApi}),
@@ -166,6 +169,7 @@ describe('EditSide', () => {
             alreadyPlaying: {},
             preventScroll,
             setPreventScroll,
+            setDraggingSide,
         };
     }
 
@@ -209,7 +213,8 @@ describe('EditSide', () => {
                 season,
                 alreadyPlaying: {},
                 preventScroll,
-                setPreventScroll
+                setPreventScroll,
+                setDraggingSide,
             }, props(sideWithPlayer), [team]);
 
             reportedError.verifyNoError();
@@ -305,7 +310,8 @@ describe('EditSide', () => {
                 season,
                 alreadyPlaying: {},
                 preventScroll,
-                setPreventScroll
+                setPreventScroll,
+                setDraggingSide,
             }, props(sideWithPlayer), [team]);
 
             reportedError.verifyNoError();
@@ -367,7 +373,8 @@ describe('EditSide', () => {
                 season,
                 alreadyPlaying: alreadyPlaying(player, anotherTournament),
                 preventScroll,
-                setPreventScroll
+                setPreventScroll,
+                setDraggingSide,
             }, props(sideWithPlayer), [otherDivisionTeam, team]);
 
             reportedError.verifyNoError();
@@ -390,6 +397,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player, anotherTournament),
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, props(sideWithPlayer), [otherDivisionTeam, team]);
 
             reportedError.verifyNoError();
@@ -404,6 +412,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player, anotherTournament),
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, props(sideWithPlayer), [team]);
 
             reportedError.verifyNoError();
@@ -777,6 +786,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player, anotherTournament),
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, props(side), [team]);
             reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
@@ -817,6 +827,7 @@ describe('EditSide', () => {
                 alreadyPlaying: {},
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, props(sideWithPlayer), [team], user(true));
 
             await doClick(findButton(context.container, 'Add player/s'));
@@ -932,6 +943,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player, anotherTournament),
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, props(teamSide), [team]);
 
             expect(context.container.querySelector('.dropdown-menu')).toBeTruthy();
@@ -944,6 +956,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player, anotherTournament),
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, props(sideWithPlayer), [team]);
 
             expect(context.container.querySelector('.list-group')).toBeTruthy();
@@ -961,6 +974,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player, anotherTournament),
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, props(teamSide), [team]);
 
             expect(context.container.querySelector('.dropdown-menu')).toBeTruthy();
@@ -978,6 +992,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player, anotherTournament),
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, props(sideWithPlayer), [team]);
 
             expect(context.container.querySelector('.list-group')).toBeTruthy();
@@ -995,6 +1010,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player, anotherTournament),
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, props(sideWithPlayer), [team]);
 
             expect(context.container.querySelector('.dropdown-menu')).toBeFalsy();
@@ -1012,6 +1028,7 @@ describe('EditSide', () => {
                 alreadyPlaying: alreadyPlaying(player, anotherTournament),
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, props(sideWithPlayer), [team]);
 
             expect(context.container.querySelector('.list-group')).toBeFalsy();

--- a/CourageScores/ClientApp/src/components/tournaments/EditSide.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditSide.test.tsx
@@ -463,7 +463,7 @@ describe('EditSide', () => {
             reportedError.verifyNoError();
             const buttons = Array.from(context.container.querySelectorAll('.btn'));
             const buttonText = buttons.map(btn => btn.textContent);
-            expect(buttonText).toContain('Add player/s');
+            expect(buttonText).toContain('New player/s');
         });
 
         it('add player button when permitted and editing side', async () => {
@@ -472,7 +472,7 @@ describe('EditSide', () => {
             reportedError.verifyNoError();
             const buttons = Array.from(context.container.querySelectorAll('.btn'));
             const buttonText = buttons.map(btn => btn.textContent);
-            expect(buttonText).toContain('Add player/s');
+            expect(buttonText).toContain('New player/s');
         });
 
         it('no add player button when not permitted', async () => {
@@ -739,7 +739,7 @@ describe('EditSide', () => {
             const side: TournamentSideDto = sideBuilder('').teamId(team.id).build();
             await renderComponent(containerProps(tournamentData, season), props(side), [team]);
 
-            await doClick(findButton(context.container, 'Save'));
+            await doClick(findButton(context.container, 'Update'));
 
             reportedError.verifyNoError();
             context.prompts.alertWasShown('Please enter a name for this side');
@@ -750,7 +750,7 @@ describe('EditSide', () => {
             const side: TournamentSideDto = sideBuilder('NAME').build();
             await renderComponent(containerProps(tournamentData, season), props(side), [team]);
 
-            await doClick(findButton(context.container, 'Save'));
+            await doClick(findButton(context.container, 'Update'));
 
             reportedError.verifyNoError();
             expect(applied).toEqual(true);
@@ -759,7 +759,7 @@ describe('EditSide', () => {
         it('can save side', async () => {
             await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team]);
 
-            await doClick(findButton(context.container, 'Save'));
+            await doClick(findButton(context.container, 'Update'));
 
             reportedError.verifyNoError();
             expect(applied).toEqual(true);
@@ -830,7 +830,7 @@ describe('EditSide', () => {
                 setDraggingSide,
             }, props(sideWithPlayer), [team], user(true));
 
-            await doClick(findButton(context.container, 'Add player/s'));
+            await doClick(findButton(context.container, 'New player/s'));
 
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             expect(headingForDialog).toBeTruthy();
@@ -839,7 +839,7 @@ describe('EditSide', () => {
 
         it('can close add player dialog', async () => {
             await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team], user(true));
-            await doClick(findButton(context.container, 'Add player/s'));
+            await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog');
 
@@ -850,7 +850,7 @@ describe('EditSide', () => {
 
         it('can add player', async () => {
             await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team], user(true));
-            await doClick(findButton(context.container, 'Add player/s'));
+            await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog')!;
 
@@ -872,7 +872,7 @@ describe('EditSide', () => {
                 .build();
             divisions = [ division ];
             await renderComponent(containerProps(multiDivisionTournament, season), props(sideWithPlayer), [team], user(true));
-            await doClick(findButton(context.container, 'Add player/s'));
+            await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog')!;
 
@@ -890,7 +890,7 @@ describe('EditSide', () => {
 
         it('selects newly created player', async () => {
             await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team], user(true));
-            await doClick(findButton(context.container, 'Add player/s'));
+            await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog')!;
 
@@ -912,7 +912,7 @@ describe('EditSide', () => {
 
         it('reloads teams after player added', async () => {
             await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team], user(true));
-            await doClick(findButton(context.container, 'Add player/s'));
+            await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog')!;
 
@@ -925,7 +925,7 @@ describe('EditSide', () => {
 
         it('closes dialog after adding a player', async () => {
             await renderComponent(containerProps(tournamentData, season), props(sideWithPlayer), [team], user(true));
-            await doClick(findButton(context.container, 'Add player/s'));
+            await doClick(findButton(context.container, 'New player/s'));
             const headingForDialog = Array.from(context.container.querySelectorAll('h5')).filter(h5 => h5.textContent === 'Add a player...')[0];
             const dialog = headingForDialog.closest('.modal-dialog')!;
 

--- a/CourageScores/ClientApp/src/components/tournaments/EditSide.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditSide.test.tsx
@@ -32,6 +32,7 @@ import {ITournamentPlayerMap} from "./Tournament";
 import {
     DivisionTournamentFixtureDetailsDto
 } from "../../interfaces/models/dtos/Division/DivisionTournamentFixtureDetailsDto";
+import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 describe('EditSide', () => {
     let context: TestContext;
@@ -120,6 +121,9 @@ describe('EditSide', () => {
     async function setDraggingSide(_: TournamentSideDto) {
     }
 
+    async function setNewMatch(_: TournamentMatchDto) {
+    }
+
     async function renderComponent(containerProps: ITournamentContainerProps, props: IEditSideProps, teams?: TeamDto[], account?: UserDto) {
         context = await renderApp(
             iocProps({playerApi}),
@@ -170,6 +174,8 @@ describe('EditSide', () => {
             preventScroll,
             setPreventScroll,
             setDraggingSide,
+            newMatch: {},
+            setNewMatch,
         };
     }
 
@@ -215,6 +221,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(sideWithPlayer), [team]);
 
             reportedError.verifyNoError();
@@ -312,6 +320,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(sideWithPlayer), [team]);
 
             reportedError.verifyNoError();
@@ -375,6 +385,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(sideWithPlayer), [otherDivisionTeam, team]);
 
             reportedError.verifyNoError();
@@ -398,6 +410,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(sideWithPlayer), [otherDivisionTeam, team]);
 
             reportedError.verifyNoError();
@@ -413,6 +427,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(sideWithPlayer), [team]);
 
             reportedError.verifyNoError();
@@ -787,6 +803,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(side), [team]);
             reportedError.verifyNoError();
             const playerItems = Array.from(context.container.querySelectorAll('.list-group .list-group-item'));
@@ -828,6 +846,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(sideWithPlayer), [team], user(true));
 
             await doClick(findButton(context.container, 'New player/s'));
@@ -944,6 +964,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(teamSide), [team]);
 
             expect(context.container.querySelector('.dropdown-menu')).toBeTruthy();
@@ -957,6 +979,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(sideWithPlayer), [team]);
 
             expect(context.container.querySelector('.list-group')).toBeTruthy();
@@ -975,6 +999,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(teamSide), [team]);
 
             expect(context.container.querySelector('.dropdown-menu')).toBeTruthy();
@@ -993,6 +1019,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(sideWithPlayer), [team]);
 
             expect(context.container.querySelector('.list-group')).toBeTruthy();
@@ -1011,6 +1039,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(sideWithPlayer), [team]);
 
             expect(context.container.querySelector('.dropdown-menu')).toBeFalsy();
@@ -1029,6 +1059,8 @@ describe('EditSide', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, props(sideWithPlayer), [team]);
 
             expect(context.container.querySelector('.list-group')).toBeFalsy();

--- a/CourageScores/ClientApp/src/components/tournaments/EditSide.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditSide.tsx
@@ -316,13 +316,12 @@ export function EditSide({side, onChange, onClose, onApply, onDelete, initialAdd
                     <label className="form-check-label no-wrap" htmlFor="addAsIndividuals">Add as individuals</label>
                 </span>) : null}
                 {canAddPlayers
-                    ? (<button className="btn btn-primary" onClick={() => setAddPlayerDialogOpen(true)}>Add
-                        player/s</button>)
+                    ? (<button className="btn btn-primary" onClick={() => setAddPlayerDialogOpen(true)}>New player/s</button>)
                     : null}
                 {side.id ? (<button className="btn btn-danger margin-right" onClick={onRemoveSide}>
                     Delete side
                 </button>) : null}
-                <button className="btn btn-primary" onClick={onSave}>Save</button>
+                <button className="btn btn-primary" onClick={onSave}>{side.id ? 'Update' : 'Add'}</button>
             </div>
             {addPlayerDialogOpen ? renderCreatePlayerDialog(season!) : null}
         </Dialog>);

--- a/CourageScores/ClientApp/src/components/tournaments/EditTournament.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditTournament.test.tsx
@@ -25,6 +25,7 @@ import {teamBuilder} from "../../helpers/builders/teams";
 import {divisionBuilder} from "../../helpers/builders/divisions";
 import {IMatchOptionsBuilder} from "../../helpers/builders/games";
 import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
+import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 describe('EditTournament', () => {
     let context: TestContext;
@@ -44,6 +45,9 @@ describe('EditTournament', () => {
     }
 
     async function setDraggingSide(_: TournamentSideDto) {
+    }
+
+    async function setNewMatch(_: TournamentMatchDto) {
     }
 
     beforeEach(() => {
@@ -85,6 +89,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: true,
                 saving: false,
@@ -114,6 +120,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: true,
                 saving: false,
@@ -141,6 +149,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: true,
                 saving: false,
@@ -170,6 +180,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: true,
                 saving: false,
@@ -197,6 +209,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: true,
                 saving: false,
@@ -230,6 +244,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: true,
                 saving: false,
@@ -271,6 +287,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: true,
                 saving: false,
@@ -314,6 +332,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: false,
                 saving: false,
@@ -352,6 +372,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: false,
                 saving: false,
@@ -390,6 +412,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: false,
                 saving: false,
@@ -423,6 +447,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: false,
                 saving: false,
@@ -457,6 +483,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: false,
                 saving: false,
@@ -495,6 +523,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: false,
                 saving: false,
@@ -537,6 +567,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: false,
                 saving: false,
@@ -579,6 +611,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: false,
                 saving: false,
@@ -622,6 +656,8 @@ describe('EditTournament', () => {
                 preventScroll,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 disabled: false,
                 saving: false,

--- a/CourageScores/ClientApp/src/components/tournaments/EditTournament.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditTournament.test.tsx
@@ -23,15 +23,12 @@ import {
 } from "../../helpers/builders/tournaments";
 import {teamBuilder} from "../../helpers/builders/teams";
 import {divisionBuilder} from "../../helpers/builders/divisions";
-import {IMatchOptionsBuilder} from "../../helpers/builders/games";
-import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
-import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
+import {tournamentContainerPropsBuilder} from "./tournamentContainerPropsBuilder";
 
 describe('EditTournament', () => {
     let context: TestContext;
     let reportedError: ErrorState;
     let updatedData: TournamentGameDto | null;
-    let preventScroll: boolean;
 
     afterEach(async () => {
         await cleanUp(context);
@@ -41,19 +38,9 @@ describe('EditTournament', () => {
         updatedData = newData;
     }
 
-    function setPreventScroll(_: boolean) {
-    }
-
-    async function setDraggingSide(_: TournamentSideDto) {
-    }
-
-    async function setNewMatch(_: TournamentMatchDto) {
-    }
-
     beforeEach(() => {
         reportedError = new ErrorState();
         updatedData = null;
-        preventScroll = false;
     });
 
     async function renderComponent(containerProps: ITournamentContainerProps, props: IEditTournamentProps, account?: UserDto, teams?: TeamDto[]) {
@@ -67,11 +54,17 @@ describe('EditTournament', () => {
             (<TournamentContainer {...containerProps}>
                 <EditTournament {...props} />
             </TournamentContainer>));
+
+        reportedError.verifyNoError();
     }
 
     describe('renders', () => {
         const account: UserDto | undefined = undefined;
         const season = seasonBuilder('SEASON').build();
+        const containerProps = new tournamentContainerPropsBuilder({
+            season,
+            setTournamentData,
+        });
 
         it('who is playing', async () => {
             const tournamentData = tournamentBuilder()
@@ -80,18 +73,7 @@ describe('EditTournament', () => {
                 .withSide((s: ITournamentSideBuilder) => s.name('ANOTHER SIDE'))
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).build(), {
                 disabled: true,
                 saving: false,
                 canSave: false,
@@ -111,18 +93,7 @@ describe('EditTournament', () => {
                 .withSide((s: ITournamentSideBuilder) => s.name('ANOTHER SIDE'))
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAllPlayers([]).withAlreadyPlaying({}).build(), {
                 disabled: true,
                 saving: false,
                 canSave: false,
@@ -140,18 +111,7 @@ describe('EditTournament', () => {
                 .withSide((s: ITournamentSideBuilder) => s.name('SIDE 1'))
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAllPlayers([]).withAlreadyPlaying({}).build(), {
                 disabled: true,
                 saving: false,
                 canSave: false,
@@ -171,18 +131,7 @@ describe('EditTournament', () => {
                 .round((r: ITournamentRoundBuilder) => r.withMatch((m: ITournamentMatchBuilder) => m.sideA('SIDE 1', 1).sideB('ANOTHER SIDE', 2)))
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAllPlayers([]).withAlreadyPlaying({}).build(), {
                 disabled: true,
                 saving: false,
                 canSave: false,
@@ -200,18 +149,7 @@ describe('EditTournament', () => {
                 .withSide((s: ITournamentSideBuilder) => s.name('SIDE 1'))
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAllPlayers([]).withAlreadyPlaying({}).build(), {
                 disabled: true,
                 saving: false,
                 canSave: false,
@@ -235,18 +173,7 @@ describe('EditTournament', () => {
                 .withSide(anotherSide)
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
                 disabled: true,
                 saving: false,
                 canSave: false,
@@ -278,18 +205,7 @@ describe('EditTournament', () => {
                 .withSide(anotherSide)
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
                 disabled: true,
                 saving: false,
                 canSave: false,
@@ -316,6 +232,10 @@ describe('EditTournament', () => {
         const season = seasonBuilder('SEASON').build();
         const division = divisionBuilder('DIVISION').build();
         const team1 = teamBuilder('TEAM 1').forSeason(season, division).build();
+        const containerProps = new tournamentContainerPropsBuilder({
+            season,
+            setTournamentData,
+        });
 
         it('can add a side', async () => {
             const existingSide = sideBuilder('SIDE 1').teamId(team1.id).build();
@@ -323,18 +243,7 @@ describe('EditTournament', () => {
                 .forSeason(season)
                 .withSide(existingSide)
                 .build();
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
                 disabled: false,
                 saving: false,
                 canSave: true,
@@ -363,18 +272,7 @@ describe('EditTournament', () => {
                 .forSeason(season)
                 .withSide(existingSide)
                 .build();
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
                 disabled: false,
                 saving: false,
                 canSave: true,
@@ -403,18 +301,7 @@ describe('EditTournament', () => {
                 .forSeason(season)
                 .withSide((s: ITournamentSideBuilder) => s.name('SIDE 1'))
                 .build();
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
                 disabled: false,
                 saving: false,
                 canSave: true,
@@ -438,18 +325,7 @@ describe('EditTournament', () => {
                 .forSeason(season)
                 .withSide(side)
                 .build();
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
                 disabled: false,
                 saving: false,
                 canSave: true,
@@ -474,18 +350,7 @@ describe('EditTournament', () => {
                 .forSeason(season)
                 .withSide(side)
                 .build();
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
                 disabled: false,
                 saving: false,
                 canSave: true,
@@ -514,18 +379,7 @@ describe('EditTournament', () => {
                     .withMatch((m: ITournamentMatchBuilder) => m.sideA(side))
                     .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3)))
                 .build();
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
                 disabled: false,
                 saving: false,
                 canSave: true,
@@ -558,18 +412,7 @@ describe('EditTournament', () => {
                     .withMatch((m: ITournamentMatchBuilder) => m.sideB(side))
                     .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3)))
                 .build();
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
                 disabled: false,
                 saving: false,
                 canSave: true,
@@ -598,22 +441,8 @@ describe('EditTournament', () => {
             const tournamentData = tournamentBuilder()
                 .forSeason(season)
                 .withSide(side)
-                .round((r: ITournamentRoundBuilder) => r
-                    .withMatch((m: ITournamentMatchBuilder) => m.sideB(side))
-                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3)))
                 .build();
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
                 disabled: false,
                 saving: false,
                 canSave: true,
@@ -647,18 +476,7 @@ describe('EditTournament', () => {
                 .withSide(side2)
                 .build();
 
-            await renderComponent({
-                tournamentData,
-                season,
-                alreadyPlaying: {},
-                allPlayers: [],
-                setTournamentData,
-                preventScroll,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
                 disabled: false,
                 saving: false,
                 canSave: true,

--- a/CourageScores/ClientApp/src/components/tournaments/EditTournament.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditTournament.test.tsx
@@ -327,7 +327,7 @@ describe('EditTournament', () => {
             const dialog = sides.querySelector('.modal-dialog')!;
             expect(dialog).toBeTruthy();
             await doSelectOption(dialog.querySelector('.dropdown-menu'), 'TEAM 1');
-            await doClick(findButton(dialog, 'Save'));
+            await doClick(findButton(dialog, 'Add'));
 
             reportedError.verifyNoError();
             expect(updatedData!.sides).toEqual([existingSide, {
@@ -366,7 +366,7 @@ describe('EditTournament', () => {
             expect(dialog).toBeTruthy();
             await doSelectOption(dialog.querySelector('.dropdown-menu'), 'TEAM 1');
             await doChange(dialog, 'input[name="name"]', 'NAME   ', context.user);
-            await doClick(findButton(dialog, 'Save'));
+            await doClick(findButton(dialog, 'Add'));
 
             reportedError.verifyNoError();
             expect(updatedData!.sides).toEqual([{
@@ -509,7 +509,7 @@ describe('EditTournament', () => {
             const dialog = sides.querySelector('.modal-dialog')!;
             expect(dialog).toBeTruthy();
             await doChange(sideElement, 'input[name="name"]', 'NEW SIDE 1', context.user);
-            await doClick(findButton(dialog, 'Save'));
+            await doClick(findButton(dialog, 'Update'));
 
             reportedError.verifyNoError();
             expect(updatedData!.round!.matches![0]).toEqual({
@@ -551,7 +551,7 @@ describe('EditTournament', () => {
             const dialog = sides.querySelector('.modal-dialog')!;
             expect(dialog).toBeTruthy();
             await doChange(sideElement, 'input[name="name"]', 'NEW SIDE 1', context.user);
-            await doClick(findButton(dialog, 'Save'));
+            await doClick(findButton(dialog, 'Update'));
 
             reportedError.verifyNoError();
             expect(updatedData!.round!.matches![0]).toEqual({
@@ -593,7 +593,7 @@ describe('EditTournament', () => {
             const dialog = sides.querySelector('.modal-dialog')!;
             expect(dialog).toBeTruthy();
             await doChange(sideElement, 'input[name="name"]', 'NEW SIDE 1   ', context.user);
-            await doClick(findButton(dialog, 'Save'));
+            await doClick(findButton(dialog, 'Update'));
 
             reportedError.verifyNoError();
             expect(updatedData!.sides![0]).toEqual({

--- a/CourageScores/ClientApp/src/components/tournaments/EditTournament.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditTournament.test.tsx
@@ -158,66 +158,6 @@ describe('EditTournament', () => {
             const accolades = context.container.querySelector('div > div > table');
             expect(accolades).toBeFalsy();
         });
-
-        it('winning side from first round', async () => {
-            const side1 = sideBuilder('SIDE 1').build();
-            const anotherSide = sideBuilder('ANOTHER SIDE').build();
-            const tournamentData = tournamentBuilder()
-                .round((r: ITournamentRoundBuilder) => r
-                    .withMatch((m: ITournamentMatchBuilder) => m
-                        .sideA(side1, 1)
-                        .sideB(anotherSide, 2))
-                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3)))
-                .forSeason(season)
-                .withSide(side1)
-                .withSide(anotherSide)
-                .build();
-
-            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
-                disabled: true,
-                saving: false,
-                canSave: false,
-            }, account);
-
-            const playing = context.container.querySelector('div > div > div:nth-child(1)')!;
-            expect(playing.textContent).toEqual('Playing:');
-            const sides = context.container.querySelector('div > div > div:nth-child(2)')!;
-            const winningSide = sides.querySelector('.bg-winner');
-            expect(winningSide).toBeTruthy();
-            expect(winningSide!.textContent).toContain('ANOTHER SIDE');
-        });
-
-        it('winning side from second round', async () => {
-            const side1 = sideBuilder('SIDE 1').build();
-            const anotherSide = sideBuilder('ANOTHER SIDE').build();
-            const tournamentData = tournamentBuilder()
-                .round((r: ITournamentRoundBuilder) => r
-                    .withMatch((m: ITournamentMatchBuilder) => m
-                        .sideA(side1, 2)
-                        .sideB(anotherSide, 2))
-                    .round((r: ITournamentRoundBuilder) => r
-                        .withMatch((m: ITournamentMatchBuilder) => m
-                            .sideA(side1, 2)
-                            .sideB(anotherSide, 1))
-                        .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3))))
-                .forSeason(season)
-                .withSide(side1)
-                .withSide(anotherSide)
-                .build();
-
-            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
-                disabled: true,
-                saving: false,
-                canSave: false,
-            }, account);
-
-            const playing = context.container.querySelector('div > div > div:nth-child(1)')!;
-            expect(playing.textContent).toEqual('Playing:');
-            const sides = context.container.querySelector('div > div > div:nth-child(2)')!;
-            const winningSide = sides.querySelector('.bg-winner')!;
-            expect(winningSide).toBeTruthy();
-            expect(winningSide.textContent).toContain('SIDE 1');
-        });
     });
 
     describe('interactivity', () => {
@@ -368,72 +308,6 @@ describe('EditTournament', () => {
 
             reportedError.verifyNoError();
             expect(updatedData!.sides).toEqual([]);
-        });
-
-        it('updates side A data in rounds', async () => {
-            const side = sideBuilder('SIDE 1').teamId(team1.id).build();
-            const tournamentData = tournamentBuilder()
-                .forSeason(season)
-                .withSide(side)
-                .round((r: ITournamentRoundBuilder) => r
-                    .withMatch((m: ITournamentMatchBuilder) => m.sideA(side))
-                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3)))
-                .build();
-            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
-                disabled: false,
-                saving: false,
-                canSave: true,
-            }, account, [team1]);
-            const playing = context.container.querySelector('div > div > div:nth-child(1)')!;
-            expect(playing.textContent).toEqual('Playing:');
-            const sides = context.container.querySelector('div > div > div:nth-child(2)')!;
-            const sideElement = sides.querySelector('div')!;
-
-            await doClick(findButton(sideElement, '✏️'));
-            const dialog = sides.querySelector('.modal-dialog')!;
-            expect(dialog).toBeTruthy();
-            await doChange(sideElement, 'input[name="name"]', 'NEW SIDE 1', context.user);
-            await doClick(findButton(dialog, 'Update'));
-
-            reportedError.verifyNoError();
-            expect(updatedData!.round!.matches![0]).toEqual({
-                id: expect.any(String),
-                sideA: {id: side.id, name: 'NEW SIDE 1', teamId: team1.id, players: []},
-                sideB: null,
-            });
-        });
-
-        it('updates side B data in rounds', async () => {
-            const side = sideBuilder('SIDE 1').teamId(team1.id).build();
-            const tournamentData = tournamentBuilder()
-                .forSeason(season)
-                .withSide(side)
-                .round((r: ITournamentRoundBuilder) => r
-                    .withMatch((m: ITournamentMatchBuilder) => m.sideB(side))
-                    .withMatchOption((o: IMatchOptionsBuilder) => o.numberOfLegs(3)))
-                .build();
-            await renderComponent(containerProps.withTournament(tournamentData).withAlreadyPlaying({}).withAllPlayers([]).build(), {
-                disabled: false,
-                saving: false,
-                canSave: true,
-            }, account, [team1]);
-            const playing = context.container.querySelector('div > div > div:nth-child(1)')!;
-            expect(playing.textContent).toEqual('Playing:');
-            const sides = context.container.querySelector('div > div > div:nth-child(2)')!;
-            const sideElement = sides.querySelector('div')!;
-
-            await doClick(findButton(sideElement, '✏️'));
-            const dialog = sides.querySelector('.modal-dialog')!;
-            expect(dialog).toBeTruthy();
-            await doChange(sideElement, 'input[name="name"]', 'NEW SIDE 1', context.user);
-            await doClick(findButton(dialog, 'Update'));
-
-            reportedError.verifyNoError();
-            expect(updatedData!.round!.matches![0]).toEqual({
-                id: expect.any(String),
-                sideA: null,
-                sideB: {id: side.id, name: 'NEW SIDE 1', teamId: team1.id, players: []},
-            });
         });
 
         it('trims whitespace from end of edited side name', async () => {

--- a/CourageScores/ClientApp/src/components/tournaments/EditTournament.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditTournament.test.tsx
@@ -24,6 +24,7 @@ import {
 import {teamBuilder} from "../../helpers/builders/teams";
 import {divisionBuilder} from "../../helpers/builders/divisions";
 import {IMatchOptionsBuilder} from "../../helpers/builders/games";
+import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
 
 describe('EditTournament', () => {
     let context: TestContext;
@@ -40,6 +41,9 @@ describe('EditTournament', () => {
     }
 
     function setPreventScroll(_: boolean) {
+    }
+
+    async function setDraggingSide(_: TournamentSideDto) {
     }
 
     beforeEach(() => {
@@ -80,6 +84,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: true,
                 saving: false,
@@ -108,6 +113,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: true,
                 saving: false,
@@ -134,6 +140,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: true,
                 saving: false,
@@ -162,6 +169,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: true,
                 saving: false,
@@ -188,6 +196,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: true,
                 saving: false,
@@ -220,6 +229,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: true,
                 saving: false,
@@ -260,6 +270,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: true,
                 saving: false,
@@ -302,6 +313,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: false,
                 saving: false,
@@ -339,6 +351,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: false,
                 saving: false,
@@ -376,6 +389,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: false,
                 saving: false,
@@ -408,6 +422,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: false,
                 saving: false,
@@ -441,6 +456,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: false,
                 saving: false,
@@ -478,6 +494,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: false,
                 saving: false,
@@ -519,6 +536,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: false,
                 saving: false,
@@ -560,6 +578,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: false,
                 saving: false,
@@ -602,6 +621,7 @@ describe('EditTournament', () => {
                 setTournamentData,
                 preventScroll,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 disabled: false,
                 saving: false,

--- a/CourageScores/ClientApp/src/components/tournaments/EditTournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditTournament.tsx
@@ -21,7 +21,7 @@ export interface IEditTournamentProps {
 
 export function EditTournament({canSave, disabled, saving}: IEditTournamentProps) {
     const {account} = useApp();
-    const {tournamentData, setTournamentData} = useTournament();
+    const {tournamentData, setTournamentData, setDraggingSide} = useTournament();
     const isAdmin: boolean = hasAccess(account, access => access.manageTournaments);
     const readOnly: boolean = !isAdmin || !canSave || disabled || saving || false;
     const winningSideId: string | undefined = getWinningSide(tournamentData.round);
@@ -79,7 +79,8 @@ export function EditTournament({canSave, disabled, saving}: IEditTournamentProps
                         setNewSide(null);
                     }}
                     showEditSide={!tournamentData.singleRound}
-                    showDeleteSide={tournamentData.singleRound && !hasBeenSelected} />);
+                    showDeleteSide={tournamentData.singleRound && !hasBeenSelected}
+                    onStartDrag={hasBeenSelected ? undefined : setDraggingSide} />);
             })}
             {readOnly
                 ? null

--- a/CourageScores/ClientApp/src/components/tournaments/EditTournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditTournament.tsx
@@ -21,7 +21,7 @@ export interface IEditTournamentProps {
 
 export function EditTournament({canSave, disabled, saving}: IEditTournamentProps) {
     const {account} = useApp();
-    const {tournamentData, setTournamentData, setDraggingSide} = useTournament();
+    const {tournamentData, setTournamentData, setDraggingSide, newMatch} = useTournament();
     const isAdmin: boolean = hasAccess(account, access => access.manageTournaments);
     const readOnly: boolean = !isAdmin || !canSave || disabled || saving || false;
     const winningSideId: string | undefined = getWinningSide(tournamentData.round);
@@ -66,7 +66,12 @@ export function EditTournament({canSave, disabled, saving}: IEditTournamentProps
         <div>Playing:</div>
         <div className="my-1 d-flex flex-wrap">
             {tournamentData.sides!.sort(sortBy('name')).map((side: TournamentSideDto, sideIndex: number) => {
-                const hasBeenSelected = (tournamentData.round?.matches?.filter(m => m.sideA?.id === side.id || m.sideB?.id === side.id) || []).length > 0
+                const allMatches = (tournamentData.round?.matches || []).concat(newMatch);
+                const hasBeenSelected = (allMatches.filter(m => m.sideA?.id === side.id || m.sideB?.id === side.id) || []).length > 0
+
+                if (hasBeenSelected) {
+                    return null;
+                }
 
                 return (<TournamentSide
                     key={sideIndex}

--- a/CourageScores/ClientApp/src/components/tournaments/EditTournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditTournament.tsx
@@ -66,6 +66,8 @@ export function EditTournament({canSave, disabled, saving}: IEditTournamentProps
         <div>Playing:</div>
         <div className="my-1 d-flex flex-wrap">
             {tournamentData.sides!.sort(sortBy('name')).map((side: TournamentSideDto, sideIndex: number) => {
+                const hasBeenSelected = (tournamentData.round?.matches?.filter(m => m.sideA?.id === side.id || m.sideB?.id === side.id) || []).length > 0
+
                 return (<TournamentSide
                     key={sideIndex}
                     winner={winningSideId === side.id}
@@ -77,7 +79,7 @@ export function EditTournament({canSave, disabled, saving}: IEditTournamentProps
                         setNewSide(null);
                     }}
                     showEditSide={!tournamentData.singleRound}
-                    showDeleteSide={tournamentData.singleRound} />);
+                    showDeleteSide={tournamentData.singleRound && !hasBeenSelected} />);
             })}
             {readOnly
                 ? null

--- a/CourageScores/ClientApp/src/components/tournaments/EditTournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditTournament.tsx
@@ -6,10 +6,8 @@ import {useState} from "react";
 import {useApp} from "../common/AppContainer";
 import {useTournament} from "./TournamentContainer";
 import {EditSide, ISaveSideOptions} from "./EditSide";
-import {TournamentRoundDto} from "../../interfaces/models/dtos/Game/TournamentRoundDto";
 import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
-import {GameMatchOptionDto} from "../../interfaces/models/dtos/Game/GameMatchOptionDto";
 import {addSide, removeSide, sideChanged} from "./tournaments";
 import {hasAccess} from "../../helpers/conditions";
 
@@ -24,29 +22,7 @@ export function EditTournament({canSave, disabled, saving}: IEditTournamentProps
     const {tournamentData, setTournamentData, setDraggingSide, newMatch} = useTournament();
     const isAdmin: boolean = hasAccess(account, access => access.manageTournaments);
     const readOnly: boolean = !isAdmin || !canSave || disabled || saving || false;
-    const winningSideId: string | undefined = getWinningSide(tournamentData.round);
     const [newSide, setNewSide] = useState<TournamentSideDto | null>(null);
-
-    function getWinningSide(round?: TournamentRoundDto): string | undefined {
-        if (round && round.nextRound) {
-            return getWinningSide(round.nextRound);
-        }
-
-        if (round && round.matches && round.matches.length === 1) {
-            const match: TournamentMatchDto = round.matches[0];
-            const matchOptions: GameMatchOptionDto = round!.matchOptions![0];
-            const bestOf: number = matchOptions ? matchOptions.numberOfLegs! : 5;
-            if (match.scoreA !== null && match.scoreB !== null && match.sideA && match.sideB) {
-                if (match.scoreA! > (bestOf / 2.0)) {
-                    return match.sideA.id;
-                } else if (match.scoreB! > (bestOf / 2.0)) {
-                    return match.sideB.id;
-                } else {
-                    return undefined;
-                }
-            }
-        }
-    }
 
     function renderEditNewSide() {
         return (<EditSide
@@ -75,7 +51,6 @@ export function EditTournament({canSave, disabled, saving}: IEditTournamentProps
 
                 return (<TournamentSide
                     key={sideIndex}
-                    winner={winningSideId === side.id}
                     readOnly={readOnly}
                     side={side}
                     onChange={async (newSide: TournamentSideDto, options: ISaveSideOptions) => await setTournamentData!(sideChanged(tournamentData, newSide, sideIndex, options))}

--- a/CourageScores/ClientApp/src/components/tournaments/ITournament.ts
+++ b/CourageScores/ClientApp/src/components/tournaments/ITournament.ts
@@ -6,6 +6,7 @@ import {SeasonDto} from "../../interfaces/models/dtos/Season/SeasonDto";
 import {ISelectablePlayer} from "../common/PlayerSelection";
 import {UntypedPromise} from "../../interfaces/UntypedPromise";
 import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
+import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 export interface ITournament {
     tournamentData: TournamentGameDto;
@@ -24,4 +25,6 @@ export interface ITournament {
     setPreventScroll(prevent: boolean): void;
     draggingSide?: TournamentSideDto;
     setDraggingSide(side?: TournamentSideDto): UntypedPromise;
+    newMatch: TournamentMatchDto;
+    setNewMatch(match: TournamentMatchDto): UntypedPromise;
 }

--- a/CourageScores/ClientApp/src/components/tournaments/ITournament.ts
+++ b/CourageScores/ClientApp/src/components/tournaments/ITournament.ts
@@ -5,6 +5,7 @@ import {ITournamentPlayerMap} from "./Tournament";
 import {SeasonDto} from "../../interfaces/models/dtos/Season/SeasonDto";
 import {ISelectablePlayer} from "../common/PlayerSelection";
 import {UntypedPromise} from "../../interfaces/UntypedPromise";
+import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
 
 export interface ITournament {
     tournamentData: TournamentGameDto;
@@ -21,4 +22,6 @@ export interface ITournament {
     setEditTournament?(edit: string): UntypedPromise;
     preventScroll: boolean;
     setPreventScroll(prevent: boolean): void;
+    draggingSide?: TournamentSideDto;
+    setDraggingSide(side?: TournamentSideDto): UntypedPromise;
 }

--- a/CourageScores/ClientApp/src/components/tournaments/MatchSayg.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/MatchSayg.test.tsx
@@ -35,6 +35,7 @@ import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMa
 import {ENTER_SCORE_BUTTON} from "../../helpers/constants";
 import {checkoutWith, keyPad} from "../../helpers/sayg";
 import {START_SCORING} from "./tournaments";
+import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
 
 describe('MatchSayg', () => {
     let context: TestContext;
@@ -106,6 +107,9 @@ describe('MatchSayg', () => {
         scrollPrevented = prevent;
     }
 
+    async function setDraggingSide(_: TournamentSideDto) {
+    }
+
     afterEach(async () => {
         await cleanUp(context);
     });
@@ -151,6 +155,7 @@ describe('MatchSayg', () => {
             preventScroll: false,
             setPreventScroll,
             saveTournament,
+            setDraggingSide,
         };
     }
 
@@ -182,6 +187,7 @@ describe('MatchSayg', () => {
                 tournamentData,
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 match,
                 matchIndex: 0,
@@ -420,6 +426,7 @@ describe('MatchSayg', () => {
                 saveTournament,
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             }, {
                 match,
                 matchIndex: 0,

--- a/CourageScores/ClientApp/src/components/tournaments/MatchSayg.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/MatchSayg.test.tsx
@@ -110,6 +110,9 @@ describe('MatchSayg', () => {
     async function setDraggingSide(_: TournamentSideDto) {
     }
 
+    async function setNewMatch(_: TournamentMatchDto) {
+    }
+
     afterEach(async () => {
         await cleanUp(context);
     });
@@ -156,6 +159,8 @@ describe('MatchSayg', () => {
             setPreventScroll,
             saveTournament,
             setDraggingSide,
+            newMatch: {},
+            setNewMatch,
         };
     }
 
@@ -188,6 +193,8 @@ describe('MatchSayg', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 match,
                 matchIndex: 0,
@@ -427,6 +434,8 @@ describe('MatchSayg', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, {
                 match,
                 matchIndex: 0,

--- a/CourageScores/ClientApp/src/components/tournaments/MatchSayg.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/MatchSayg.test.tsx
@@ -35,7 +35,7 @@ import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMa
 import {ENTER_SCORE_BUTTON} from "../../helpers/constants";
 import {checkoutWith, keyPad} from "../../helpers/sayg";
 import {START_SCORING} from "./tournaments";
-import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
+import {tournamentContainerPropsBuilder} from "./tournamentContainerPropsBuilder";
 
 describe('MatchSayg', () => {
     let context: TestContext;
@@ -107,12 +107,6 @@ describe('MatchSayg', () => {
         scrollPrevented = prevent;
     }
 
-    async function setDraggingSide(_: TournamentSideDto) {
-    }
-
-    async function setNewMatch(_: TournamentMatchDto) {
-    }
-
     afterEach(async () => {
         await cleanUp(context);
     });
@@ -151,19 +145,6 @@ describe('MatchSayg', () => {
         };
     }
 
-    function containerProps(tournamentData: TournamentGameDto): ITournamentContainerProps {
-        return {
-            setTournamentData,
-            tournamentData,
-            preventScroll: false,
-            setPreventScroll,
-            saveTournament,
-            setDraggingSide,
-            newMatch: {},
-            setNewMatch,
-        };
-    }
-
     describe('renders', () => {
         const matchOptions = matchOptionsBuilder().build();
         const sideA = sideBuilder('SIDE A').withPlayer('PLAYER A').build();
@@ -176,6 +157,11 @@ describe('MatchSayg', () => {
         const permitted: UserDto = user(true);
         const sideAvsSideBMatch: TournamentMatchDto = tournamentMatchBuilder().sideA(sideA).sideB(sideB).saygId(createTemporaryId()).build();
         const sideAvsSideBRound = roundBuilder().withMatch(sideAvsSideBMatch).build();
+        const containerProps = new tournamentContainerPropsBuilder({
+            saveTournament,
+            setPreventScroll,
+            setTournamentData,
+        });
 
         it('shows no sayg links when no players', async () => {
             const match = tournamentMatchBuilder()
@@ -187,15 +173,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent({
-                setTournamentData,
-                tournamentData,
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -210,7 +188,7 @@ describe('MatchSayg', () => {
         it('shows no sayg links when no data and not logged in', async () => {
             const tournamentData = tournamentBuilder().round(sideAvsSideBRound).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match: sideAvsSideBMatch,
                 matchIndex: 0,
                 patchData,
@@ -225,7 +203,7 @@ describe('MatchSayg', () => {
         it('shows no sayg links when no data and not permitted', async () => {
             const tournamentData = tournamentBuilder().round(sideAvsSideBRound).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match: sideAvsSideBMatch,
                 matchIndex: 0,
                 patchData,
@@ -242,7 +220,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -259,7 +237,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -274,7 +252,7 @@ describe('MatchSayg', () => {
         it('shows view sayg link when data and not logged in', async () => {
             const tournamentData = tournamentBuilder().round(sideAvsSideBRound).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match: sideAvsSideBMatch,
                 matchIndex: 0,
                 patchData,
@@ -290,7 +268,7 @@ describe('MatchSayg', () => {
         it('shows view sayg link when data and not permitted', async () => {
             const tournamentData = tournamentBuilder().round(sideAvsSideBRound).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match: sideAvsSideBMatch,
                 matchIndex: 0,
                 patchData,
@@ -306,7 +284,7 @@ describe('MatchSayg', () => {
         it('does not show view sayg link when data and not permitted and not requested', async () => {
             const tournamentData = tournamentBuilder().round(sideAvsSideBRound).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match: sideAvsSideBMatch,
                 matchIndex: 0,
                 patchData,
@@ -321,7 +299,7 @@ describe('MatchSayg', () => {
         it('shows edit sayg link when data and permitted', async () => {
             const tournamentData = tournamentBuilder().round(sideAvsSideBRound).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match: sideAvsSideBMatch,
                 matchIndex: 0,
                 patchData,
@@ -335,7 +313,7 @@ describe('MatchSayg', () => {
         it('shows edit sayg link when no data but single round (superleague)', async () => {
             const tournamentData = tournamentBuilder().singleRound().round(sideAvsSideBRound).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match: sideAvsSideBMatch,
                 matchIndex: 0,
                 patchData,
@@ -349,7 +327,7 @@ describe('MatchSayg', () => {
         it('shows edit sayg link when no data and both sides have single players', async () => {
             const tournamentData = tournamentBuilder().round(sideAvsSideBRound).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match: sideAvsSideBMatch,
                 matchIndex: 0,
                 patchData,
@@ -365,7 +343,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -382,7 +360,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -405,6 +383,11 @@ describe('MatchSayg', () => {
         const pairB = sideBuilder('PAIR B').withPlayer('PLAYER B 1').withPlayer('PLAYER B 2').build();
         const permitted: UserDto = user(true);
         const permittedWithDebug: UserDto = user(true, true);
+        const containerProps = new tournamentContainerPropsBuilder({
+            saveTournament,
+            setPreventScroll,
+            setTournamentData,
+        });
 
         async function enterScore(score: number, noOfDarts?: number) {
             await keyPad(context, score.toString().split('').concat(ENTER_SCORE_BUTTON));
@@ -427,16 +410,8 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent({
-                setTournamentData,
-                tournamentData,
-                saveTournament,
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, {
+            await renderComponent(
+                containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -463,7 +438,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -481,7 +456,7 @@ describe('MatchSayg', () => {
             const match = tournamentMatchBuilder().noId().sideA(sideA).sideB(sideB).build();
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -502,7 +477,7 @@ describe('MatchSayg', () => {
             const match = tournamentMatchBuilder().sideA(sideA).sideB(sideB).build();
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -525,7 +500,7 @@ describe('MatchSayg', () => {
             const match = tournamentMatchBuilder().sideA(sideA).sideB(sideB).build();
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -551,7 +526,7 @@ describe('MatchSayg', () => {
             const match = tournamentMatchBuilder().sideA(sideA).sideB(sideB).build();
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -579,7 +554,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -623,7 +598,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -663,7 +638,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -688,7 +663,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -893,7 +868,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -928,7 +903,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,
@@ -973,7 +948,7 @@ describe('MatchSayg', () => {
             const round = roundBuilder().withMatch(match).build();
             const tournamentData = tournamentBuilder().round(round).build();
 
-            await renderComponent(containerProps(tournamentData), {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 match,
                 matchIndex: 0,
                 patchData,

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
@@ -31,6 +31,7 @@ import {seasonBuilder} from "../../helpers/builders/seasons";
 import {divisionBuilder} from "../../helpers/builders/divisions";
 import {IAppContainerProps} from "../common/AppContainer";
 import {UserDto} from "../../interfaces/models/dtos/Identity/UserDto";
+import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 interface ISideInfo {
     sideAwinner?: boolean;
@@ -72,6 +73,9 @@ describe('PrintableSheet', () => {
     }
 
     async function setDraggingSide(_: TournamentSideDto) {
+    }
+
+    async function setNewMatch(_: TournamentMatchDto) {
     }
 
     async function renderComponent(containerProps: ITournamentContainerProps, props: IPrintableSheetProps, appProps: IAppContainerProps) {

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
@@ -804,7 +804,7 @@ describe('PrintableSheet', () => {
             await doClick(playing.querySelector('li')!);
             const dialog = context.container.querySelector('div.modal-dialog')!;
             await doChange(dialog, 'input[name="name"]', 'NEW SIDE A', context.user);
-            await doClick(findButton(dialog, 'Save'));
+            await doClick(findButton(dialog, 'Update'));
 
             expect(updatedTournament).not.toBeNull();
             expect(updatedTournament!.sides!.map((s: TournamentSideDto) => s.name))
@@ -845,7 +845,7 @@ describe('PrintableSheet', () => {
             const dialog = context.container.querySelector('div.modal-dialog')!;
             await doChange(dialog, 'input[name="name"]', 'NEW SIDE', context.user);
             await doClick(dialog.querySelector('.list-group li.list-group-item:not(.disabled)')!); // select a player
-            await doClick(findButton(dialog, 'Save'));
+            await doClick(findButton(dialog, 'Add'));
 
             expect(updatedTournament).not.toBeNull();
             expect(updatedTournament!.sides!.map((s: TournamentSideDto) => s.name))
@@ -1031,7 +1031,7 @@ describe('PrintableSheet', () => {
             const dialog = context.container.querySelector('div.modal-dialog')!;
             await doChange(dialog, 'input[name="name"]', 'NEW SIDE', context.user);
             await doClick(dialog.querySelector('.list-group li.list-group-item')!); // select a player
-            await doClick(findButton(dialog, 'Save'));
+            await doClick(findButton(dialog, 'Add'));
 
             expect(updatedTournament).not.toBeNull();
             expect(updatedTournament!.sides!.map((s: TournamentSideDto) => s.name)).toEqual(['NEW SIDE']);

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
@@ -31,7 +31,7 @@ import {seasonBuilder} from "../../helpers/builders/seasons";
 import {divisionBuilder} from "../../helpers/builders/divisions";
 import {IAppContainerProps} from "../common/AppContainer";
 import {UserDto} from "../../interfaces/models/dtos/Identity/UserDto";
-import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
+import {tournamentContainerPropsBuilder} from "./tournamentContainerPropsBuilder";
 
 interface ISideInfo {
     sideAwinner?: boolean;
@@ -67,15 +67,6 @@ describe('PrintableSheet', () => {
 
     async function setEditTournament(value: string) {
         editTournament = value;
-    }
-
-    function setPreventScroll(_: boolean) {
-    }
-
-    async function setDraggingSide(_: TournamentSideDto) {
-    }
-
-    async function setNewMatch(_: TournamentMatchDto) {
     }
 
     async function renderComponent(containerProps: ITournamentContainerProps, props: IPrintableSheetProps, appProps: IAppContainerProps) {
@@ -255,6 +246,13 @@ describe('PrintableSheet', () => {
             .build();
         let twoRoundTournament4Sides: TournamentGameDto;
         let oneRoundTournament2Sides: TournamentGameDto;
+        const containerProps = new tournamentContainerPropsBuilder({
+            season,
+            division,
+            matchOptionDefaults,
+            setTournamentData,
+            setEditTournament,
+        });
 
         beforeEach(() => {
             twoRoundTournament4Sides = tournamentBuilder()
@@ -282,7 +280,7 @@ describe('PrintableSheet', () => {
 
         it('renders tournament with one round', async () => {
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -298,7 +296,7 @@ describe('PrintableSheet', () => {
             oneRoundTournament2Sides.round!.matches![0].saygId = saygId;
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -322,7 +320,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(tournamentData).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -342,7 +340,7 @@ describe('PrintableSheet', () => {
 
         it('renders tournament with 2 rounds', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(twoRoundTournament4Sides).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -374,7 +372,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(tournamentData).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -426,7 +424,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(tournamentData).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -459,7 +457,7 @@ describe('PrintableSheet', () => {
             oneRoundTournament2Sides.round!.matchOptions![0].numberOfLegs = 5;
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).build(),
                 {},
                 appProps({ teams: [player2Team], divisions: [division] }, reportedError));
 
@@ -491,7 +489,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(tournamentData).build(),
                 {},
                 appProps({teams: [player2Team], divisions: [division]}, reportedError));
 
@@ -502,7 +500,7 @@ describe('PrintableSheet', () => {
 
         it('renders winner', async () => {
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).build(),
                 {},
                 appProps({ teams: [player2Team], divisions: [division] }, reportedError));
 
@@ -513,7 +511,7 @@ describe('PrintableSheet', () => {
 
         it('renders winner when cross-divisional', async () => {
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).build(),
                 {},
                 appProps({ teams: [player2Team], divisions: [division] }, reportedError));
 
@@ -524,7 +522,7 @@ describe('PrintableSheet', () => {
 
         it('renders who is playing (singles)', async () => {
             await renderComponent(
-                {tournamentData: singlePlayerTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(singlePlayerTournament).build(),
                 {},
                 appProps({ teams: [player1Team], divisions: [division] }, reportedError));
 
@@ -538,7 +536,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData: singlePlayerTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(singlePlayerTournament).build(),
                 {},
                 appProps({ teams: [team], divisions: [division] }, reportedError));
 
@@ -558,7 +556,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(tournamentData).build(),
                 {},
                 appProps({ teams: [noPlayerTeam], divisions: [division] }, reportedError));
 
@@ -570,7 +568,7 @@ describe('PrintableSheet', () => {
 
         it('renders who is playing when cross-divisional', async () => {
             await renderComponent(
-                {tournamentData: singlePlayerTournament, season: anotherSeason, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(singlePlayerTournament).build(),
                 {},
                 appProps({ teams: [noPlayerTeam], divisions: [division] }, reportedError));
 
@@ -584,7 +582,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData: singlePlayerTournament, season, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(singlePlayerTournament).build(),
                 {},
                 appProps({ teams: [team], divisions: [division] }, reportedError));
 
@@ -596,7 +594,7 @@ describe('PrintableSheet', () => {
             oneRoundTournament2Sides.sides!.push(sideBuilder('C').noShow().build());
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).build(),
                 {},
                 appProps({ teams: [], divisions: [division] }, reportedError));
 
@@ -613,7 +611,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(tournamentData).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -624,7 +622,7 @@ describe('PrintableSheet', () => {
         it('renders 180s', async () => {
             oneRoundTournament2Sides.oneEighties!.push(player1, player2, player1, player1);
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).build(),
                 {},
                 appProps({ teams: [player1Team], divisions: [division] }, reportedError));
 
@@ -636,7 +634,7 @@ describe('PrintableSheet', () => {
         it('renders 180s when cross-divisional', async () => {
             oneRoundTournament2Sides.oneEighties!.push(player1, player2, player1, player1);
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).build(),
                 {},
                 appProps({ teams: [player1Team], divisions: [division] }, reportedError));
 
@@ -651,7 +649,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).build(),
                 {},
                 appProps({ teams: [team], divisions: [division] }, reportedError));
 
@@ -665,7 +663,7 @@ describe('PrintableSheet', () => {
             oneRoundTournament2Sides.over100Checkouts!.push(Object.assign({}, player2, {score: 120}));
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).build(),
                 {},
                 appProps({ teams: [player1Team], divisions: [division] }, reportedError));
 
@@ -679,7 +677,7 @@ describe('PrintableSheet', () => {
             oneRoundTournament2Sides.over100Checkouts!.push(Object.assign({}, player2, {score: 120}));
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).build(),
                 {},
                 appProps({ teams: [player1Team], divisions: [division] }, reportedError));
 
@@ -689,7 +687,7 @@ describe('PrintableSheet', () => {
 
         it('cannot set match side a when not permitted', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(twoRoundTournament4Sides).build(),
                 {editable: false},
                 appProps({}, reportedError));
 
@@ -701,7 +699,7 @@ describe('PrintableSheet', () => {
         it('can edit match side a', async () => {
             twoRoundTournament4Sides.sides!.push(sideE);
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(twoRoundTournament4Sides).build(),
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -718,7 +716,7 @@ describe('PrintableSheet', () => {
 
         it('can remove match side a', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(twoRoundTournament4Sides).build(),
                 {editable: true},
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideA"]')!);
@@ -733,7 +731,7 @@ describe('PrintableSheet', () => {
         it('can edit match side b', async () => {
             twoRoundTournament4Sides.sides!.push(sideE);
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(twoRoundTournament4Sides).build(),
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -750,7 +748,7 @@ describe('PrintableSheet', () => {
 
         it('can remove match side b', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(twoRoundTournament4Sides).build(),
                 {editable: true},
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideB"]')!);
@@ -764,7 +762,7 @@ describe('PrintableSheet', () => {
 
         it('can edit 180s', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(twoRoundTournament4Sides).withAllPlayers([player1]).build(),
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -781,7 +779,7 @@ describe('PrintableSheet', () => {
 
         it('can edit hi checks', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(twoRoundTournament4Sides).withAllPlayers([player1]).build(),
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -800,7 +798,7 @@ describe('PrintableSheet', () => {
         it('can edit side', async () => {
             sideA.players = [ player1 ];
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(twoRoundTournament4Sides).withAllPlayers([player1]).build(),
                 {editable: true},
                 appProps({account}, reportedError));
 
@@ -817,7 +815,7 @@ describe('PrintableSheet', () => {
 
         it('can close edit side dialog', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(twoRoundTournament4Sides).withAllPlayers([player1]).build(),
                 {editable: true},
                 appProps({account}, reportedError));
 
@@ -841,7 +839,7 @@ describe('PrintableSheet', () => {
                 .forSeason(season, division, [player3])
                 .build();
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1, player2, player3], alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(tournamentData).withAllPlayers([player1, player2, player3]).withAlreadyPlaying({}).build(),
                 {editable: true},
                 appProps({account, teams: [player1Team, player2Team, player3Team]}, reportedError));
             await doClick(context.container.querySelector('li[datatype="add-side"]')!);
@@ -858,7 +856,7 @@ describe('PrintableSheet', () => {
 
         it('can remove a side', async () => {
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(oneRoundTournament2Sides).withAlreadyPlaying({}).build(),
                 {editable: true},
                 appProps({account}, reportedError));
             context.prompts.respondToConfirm('Are you sure you want to remove A?', true);
@@ -897,10 +895,17 @@ describe('PrintableSheet', () => {
             .withSide(sideA)
             .withSide(sideB)
             .build();
+        const containerProps = new tournamentContainerPropsBuilder({
+            season,
+            division,
+            matchOptionDefaults,
+            setTournamentData,
+            setEditTournament,
+        });
 
         it('renders tournament with 2 sides', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(sideAandBTournament).withAlreadyPlaying({}).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -922,7 +927,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(tournamentData).withAlreadyPlaying({}).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -938,7 +943,7 @@ describe('PrintableSheet', () => {
 
         it('renders who is playing', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(sideAandBTournament).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -947,7 +952,7 @@ describe('PrintableSheet', () => {
 
         it('renders who is playing when cross-divisional', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(sideAandBTournament).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -963,7 +968,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(tournamentData).build(),
                 {},
                 appProps({}, reportedError));
 
@@ -973,7 +978,7 @@ describe('PrintableSheet', () => {
 
         it('can set match side a', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(sideAandBTournament).build(),
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -990,7 +995,7 @@ describe('PrintableSheet', () => {
 
         it('can set match side b', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(sideAandBTournament).build(),
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -1014,7 +1019,7 @@ describe('PrintableSheet', () => {
                 .withSide(noShowSide)
                 .build();
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(tournamentData).build(),
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -1027,7 +1032,7 @@ describe('PrintableSheet', () => {
 
         it('can add a side', async () => {
             await renderComponent(
-                {tournamentData: emptyTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(emptyTournament).withAlreadyPlaying({}).withAllPlayers([player1]).build(),
                 {editable: true},
                 appProps({teams: [player1Team], account}, reportedError));
 
@@ -1043,7 +1048,7 @@ describe('PrintableSheet', () => {
 
         it('can add sides from hint', async () => {
             await renderComponent(
-                {tournamentData: emptyTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(emptyTournament).withAlreadyPlaying({}).withAllPlayers([player1]).build(),
                 {editable: true},
                 appProps({teams: [player1Team], account}, reportedError));
 
@@ -1054,7 +1059,7 @@ describe('PrintableSheet', () => {
 
         it('does not show add sides hint when some sides', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(sideAandBTournament).withAlreadyPlaying({}).withAllPlayers([player1]).build(),
                 {editable: true},
                 appProps({teams: [player1Team], account}, reportedError));
 
@@ -1063,7 +1068,7 @@ describe('PrintableSheet', () => {
 
         it('can close add a side dialog', async () => {
             await renderComponent(
-                {tournamentData: emptyTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(emptyTournament).withAlreadyPlaying({}).withAllPlayers([player1]).build(),
                 {editable: true},
                 appProps({teams: [player1Team], account}, reportedError));
 
@@ -1077,7 +1082,7 @@ describe('PrintableSheet', () => {
 
         it('can remove a side', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(sideAandBTournament).build(),
                 {editable: true},
                 appProps({account}, reportedError));
             context.prompts.respondToConfirm('Are you sure you want to remove A?', true);
@@ -1102,10 +1107,17 @@ describe('PrintableSheet', () => {
         const tournamentData: TournamentGameDto = tournamentBuilder()
             .round((r: ITournamentRoundBuilder) => r)
             .build();
+        const containerProps = new tournamentContainerPropsBuilder({
+            season,
+            division,
+            matchOptionDefaults,
+            setTournamentData,
+            setEditTournament,
+        });
 
         it('can edit tournament when permitted', async () => {
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}, setEditTournament, preventScroll: false, setPreventScroll, setDraggingSide},
+                containerProps.withTournament(tournamentData).withAlreadyPlaying({}).build(),
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -1115,8 +1127,10 @@ describe('PrintableSheet', () => {
         });
 
         it('cannot edit tournament when not permitted', async () => {
+            const readonlyContainerProps = containerProps.withTournament(tournamentData).withAlreadyPlaying({}).build();
+            readonlyContainerProps.setEditTournament = undefined;
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
+                readonlyContainerProps,
                 {editable: true},
                 appProps({}, reportedError));
 

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.test.tsx
@@ -71,6 +71,9 @@ describe('PrintableSheet', () => {
     function setPreventScroll(_: boolean) {
     }
 
+    async function setDraggingSide(_: TournamentSideDto) {
+    }
+
     async function renderComponent(containerProps: ITournamentContainerProps, props: IPrintableSheetProps, appProps: IAppContainerProps) {
         context = await renderApp(
             iocProps(),
@@ -275,7 +278,7 @@ describe('PrintableSheet', () => {
 
         it('renders tournament with one round', async () => {
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -291,7 +294,7 @@ describe('PrintableSheet', () => {
             oneRoundTournament2Sides.round!.matches![0].saygId = saygId;
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -315,7 +318,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -335,7 +338,7 @@ describe('PrintableSheet', () => {
 
         it('renders tournament with 2 rounds', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -367,7 +370,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -419,7 +422,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -452,7 +455,7 @@ describe('PrintableSheet', () => {
             oneRoundTournament2Sides.round!.matchOptions![0].numberOfLegs = 5;
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [player2Team], divisions: [division] }, reportedError));
 
@@ -484,7 +487,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({teams: [player2Team], divisions: [division]}, reportedError));
 
@@ -495,7 +498,7 @@ describe('PrintableSheet', () => {
 
         it('renders winner', async () => {
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [player2Team], divisions: [division] }, reportedError));
 
@@ -506,7 +509,7 @@ describe('PrintableSheet', () => {
 
         it('renders winner when cross-divisional', async () => {
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [player2Team], divisions: [division] }, reportedError));
 
@@ -517,7 +520,7 @@ describe('PrintableSheet', () => {
 
         it('renders who is playing (singles)', async () => {
             await renderComponent(
-                {tournamentData: singlePlayerTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: singlePlayerTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [player1Team], divisions: [division] }, reportedError));
 
@@ -531,7 +534,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData: singlePlayerTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: singlePlayerTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [team], divisions: [division] }, reportedError));
 
@@ -551,7 +554,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [noPlayerTeam], divisions: [division] }, reportedError));
 
@@ -563,7 +566,7 @@ describe('PrintableSheet', () => {
 
         it('renders who is playing when cross-divisional', async () => {
             await renderComponent(
-                {tournamentData: singlePlayerTournament, season: anotherSeason, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: singlePlayerTournament, season: anotherSeason, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [noPlayerTeam], divisions: [division] }, reportedError));
 
@@ -577,7 +580,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData: singlePlayerTournament, season, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: singlePlayerTournament, season, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [team], divisions: [division] }, reportedError));
 
@@ -589,7 +592,7 @@ describe('PrintableSheet', () => {
             oneRoundTournament2Sides.sides!.push(sideBuilder('C').noShow().build());
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [], divisions: [division] }, reportedError));
 
@@ -606,7 +609,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -617,7 +620,7 @@ describe('PrintableSheet', () => {
         it('renders 180s', async () => {
             oneRoundTournament2Sides.oneEighties!.push(player1, player2, player1, player1);
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [player1Team], divisions: [division] }, reportedError));
 
@@ -629,7 +632,7 @@ describe('PrintableSheet', () => {
         it('renders 180s when cross-divisional', async () => {
             oneRoundTournament2Sides.oneEighties!.push(player1, player2, player1, player1);
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [player1Team], divisions: [division] }, reportedError));
 
@@ -644,7 +647,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [team], divisions: [division] }, reportedError));
 
@@ -658,7 +661,7 @@ describe('PrintableSheet', () => {
             oneRoundTournament2Sides.over100Checkouts!.push(Object.assign({}, player2, {score: 120}));
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [player1Team], divisions: [division] }, reportedError));
 
@@ -672,7 +675,7 @@ describe('PrintableSheet', () => {
             oneRoundTournament2Sides.over100Checkouts!.push(Object.assign({}, player2, {score: 120}));
 
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({ teams: [player1Team], divisions: [division] }, reportedError));
 
@@ -682,7 +685,7 @@ describe('PrintableSheet', () => {
 
         it('cannot set match side a when not permitted', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll},
+                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: false},
                 appProps({}, reportedError));
 
@@ -694,7 +697,7 @@ describe('PrintableSheet', () => {
         it('can edit match side a', async () => {
             twoRoundTournament4Sides.sides!.push(sideE);
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll},
+                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -711,7 +714,7 @@ describe('PrintableSheet', () => {
 
         it('can remove match side a', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll},
+                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideA"]')!);
@@ -726,7 +729,7 @@ describe('PrintableSheet', () => {
         it('can edit match side b', async () => {
             twoRoundTournament4Sides.sides!.push(sideE);
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll},
+                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -743,7 +746,7 @@ describe('PrintableSheet', () => {
 
         it('can remove match side b', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll},
+                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideB"]')!);
@@ -757,7 +760,7 @@ describe('PrintableSheet', () => {
 
         it('can edit 180s', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll},
+                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -774,7 +777,7 @@ describe('PrintableSheet', () => {
 
         it('can edit hi checks', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll},
+                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -793,7 +796,7 @@ describe('PrintableSheet', () => {
         it('can edit side', async () => {
             sideA.players = [ player1 ];
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll},
+                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({account}, reportedError));
 
@@ -810,7 +813,7 @@ describe('PrintableSheet', () => {
 
         it('can close edit side dialog', async () => {
             await renderComponent(
-                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll},
+                {tournamentData: twoRoundTournament4Sides, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({account}, reportedError));
 
@@ -834,7 +837,7 @@ describe('PrintableSheet', () => {
                 .forSeason(season, division, [player3])
                 .build();
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1, player2, player3], alreadyPlaying: {}, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1, player2, player3], alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({account, teams: [player1Team, player2Team, player3Team]}, reportedError));
             await doClick(context.container.querySelector('li[datatype="add-side"]')!);
@@ -851,7 +854,7 @@ describe('PrintableSheet', () => {
 
         it('can remove a side', async () => {
             await renderComponent(
-                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}, preventScroll: false, setPreventScroll},
+                {tournamentData: oneRoundTournament2Sides, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({account}, reportedError));
             context.prompts.respondToConfirm('Are you sure you want to remove A?', true);
@@ -893,7 +896,7 @@ describe('PrintableSheet', () => {
 
         it('renders tournament with 2 sides', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -915,7 +918,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -931,7 +934,7 @@ describe('PrintableSheet', () => {
 
         it('renders who is playing', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -940,7 +943,7 @@ describe('PrintableSheet', () => {
 
         it('renders who is playing when cross-divisional', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData: sideAandBTournament, season, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -956,7 +959,7 @@ describe('PrintableSheet', () => {
                 .build();
 
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, matchOptionDefaults, preventScroll: false, setPreventScroll, setDraggingSide},
                 {},
                 appProps({}, reportedError));
 
@@ -966,7 +969,7 @@ describe('PrintableSheet', () => {
 
         it('can set match side a', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll},
+                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -983,7 +986,7 @@ describe('PrintableSheet', () => {
 
         it('can set match side b', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll},
+                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -1007,7 +1010,7 @@ describe('PrintableSheet', () => {
                 .withSide(noShowSide)
                 .build();
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -1020,7 +1023,7 @@ describe('PrintableSheet', () => {
 
         it('can add a side', async () => {
             await renderComponent(
-                {tournamentData: emptyTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll},
+                {tournamentData: emptyTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({teams: [player1Team], account}, reportedError));
 
@@ -1036,7 +1039,7 @@ describe('PrintableSheet', () => {
 
         it('can add sides from hint', async () => {
             await renderComponent(
-                {tournamentData: emptyTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll},
+                {tournamentData: emptyTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({teams: [player1Team], account}, reportedError));
 
@@ -1047,7 +1050,7 @@ describe('PrintableSheet', () => {
 
         it('does not show add sides hint when some sides', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll},
+                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({teams: [player1Team], account}, reportedError));
 
@@ -1056,7 +1059,7 @@ describe('PrintableSheet', () => {
 
         it('can close add a side dialog', async () => {
             await renderComponent(
-                {tournamentData: emptyTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll},
+                {tournamentData: emptyTournament, season, division, matchOptionDefaults, setTournamentData, allPlayers: [player1], alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({teams: [player1Team], account}, reportedError));
 
@@ -1070,7 +1073,7 @@ describe('PrintableSheet', () => {
 
         it('can remove a side', async () => {
             await renderComponent(
-                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll},
+                {tournamentData: sideAandBTournament, season, division, matchOptionDefaults, setTournamentData, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({account}, reportedError));
             context.prompts.respondToConfirm('Are you sure you want to remove A?', true);
@@ -1098,7 +1101,7 @@ describe('PrintableSheet', () => {
 
         it('can edit tournament when permitted', async () => {
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}, setEditTournament, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}, setEditTournament, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({}, reportedError));
 
@@ -1109,7 +1112,7 @@ describe('PrintableSheet', () => {
 
         it('cannot edit tournament when not permitted', async () => {
             await renderComponent(
-                {tournamentData, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}, preventScroll: false, setPreventScroll},
+                {tournamentData, season, division, matchOptionDefaults, setTournamentData, alreadyPlaying: {}, preventScroll: false, setPreventScroll, setDraggingSide},
                 {editable: true},
                 appProps({}, reportedError));
 

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheetMatch.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheetMatch.test.tsx
@@ -89,6 +89,9 @@ describe('PrintableSheetMatch', () => {
     function setPreventScroll(_: boolean) {
     }
 
+    async function setDraggingSide(_: TournamentSideDto) {
+    }
+
     async function renderComponent(containerProps: ITournamentContainerProps, props: IPrintableSheetMatchProps, appProps: IAppContainerProps) {
         context = await renderApp(
             iocProps({saygApi, tournamentApi}),
@@ -108,7 +111,8 @@ describe('PrintableSheetMatch', () => {
             setPreventScroll,
             async saveTournament(): Promise<TournamentGameDto> {
                 return tournamentData;
-            }
+            },
+            setDraggingSide,
         };
     }
 

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheetMatch.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheetMatch.test.tsx
@@ -35,7 +35,7 @@ import {START_SCORING} from "./tournaments";
 import {ITournamentGameApi} from "../../interfaces/apis/ITournamentGameApi";
 import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
 import {TournamentRoundDto} from "../../interfaces/models/dtos/Game/TournamentRoundDto";
-import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
+import {tournamentContainerPropsBuilder} from "./tournamentContainerPropsBuilder";
 
 describe('PrintableSheetMatch', () => {
     let context: TestContext;
@@ -87,15 +87,6 @@ describe('PrintableSheetMatch', () => {
         updatedTournament = update;
     }
 
-    function setPreventScroll(_: boolean) {
-    }
-
-    async function setDraggingSide(_: TournamentSideDto) {
-    }
-
-    async function setNewMatch(_: TournamentMatchDto) {
-    }
-
     async function renderComponent(containerProps: ITournamentContainerProps, props: IPrintableSheetMatchProps, appProps: IAppContainerProps) {
         context = await renderApp(
             iocProps({saygApi, tournamentApi}),
@@ -104,22 +95,8 @@ describe('PrintableSheetMatch', () => {
             (<TournamentContainer {...containerProps}>
                 <PrintableSheetMatch {...props} />
             </TournamentContainer>));
-    }
 
-    function containerProps(tournamentData: TournamentGameDto, matchOptionDefaults: GameMatchOptionDto): ITournamentContainerProps {
-        return {
-            tournamentData,
-            setTournamentData,
-            matchOptionDefaults,
-            preventScroll: false,
-            setPreventScroll,
-            async saveTournament(): Promise<TournamentGameDto> {
-                return tournamentData;
-            },
-            setDraggingSide,
-            newMatch: {},
-            setNewMatch,
-        };
+        reportedError.verifyNoError();
     }
 
     function props(matchData: ILayoutDataForMatch, editable?: boolean, ...possibleSides: TournamentSideDto[]): IPrintableSheetMatchProps {
@@ -162,6 +139,13 @@ describe('PrintableSheetMatch', () => {
     describe('renders', () => {
         const matchOptionDefaults: GameMatchOptionDto = matchOptionsBuilder().build();
         const tournamentData: TournamentGameDto = tournamentBuilder().build();
+        const containerProps = new tournamentContainerPropsBuilder({
+            matchOptionDefaults,
+            async saveTournament(): Promise<TournamentGameDto> {
+                return tournamentData;
+            },
+            setTournamentData,
+        });
 
         it('match mnemonic', async () => {
             const matchData: ILayoutDataForMatch = {
@@ -172,7 +156,7 @@ describe('PrintableSheetMatch', () => {
                 mnemonic: 'M1',
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData),
                 appProps({}, reportedError));
 
@@ -191,7 +175,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData),
                 appProps({}, reportedError));
 
@@ -209,7 +193,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData),
                 appProps({}, reportedError));
 
@@ -229,7 +213,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData),
                 appProps({}, reportedError));
 
@@ -249,6 +233,13 @@ describe('PrintableSheetMatch', () => {
         let saygData: RecordedScoreAsYouGoDto & UpdateRecordedScoreAsYouGoDto;
         let matchData: ILayoutDataForMatch;
         let tournamentDataWithMatch: TournamentGameDto;
+        const containerProps = new tournamentContainerPropsBuilder({
+            matchOptionDefaults,
+            async saveTournament(): Promise<TournamentGameDto> {
+                return tournamentData;
+            },
+            setTournamentData,
+        });
 
         beforeEach(() => {
              saygData = saygBuilder()
@@ -280,7 +271,7 @@ describe('PrintableSheetMatch', () => {
 
         it('can change side and score for sideA', async () => {
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true, sideA, sideB, sideC),
                 appProps({}, reportedError));
             const side = context.container.querySelector('div[datatype="sideA"]')!;
@@ -308,7 +299,7 @@ describe('PrintableSheetMatch', () => {
 
         it('can change side and score for sideB', async () => {
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true, sideA, sideB, sideC),
                 appProps({}, reportedError));
             const side = context.container.querySelector('div[datatype="sideB"]')!;
@@ -350,7 +341,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true, sideA, sideB, sideC),
                 appProps({}, reportedError));
             const side = context.container.querySelector('div[datatype="sideB"]')!;
@@ -389,7 +380,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true, sideA, sideB, sideC),
                 appProps({}, reportedError));
             const side = context.container.querySelector('div[datatype="sideB"]')!;
@@ -418,7 +409,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 withRoundIndex(props(nestedMatchData, true), 1),
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideB"]')!);
@@ -442,7 +433,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 withRoundIndex(props(nestedMatchData, true, sideA, sideB), 1),
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideB"]')!);
@@ -473,7 +464,7 @@ describe('PrintableSheetMatch', () => {
         it('preselects side to mnemonic', async () => {
             matchData.sideA.mnemonic = sideC.name;
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true, sideA, sideB, sideC),
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideA"]')!);
@@ -499,7 +490,7 @@ describe('PrintableSheetMatch', () => {
 
         it('cannot save side when no side selected', async () => {
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true, sideA, sideB, sideC),
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideA"]')!);
@@ -521,7 +512,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, false),
                 appProps({}, reportedError));
             const sideB = context.container.querySelector('div[datatype="sideA"]')!;
@@ -542,7 +533,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true),
                 appProps({}, reportedError));
 
@@ -562,7 +553,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, false),
                 appProps({}, reportedError));
 
@@ -582,7 +573,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true),
                 appProps({}, reportedError));
 
@@ -608,7 +599,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true),
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideA"]')!);
@@ -649,7 +640,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true),
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideB"]')!);
@@ -689,7 +680,7 @@ describe('PrintableSheetMatch', () => {
                 hideMnemonic: true,
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true),
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideB"]')!);
@@ -705,7 +696,7 @@ describe('PrintableSheetMatch', () => {
         it('shows layout match options number of legs when present', async () => {
             matchData.matchOptions = matchOptionsBuilder().numberOfLegs(9).build();
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true, sideA, sideB, sideC),
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideB"]')!);
@@ -719,7 +710,7 @@ describe('PrintableSheetMatch', () => {
 
         it('shows default match options number of legs when match options not present', async () => {
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 props(matchData, true, sideA, sideB, sideC),
                 appProps({}, reportedError));
             await doClick(context.container.querySelector('div[datatype="sideB"]')!);
@@ -757,7 +748,7 @@ describe('PrintableSheetMatch', () => {
                 match: tournamentData.round!.matches![0],
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 patchable(props(matchData, true)),
                 appProps({ account: user(true) }, reportedError));
 
@@ -808,7 +799,7 @@ describe('PrintableSheetMatch', () => {
                 match: tournamentData!.round!.matches![0],
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 patchable(withRoundIndex(props(matchData, true), 1)),
                 appProps({ account: user(true) }, reportedError));
 
@@ -852,7 +843,7 @@ describe('PrintableSheetMatch', () => {
                 match: tournamentData!.round!.matches![0],
             };
             await renderComponent(
-                containerProps(tournamentData, matchOptionDefaults),
+                containerProps.withTournament(tournamentData).build(),
                 patchable(props(matchData, true)),
                 appProps({ }, reportedError));
 
@@ -870,7 +861,7 @@ describe('PrintableSheetMatch', () => {
                 match: tournamentDataWithMatch!.round!.matches![0],
             };
             await renderComponent(
-                containerProps(tournamentDataWithMatch, matchOptionDefaults),
+                containerProps.withTournament(tournamentDataWithMatch).build(),
                 patchable(props(matchData, true)),
                 appProps({ }, reportedError));
 
@@ -897,7 +888,7 @@ describe('PrintableSheetMatch', () => {
                 saygId: saygData.id,
             };
             await renderComponent(
-                containerProps(tournamentDataWithMatch, matchOptionDefaults),
+                containerProps.withTournament(tournamentDataWithMatch).build(),
                 withRound(patchable(props(matchData, true)), tournamentDataWithMatch!.round!),
                 appProps({ account: user(true, true) }, reportedError));
             context.prompts.respondToConfirm('Are you sure you want to delete the sayg data for this match?', true);
@@ -941,7 +932,7 @@ describe('PrintableSheetMatch', () => {
                 saygId: saygData.id,
             };
             await renderComponent(
-                containerProps(tournamentDataWithMatch, matchOptionDefaults),
+                containerProps.withTournament(tournamentDataWithMatch).build(),
                 withRound(patchable(props(matchData, true)), tournamentDataWithMatch!.round!),
                 appProps({ account: user(true, true) }, reportedError));
             context.prompts.respondToConfirm('Are you sure you want to delete the sayg data for this match?', true);
@@ -979,7 +970,7 @@ describe('PrintableSheetMatch', () => {
                 saygId: saygData.id,
             };
             await renderComponent(
-                containerProps(tournamentDataWithMatch, matchOptionDefaults),
+                containerProps.withTournament(tournamentDataWithMatch).build(),
                 withRound(patchable(props(matchData, true)), tournamentDataWithMatch!.round!),
                 appProps({ account: user(true, true) }, reportedError));
             context.prompts.respondToConfirm('Are you sure you want to delete the sayg data for this match?', true);

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheetMatch.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheetMatch.test.tsx
@@ -35,6 +35,7 @@ import {START_SCORING} from "./tournaments";
 import {ITournamentGameApi} from "../../interfaces/apis/ITournamentGameApi";
 import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
 import {TournamentRoundDto} from "../../interfaces/models/dtos/Game/TournamentRoundDto";
+import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 describe('PrintableSheetMatch', () => {
     let context: TestContext;
@@ -92,6 +93,9 @@ describe('PrintableSheetMatch', () => {
     async function setDraggingSide(_: TournamentSideDto) {
     }
 
+    async function setNewMatch(_: TournamentMatchDto) {
+    }
+
     async function renderComponent(containerProps: ITournamentContainerProps, props: IPrintableSheetMatchProps, appProps: IAppContainerProps) {
         context = await renderApp(
             iocProps({saygApi, tournamentApi}),
@@ -113,6 +117,8 @@ describe('PrintableSheetMatch', () => {
                 return tournamentData;
             },
             setDraggingSide,
+            newMatch: {},
+            setNewMatch,
         };
     }
 

--- a/CourageScores/ClientApp/src/components/tournaments/Tournament.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/Tournament.test.tsx
@@ -764,7 +764,7 @@ describe('Tournament', () => {
             reportedError.verifyNoError();
             const editSideDialog = context.container.querySelector('.modal-dialog')!;
             await doClick(editSideDialog.querySelector('.list-group-item:nth-child(2)')!); // click on a player
-            await doClick(findButton(editSideDialog, 'Save')); // close the dialog
+            await doClick(findButton(editSideDialog, 'Add')); // close the dialog
             reportedError.verifyNoError();
 
             // open the 180s dialog
@@ -784,7 +784,7 @@ describe('Tournament', () => {
             reportedError.verifyNoError();
             const addSideDialog = context.container.querySelector('.modal-dialog')!;
             await doClick(addSideDialog.querySelector('.list-group-item:nth-child(2)')!); // click on a player
-            await doClick(findButton(addSideDialog, 'Save')); // close the dialog
+            await doClick(findButton(addSideDialog, 'Add')); // close the dialog
             reportedError.verifyNoError();
 
             // open the hi-checks dialog
@@ -890,7 +890,7 @@ describe('Tournament', () => {
             const playing = context.container.querySelector('div[datatype="playing"]')!;
             await doClick(playing.querySelector('li:nth-child(1)')!); // open edit side dialog
             await doClick(context.container.querySelector('.modal-dialog input[name="noShow"]')!);
-            await doClick(findButton(context.container.querySelector('.modal-dialog')!, 'Save'));
+            await doClick(findButton(context.container.querySelector('.modal-dialog')!, 'Update'));
             reportedError.verifyNoError();
 
             // open the 180s dialog
@@ -915,7 +915,7 @@ describe('Tournament', () => {
             const playing = context.container.querySelector('div[datatype="playing"]')!;
             await doClick(playing.querySelector('li:nth-child(1)')!); // open edit side dialog
             await doClick(context.container.querySelector('.modal-dialog input[name="noShow"]')!);
-            await doClick(findButton(context.container.querySelector('.modal-dialog'), 'Save'));
+            await doClick(findButton(context.container.querySelector('.modal-dialog'), 'Update'));
             reportedError.verifyNoError();
 
             // open the 180s dialog
@@ -1041,7 +1041,7 @@ describe('Tournament', () => {
             await doClick(context.container.querySelector('li[datatype="add-side"]')!);
             const dialog = context.container.querySelector('div.modal-dialog')!;
             await doSelectOption(dialog.querySelector('.dropdown-menu'), 'TEAM');
-            await doClick(findButton(dialog, 'Save'));
+            await doClick(findButton(dialog, 'Add'));
             reportedError.verifyNoError();
 
             await doClick(context.container.querySelector('div[data-accolades="180s"]')!);

--- a/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
@@ -10,7 +10,7 @@ import {useDependencies} from "../common/IocContainer";
 import {useApp} from "../common/AppContainer";
 import {Dialog} from "../common/Dialog";
 import {EditPlayerDetails} from "../division_players/EditPlayerDetails";
-import {EMPTY_ID} from "../../helpers/projection";
+import {createTemporaryId, EMPTY_ID} from "../../helpers/projection";
 import {TournamentContainer} from "./TournamentContainer";
 import {SuperLeaguePrintout} from "./superleague/SuperLeaguePrintout";
 import {PrintableSheet} from "./PrintableSheet";
@@ -46,6 +46,7 @@ import {
 import {useBranding} from "../common/BrandingContainer";
 import {renderDate} from "../../helpers/rendering";
 import {isEqual} from "../common/ObjectComparer";
+import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 export interface ITournamentPlayerMap {
     [id: string]: DivisionTournamentFixtureDetailsDto;
@@ -78,6 +79,7 @@ export function Tournament() {
     const {setTitle} = useBranding();
     const [originalTournamentData, setOriginalTournamentData] = useState<TournamentGameDto | null>(null);
     const [draggingSide, setDraggingSide] = useState<TournamentSideDto | undefined>(undefined);
+    const [newMatch, setNewMatch] = useState<TournamentMatchDto>(createNewMatch());
 
     useEffect(() => {
         featureApi.getFeatures().then(features => {
@@ -106,6 +108,14 @@ export function Tournament() {
         },
         // eslint-disable-next-line
         [appLoading, loading, seasons]);
+
+    function createNewMatch(): TournamentMatchDto {
+        return {
+            sideA: null!,
+            sideB: null!,
+            id: createTemporaryId(),
+        };
+    }
 
     async function loadFixtureData() {
         try {
@@ -393,7 +403,9 @@ export function Tournament() {
                     preventScroll={preventScroll}
                     setPreventScroll={setPreventScroll}
                     draggingSide={draggingSide}
-                    setDraggingSide={asyncCallback(setDraggingSide)}>
+                    setDraggingSide={asyncCallback(setDraggingSide)}
+                    newMatch={newMatch}
+                    setNewMatch={asyncCallback(setNewMatch)}>
                     {canManageTournaments && tournamentData && editTournament === 'matches'
                         ? (<Dialog title="Edit sides and matches" className="d-print-none">
                             <div>

--- a/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
@@ -3,7 +3,7 @@ import {useParams} from "react-router";
 import {DivisionControls} from "../league/DivisionControls";
 import {ErrorDisplay} from "../common/ErrorDisplay";
 import {any, sortBy} from "../../helpers/collections";
-import {propChanged} from "../../helpers/events";
+import {asyncCallback, propChanged} from "../../helpers/events";
 import {Loading} from "../common/Loading";
 import {EditTournament} from "./EditTournament";
 import {useDependencies} from "../common/IocContainer";
@@ -77,6 +77,7 @@ export function Tournament() {
     const [photosEnabled, setPhotosEnabled] = useState<boolean>(false);
     const {setTitle} = useBranding();
     const [originalTournamentData, setOriginalTournamentData] = useState<TournamentGameDto | null>(null);
+    const [draggingSide, setDraggingSide] = useState<TournamentSideDto | undefined>(undefined);
 
     useEffect(() => {
         featureApi.getFeatures().then(features => {
@@ -383,14 +384,16 @@ export function Tournament() {
                     alreadyPlaying={alreadyPlaying!}
                     allPlayers={allPlayers}
                     saveTournament={saveTournament}
-                    setWarnBeforeEditDialogClose={async (warning: string) => setWarnBeforeEditDialogClose(warning)}
+                    setWarnBeforeEditDialogClose={asyncCallback(setWarnBeforeEditDialogClose)}
                     matchOptionDefaults={getMatchOptionDefaults(tournamentData)}
                     saving={saving}
                     editTournament={editTournament}
-                    setEditTournament={canManageTournaments ? async (value: string) => setEditTournament(value) : undefined}
+                    setEditTournament={canManageTournaments ? asyncCallback(setEditTournament) : undefined}
                     liveOptions={liveOptions}
                     preventScroll={preventScroll}
-                    setPreventScroll={setPreventScroll}>
+                    setPreventScroll={setPreventScroll}
+                    draggingSide={draggingSide}
+                    setDraggingSide={asyncCallback(setDraggingSide)}>
                     {canManageTournaments && tournamentData && editTournament === 'matches'
                         ? (<Dialog title="Edit sides and matches" className="d-print-none">
                             <div>

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentRound.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentRound.test.tsx
@@ -95,6 +95,9 @@ describe('TournamentRound', () => {
     function setPreventScroll(_: boolean) {
     }
 
+    async function setDraggingSide(_: TournamentSideDto) {
+    }
+
     async function renderComponent(containerProps: ITournamentContainerProps, props: ITournamentRoundProps, account?: UserDto) {
         context = await renderApp(
             iocProps({tournamentApi, saygApi}),
@@ -142,6 +145,7 @@ describe('TournamentRound', () => {
             saveTournament,
             preventScroll: false,
             setPreventScroll,
+            setDraggingSide,
         };
 
         describe('renders', () => {
@@ -227,6 +231,7 @@ describe('TournamentRound', () => {
             saveTournament,
             preventScroll: false,
             setPreventScroll,
+            setDraggingSide,
         }
 
         describe('renders', () => {
@@ -266,6 +271,7 @@ describe('TournamentRound', () => {
                         setTournamentData,
                         preventScroll: false,
                         setPreventScroll,
+                        setDraggingSide,
                     },
                     {
                         round: roundBuilder()
@@ -315,6 +321,7 @@ describe('TournamentRound', () => {
                         setWarnBeforeEditDialogClose,
                         preventScroll: false,
                         setPreventScroll,
+                        setDraggingSide,
                     },
                     {
                         round: roundBuilder()
@@ -347,6 +354,7 @@ describe('TournamentRound', () => {
                         setWarnBeforeEditDialogClose,
                         preventScroll: false,
                         setPreventScroll,
+                        setDraggingSide,
                     },
                     {
                         round: roundBuilder().withMatch(match).build(),
@@ -389,6 +397,7 @@ describe('TournamentRound', () => {
                         setWarnBeforeEditDialogClose,
                         preventScroll: false,
                         setPreventScroll,
+                        setDraggingSide,
                     },
                     {
                         round: roundBuilder().withMatch(match).build(),
@@ -413,6 +422,7 @@ describe('TournamentRound', () => {
                         setWarnBeforeEditDialogClose,
                         preventScroll: false,
                         setPreventScroll,
+                        setDraggingSide,
                     },
                     {
                         round: roundBuilder().withMatch(match).build(),
@@ -447,6 +457,7 @@ describe('TournamentRound', () => {
                         setWarnBeforeEditDialogClose,
                         preventScroll: false,
                         setPreventScroll,
+                        setDraggingSide,
                     },
                     {
                         round: roundBuilder().withMatch(match).build(),
@@ -514,6 +525,7 @@ describe('TournamentRound', () => {
                         setWarnBeforeEditDialogClose,
                         preventScroll: false,
                         setPreventScroll,
+                        setDraggingSide,
                     },
                     {
                         round: roundBuilder().build(),

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentRound.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentRound.test.tsx
@@ -30,6 +30,7 @@ import {createTemporaryId} from "../../helpers/projection";
 import {ISaygApi} from "../../interfaces/apis/ISaygApi";
 import {ITournamentGameApi} from "../../interfaces/apis/ITournamentGameApi";
 import {CreateTournamentSaygDto} from "../../interfaces/models/dtos/Game/CreateTournamentSaygDto";
+import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 describe('TournamentRound', () => {
     let context: TestContext;
@@ -96,6 +97,9 @@ describe('TournamentRound', () => {
     }
 
     async function setDraggingSide(_: TournamentSideDto) {
+    }
+
+    async function setNewMatch(_: TournamentMatchDto) {
     }
 
     async function renderComponent(containerProps: ITournamentContainerProps, props: ITournamentRoundProps, account?: UserDto) {

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentRound.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentRound.test.tsx
@@ -30,6 +30,7 @@ import {createTemporaryId} from "../../helpers/projection";
 import {ISaygApi} from "../../interfaces/apis/ISaygApi";
 import {ITournamentGameApi} from "../../interfaces/apis/ITournamentGameApi";
 import {CreateTournamentSaygDto} from "../../interfaces/models/dtos/Game/CreateTournamentSaygDto";
+import {tournamentContainerPropsBuilder} from "./tournamentContainerPropsBuilder";
 import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 describe('TournamentRound', () => {
@@ -82,24 +83,8 @@ describe('TournamentRound', () => {
         updatedRound = newRound;
     }
 
-    async function setTournamentData() {
-    }
-
     async function setWarnBeforeEditDialogClose(msg: string) {
         warnBeforeEditDialogClose = msg;
-    }
-
-    async function saveTournament(): Promise<TournamentGameDto> {
-        return null!;
-    }
-
-    function setPreventScroll(_: boolean) {
-    }
-
-    async function setDraggingSide(_: TournamentSideDto) {
-    }
-
-    async function setNewMatch(_: TournamentMatchDto) {
     }
 
     async function renderComponent(containerProps: ITournamentContainerProps, props: ITournamentRoundProps, account?: UserDto) {
@@ -112,6 +97,8 @@ describe('TournamentRound', () => {
             (<TournamentContainer {...containerProps} >
                 <TournamentRound {...props} />
             </TournamentContainer>));
+
+        reportedError!.verifyNoError();
     }
 
     function assertMatch(table: Element, ordinal: number, expectedText: string[]) {
@@ -141,32 +128,24 @@ describe('TournamentRound', () => {
         const side3: TournamentSideDto = sideBuilder('SIDE 3').build();
         const side4: TournamentSideDto = sideBuilder('SIDE 4').build();
         const readOnly: boolean = true;
-        const emptyTournamentGame: TournamentGameDto = tournamentBuilder().build();
-        const defaultTournamentContainerProps: ITournamentContainerProps = {
-            tournamentData: emptyTournamentGame,
-            setTournamentData,
+        const containerProps = new tournamentContainerPropsBuilder({
             setWarnBeforeEditDialogClose,
-            saveTournament,
-            preventScroll: false,
-            setPreventScroll,
-            setDraggingSide,
-        };
+        });
 
         describe('renders', () => {
             it('when no matches', async () => {
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     round: roundBuilder().build(),
                     sides: [],
                     readOnly,
                     onChange,
                 });
 
-                reportedError!.verifyNoError();
                 expect(context.container.textContent).toContain('No matches defined');
             });
 
             it('unplayed round', async () => {
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     round: roundBuilder()
                         .withMatch((m: ITournamentMatchBuilder) => m.sideA(side1).sideB(side2))
                         .withMatchOption((o: IMatchOptionsBuilder) => o.startingScore(601).numberOfLegs(7))
@@ -176,13 +155,12 @@ describe('TournamentRound', () => {
                     onChange,
                 });
 
-                reportedError!.verifyNoError();
                 const table = context.container.querySelector('table')!;
                 assertMatch(table, 1, ['SIDE 1', '', 'vs', '', 'SIDE 2']);
             });
 
             it('played round', async () => {
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     round: roundBuilder()
                         .withMatch((m: ITournamentMatchBuilder) => m.sideA(side1, 1).sideB(side2, 2))
                         .withMatch((m: ITournamentMatchBuilder) => m.sideA(side3, 2).sideB(side4, 1))
@@ -193,7 +171,6 @@ describe('TournamentRound', () => {
                     onChange,
                 });
 
-                reportedError!.verifyNoError();
                 const table = context.container.querySelector('table')!;
                 assertMatch(table, 1, ['SIDE 1', '1', 'vs', '2', 'SIDE 2']);
                 assertMatch(table, 2, ['SIDE 3', '2', 'vs', '1', 'SIDE 4']);
@@ -201,7 +178,7 @@ describe('TournamentRound', () => {
         });
 
         it('no next round (when single round)', async () => {
-            await renderComponent(defaultTournamentContainerProps, {
+            await renderComponent(containerProps.build(), {
                 round: roundBuilder()
                     .withMatch((m: ITournamentMatchBuilder) => m.sideA(side1, 1).sideB(side2, 2))
                     .withMatch((m: ITournamentMatchBuilder) => m.sideA(side3, 2).sideB(side4, 1))
@@ -215,7 +192,6 @@ describe('TournamentRound', () => {
                 onChange,
             });
 
-            reportedError!.verifyNoError();
             const roundTables = context.container.querySelectorAll('table');
             expect(roundTables.length).toEqual(1);
         });
@@ -227,32 +203,24 @@ describe('TournamentRound', () => {
         const side3: TournamentSideDto = sideBuilder('SIDE 3').build();
         const side4: TournamentSideDto = sideBuilder('SIDE 4').build();
         const readOnly: boolean = false;
-        const emptyTournamentGame: TournamentGameDto = tournamentBuilder().build();
-        const defaultTournamentContainerProps: ITournamentContainerProps = {
-            tournamentData: emptyTournamentGame,
-            setTournamentData: setTournamentData,
+        const containerProps = new tournamentContainerPropsBuilder({
             setWarnBeforeEditDialogClose,
-            saveTournament,
-            preventScroll: false,
-            setPreventScroll,
-            setDraggingSide,
-        }
+        });
 
         describe('renders', () => {
             it('when no matches', async () => {
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     round: roundBuilder().build(),
                     sides: [side1, side2],
                     readOnly,
                     onChange,
                 });
 
-                reportedError!.verifyNoError();
                 expect(context.container.querySelector('table')).toBeTruthy();
             });
 
             it('unplayed round', async () => {
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     round: roundBuilder()
                         .withMatch((m: ITournamentMatchBuilder) => m.sideA(side1).sideB(side2))
                         .withMatchOption((o: IMatchOptionsBuilder) => o.startingScore(601).numberOfLegs(7))
@@ -262,21 +230,13 @@ describe('TournamentRound', () => {
                     onChange,
                 });
 
-                reportedError!.verifyNoError();
                 const table = context.container.querySelector('table')!;
                 assertEditableMatch(table, 1, ['SIDE 1', '', 'vs', '', 'SIDE 2', '🗑🛠']);
             });
 
             it('played round', async () => {
                 await renderComponent(
-                    {
-                        tournamentData: emptyTournamentGame,
-                        matchOptionDefaults: {numberOfLegs: 3},
-                        setTournamentData,
-                        preventScroll: false,
-                        setPreventScroll,
-                        setDraggingSide,
-                    },
+                    containerProps.withMatchOptionDefaults({numberOfLegs: 3}).build(),
                     {
                         round: roundBuilder()
                             .withMatch((m: ITournamentMatchBuilder) => m.sideA(side1, 1).sideB(side2, 2))
@@ -288,14 +248,13 @@ describe('TournamentRound', () => {
                         onChange,
                     });
 
-                reportedError!.verifyNoError();
                 const table = context.container.querySelector('table')!;
                 assertEditableMatch(table, 1, ['SIDE 1', '1', 'vs', '2', 'SIDE 2', '🗑🛠']);
                 assertEditableMatch(table, 2, ['SIDE 3', '2', 'vs', '1', 'SIDE 4', '🗑🛠']);
             });
 
             it('no next round (when single round)', async () => {
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     round: roundBuilder()
                         .withMatch((m: ITournamentMatchBuilder) => m.sideA(side1, 1).sideB(side2, 2))
                         .withMatch((m: ITournamentMatchBuilder) => m.sideA(side3, 2).sideB(side4, 1))
@@ -309,7 +268,6 @@ describe('TournamentRound', () => {
                     onChange,
                 });
 
-                reportedError!.verifyNoError();
                 const roundTables = context.container.querySelectorAll('table');
                 expect(roundTables.length).toEqual(1);
             });
@@ -318,15 +276,7 @@ describe('TournamentRound', () => {
         describe('interactivity', () => {
             it('can delete match', async () => {
                 await renderComponent(
-                    {
-                        tournamentData: emptyTournamentGame,
-                        matchOptionDefaults: {numberOfLegs: 3},
-                        setTournamentData,
-                        setWarnBeforeEditDialogClose,
-                        preventScroll: false,
-                        setPreventScroll,
-                        setDraggingSide,
-                    },
+                    containerProps.withMatchOptionDefaults({numberOfLegs: 3}).build(),
                     {
                         round: roundBuilder()
                             .withMatch((m: ITournamentMatchBuilder) => m.sideA(side1).sideB(side2))
@@ -335,7 +285,6 @@ describe('TournamentRound', () => {
                         readOnly,
                         onChange,
                     });
-                reportedError!.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
                 context.prompts.respondToConfirm('Are you sure you want to remove this match?', true);
 
@@ -351,22 +300,13 @@ describe('TournamentRound', () => {
             it('can change match options', async () => {
                 const match = tournamentMatchBuilder().sideA(side1).sideB(side2).build();
                 await renderComponent(
-                    {
-                        tournamentData: emptyTournamentGame,
-                        matchOptionDefaults: {numberOfLegs: 5, startingScore: 501},
-                        setTournamentData,
-                        setWarnBeforeEditDialogClose,
-                        preventScroll: false,
-                        setPreventScroll,
-                        setDraggingSide,
-                    },
+                    containerProps.withMatchOptionDefaults({numberOfLegs: 5, startingScore: 501}).build(),
                     {
                         round: roundBuilder().withMatch(match).build(),
                         sides: [side1, side2, side3, side4],
                         readOnly,
                         onChange,
                     });
-                reportedError!.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)');
 
                 await doClick(findButton(matchRow, '🛠'));
@@ -394,15 +334,7 @@ describe('TournamentRound', () => {
                     }
                 };
                 await renderComponent(
-                    {
-                        tournamentData: emptyTournamentGame,
-                        matchOptionDefaults: {numberOfLegs: 3},
-                        setTournamentData,
-                        setWarnBeforeEditDialogClose,
-                        preventScroll: false,
-                        setPreventScroll,
-                        setDraggingSide,
-                    },
+                    containerProps.withMatchOptionDefaults({numberOfLegs: 3}).build(),
                     {
                         round: roundBuilder().withMatch(match).build(),
                         sides: [side1, side2, side3, side4],
@@ -410,7 +342,6 @@ describe('TournamentRound', () => {
                         onChange,
                     },
                     permittedAccount);
-                reportedError!.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)')!;
 
                 expect(matchRow.textContent).not.toContain('📊');
@@ -419,22 +350,13 @@ describe('TournamentRound', () => {
             it('can change sideA', async () => {
                 const match = tournamentMatchBuilder().sideA(side1).sideB(side2).build();
                 await renderComponent(
-                    {
-                        tournamentData: emptyTournamentGame,
-                        matchOptionDefaults: {numberOfLegs: 3},
-                        setTournamentData,
-                        setWarnBeforeEditDialogClose,
-                        preventScroll: false,
-                        setPreventScroll,
-                        setDraggingSide,
-                    },
+                    containerProps.withMatchOptionDefaults({numberOfLegs: 3}).build(),
                     {
                         round: roundBuilder().withMatch(match).build(),
                         sides: [side1, side2, side3, side4],
                         readOnly,
                         onChange,
                     });
-                reportedError!.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)')!;
                 const sideA = matchRow.querySelector('td:nth-child(1)')!;
 
@@ -454,22 +376,13 @@ describe('TournamentRound', () => {
             it('can change sideB', async () => {
                 const match = tournamentMatchBuilder().sideA(side1).sideB(side2).build();
                 await renderComponent(
-                    {
-                        tournamentData: emptyTournamentGame,
-                        matchOptionDefaults: {numberOfLegs: 3},
-                        setTournamentData,
-                        setWarnBeforeEditDialogClose,
-                        preventScroll: false,
-                        setPreventScroll,
-                        setDraggingSide,
-                    },
+                    containerProps.withMatchOptionDefaults({numberOfLegs: 3}).build(),
                     {
                         round: roundBuilder().withMatch(match).build(),
                         sides: [side1, side2, side3, side4],
                         readOnly,
                         onChange,
                     });
-                reportedError!.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)')!;
                 const sideB = matchRow.querySelector('td:nth-child(5)')!;
 
@@ -487,13 +400,12 @@ describe('TournamentRound', () => {
             });
 
             it('cannot add match with only sideA', async () => {
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     round: roundBuilder().build(),
                     sides: [side1, side2, side3, side4],
                     readOnly,
                     onChange,
                 });
-                reportedError!.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)')!;
 
                 await doSelectOption(matchRow.querySelector('td:nth-child(1) .dropdown-menu'), 'SIDE 1');
@@ -504,13 +416,12 @@ describe('TournamentRound', () => {
             });
 
             it('cannot add match with only sideB', async () => {
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     round: roundBuilder().build(),
                     sides: [side1, side2, side3, side4],
                     readOnly,
                     onChange,
                 });
-                reportedError!.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)')!;
 
                 await doSelectOption(matchRow.querySelector('td:nth-child(1) .dropdown-menu'), 'SIDE 1');
@@ -521,23 +432,30 @@ describe('TournamentRound', () => {
             });
 
             it('can add match', async () => {
+                const newMatch = {
+                    id: '',
+                };
+                async function setNewMatch(updates: TournamentMatchDto) {
+                    if (updates.id) {
+                        // setNewMatch(createNewMatch()) has been called, this would wipe out the current state
+                        // excluding these updates to allow us to confirm the previous update is working as expected.
+                        return;
+                    }
+                    Object.assign(newMatch, updates)
+                }
                 await renderComponent(
-                    {
-                        tournamentData: tournamentBuilder().bestOf(3).build(),
-                        matchOptionDefaults: {numberOfLegs: 3, startingScore: 501},
-                        setTournamentData,
-                        setWarnBeforeEditDialogClose,
-                        preventScroll: false,
-                        setPreventScroll,
-                        setDraggingSide,
-                    },
+                    containerProps
+                        .withNewMatch(newMatch as TournamentMatchDto)
+                        .withSetNewMatch(setNewMatch)
+                        .withTournament(tournamentBuilder().bestOf(3).build())
+                        .withMatchOptionDefaults({numberOfLegs: 3, startingScore: 501})
+                        .build(),
                     {
                         round: roundBuilder().build(),
                         sides: [side1, side2, side3, side4],
                         readOnly,
                         onChange,
                     });
-                reportedError!.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)')!;
 
                 await doSelectOption(matchRow.querySelector('td:nth-child(1) .dropdown-menu'), 'SIDE 1');
@@ -557,13 +475,26 @@ describe('TournamentRound', () => {
             });
 
             it('sets up warning if side not added and tournament saved', async () => {
-                await renderComponent(defaultTournamentContainerProps, {
+                const newMatch = {
+                    id: '',
+                };
+                async function setNewMatch(updates: TournamentMatchDto) {
+                    if (updates.id) {
+                        // setNewMatch(createNewMatch()) has been called, this would wipe out the current state
+                        // excluding these updates to allow us to confirm the previous update is working as expected.
+                        return;
+                    }
+                    Object.assign(newMatch, updates)
+                }
+                await renderComponent(containerProps
+                        .withNewMatch(newMatch as TournamentMatchDto)
+                        .withSetNewMatch(setNewMatch)
+                        .build(), {
                     round: roundBuilder().build(),
                     sides: [side1, side2, side3, side4],
                     readOnly,
                     onChange,
                 });
-                reportedError!.verifyNoError();
                 const matchRow = context.container.querySelector('table tr:nth-child(1)')!;
 
                 await doSelectOption(matchRow.querySelector('td:nth-child(1) .dropdown-menu'), 'SIDE 1');

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentRound.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentRound.tsx
@@ -115,7 +115,9 @@ ${newNewMatch.sideA ? newNewMatch.sideA.name : ''} vs ${newNewMatch.sideB ? newN
     }
 
     function preventDefault(event: React.DragEvent) {
+        /* istanbul ignore next */
         if (draggingSide) {
+            /* istanbul ignore next */
             event.preventDefault();
         }
     }

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentRound.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentRound.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {BootstrapDropdown, IBootstrapDropdownItem} from "../common/BootstrapDropdown";
 import {any, elementAt, isEmpty} from "../../helpers/collections";
 import {TournamentRoundMatch} from "./TournamentRoundMatch";
@@ -7,8 +7,8 @@ import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMa
 import {TournamentRoundDto} from "../../interfaces/models/dtos/Game/TournamentRoundDto";
 import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
 import {GameMatchOptionDto} from "../../interfaces/models/dtos/Game/GameMatchOptionDto";
-import {createTemporaryId} from "../../helpers/projection";
 import {UntypedPromise} from "../../interfaces/UntypedPromise";
+import {createTemporaryId} from "../../helpers/projection";
 
 export interface ITournamentRoundProps {
     round: TournamentRoundDto;
@@ -18,13 +18,12 @@ export interface ITournamentRoundProps {
 }
 
 export function TournamentRound({ round, onChange, sides, readOnly }: ITournamentRoundProps) {
-    const [newMatch, setNewMatch] = useState<TournamentMatchDto>(createNewMatch());
-    const {setWarnBeforeEditDialogClose, matchOptionDefaults, tournamentData, draggingSide} = useTournament();
+    const {newMatch, setNewMatch, setWarnBeforeEditDialogClose, matchOptionDefaults, tournamentData, draggingSide} = useTournament();
 
     async function setNewSide(sideId: string, property: string) {
         const newNewMatch: TournamentMatchDto = Object.assign({}, newMatch);
         newNewMatch[property] = sides.filter(s => s.id === sideId)[0];
-        setNewMatch(newNewMatch);
+        await setNewMatch(newNewMatch);
         if (setWarnBeforeEditDialogClose) {
             await setWarnBeforeEditDialogClose(`Add the (new) match before saving, otherwise it would be lost.
 
@@ -77,7 +76,7 @@ ${newNewMatch.sideA ? newNewMatch.sideA.name : ''} vs ${newNewMatch.sideB ? newN
         newRound.matchOptions = matchOptionDefaults
             ? (newRound.matchOptions || []).concat(matchOptionDefaults)
             : (newRound.matchOptions || []);
-        setNewMatch(createNewMatch());
+        await setNewMatch(createNewMatch());
         if (setWarnBeforeEditDialogClose) {
             await setWarnBeforeEditDialogClose(null);
         }

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentRound.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentRound.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import React, {useState} from 'react';
 import {BootstrapDropdown, IBootstrapDropdownItem} from "../common/BootstrapDropdown";
 import {any, elementAt, isEmpty} from "../../helpers/collections";
 import {TournamentRoundMatch} from "./TournamentRoundMatch";
@@ -19,7 +19,7 @@ export interface ITournamentRoundProps {
 
 export function TournamentRound({ round, onChange, sides, readOnly }: ITournamentRoundProps) {
     const [newMatch, setNewMatch] = useState<TournamentMatchDto>(createNewMatch());
-    const {setWarnBeforeEditDialogClose, matchOptionDefaults, tournamentData} = useTournament();
+    const {setWarnBeforeEditDialogClose, matchOptionDefaults, tournamentData, draggingSide} = useTournament();
 
     async function setNewSide(sideId: string, property: string) {
         const newNewMatch: TournamentMatchDto = Object.assign({}, newMatch);
@@ -103,6 +103,24 @@ ${newNewMatch.sideA ? newNewMatch.sideA.name : ''} vs ${newNewMatch.sideB ? newN
         };
     }
 
+    async function dropSideA() {
+        if (draggingSide) {
+            await setNewSide(draggingSide.id, 'sideA');
+        }
+    }
+
+    async function dropSideB() {
+        if (draggingSide) {
+            await setNewSide(draggingSide.id, 'sideB');
+        }
+    }
+
+    function preventDefault(event: React.DragEvent) {
+        if (draggingSide) {
+            event.preventDefault();
+        }
+    }
+
     const allSidesSelected: boolean = (round.matches && round.matches.length * 2 === sides.length) || false;
     const hasNextRound: boolean = (round.nextRound && round.nextRound.matches && any(round.nextRound.matches)) || false;
 
@@ -129,7 +147,7 @@ ${newNewMatch.sideA ? newNewMatch.sideA.name : ''} vs ${newNewMatch.sideB ? newN
                     showEditMatchOptions={!tournamentData.singleRound} />);
             })}
             {readOnly || allSidesSelected || hasNextRound ? null : (<tr className="bg-yellow p-1">
-                <td>
+                <td onDrop={dropSideA} onDragOver={preventDefault}>
                     <BootstrapDropdown value={newMatch.sideA ? newMatch.sideA.id : null}
                                        onChange={async (side) => setNewSide(side, 'sideA')}
                                        options={sides.filter(s => exceptSelected(s, undefined, 'sideA')).map(sideSelection)}
@@ -138,7 +156,7 @@ ${newNewMatch.sideA ? newNewMatch.sideA.name : ''} vs ${newNewMatch.sideB ? newN
                 <td></td>
                 <td>vs</td>
                 <td></td>
-                <td>
+                <td onDrop={dropSideB} onDragOver={preventDefault}>
                     <BootstrapDropdown value={newMatch.sideB ? newMatch.sideB.id : null}
                                        onChange={async (side) => setNewSide(side, 'sideB')}
                                        options={sides.filter(s => exceptSelected(s, undefined, 'sideB')).map(sideSelection)}

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentRoundMatch.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentRoundMatch.test.tsx
@@ -15,7 +15,6 @@ import {ITournamentRoundMatchProps, TournamentRoundMatch} from "./TournamentRoun
 import {ITournamentContainerProps, TournamentContainer} from "./TournamentContainer";
 import {GameMatchOptionDto} from "../../interfaces/models/dtos/Game/GameMatchOptionDto";
 import {RecordedScoreAsYouGoDto} from "../../interfaces/models/dtos/Game/Sayg/RecordedScoreAsYouGoDto";
-import {TournamentGameDto} from "../../interfaces/models/dtos/Game/TournamentGameDto";
 import {TournamentRoundDto} from "../../interfaces/models/dtos/Game/TournamentRoundDto";
 import {UserDto} from "../../interfaces/models/dtos/Identity/UserDto";
 import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
@@ -23,14 +22,13 @@ import {TeamPlayerDto} from "../../interfaces/models/dtos/Team/TeamPlayerDto";
 import {
     roundBuilder,
     sideBuilder,
-    tournamentBuilder,
     tournamentMatchBuilder
 } from "../../helpers/builders/tournaments";
 import {playerBuilder} from "../../helpers/builders/players";
 import {matchOptionsBuilder} from "../../helpers/builders/games";
 import {ISaygApi} from "../../interfaces/apis/ISaygApi";
 import {ITournamentGameApi} from "../../interfaces/apis/ITournamentGameApi";
-import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
+import {tournamentContainerPropsBuilder} from "./tournamentContainerPropsBuilder";
 
 describe('TournamentRoundMatch', () => {
     let context: TestContext;
@@ -55,31 +53,11 @@ describe('TournamentRoundMatch', () => {
         updatedRound = null;
     });
 
-    async function setTournamentData() {
-    }
-
-    async function saveTournament(): Promise<TournamentGameDto> {
-        return {
-            date: '',
-            id: '',
-            address: '',
-        };
-    }
-
     async function onMatchOptionsChanged(_: GameMatchOptionDto) {
     }
 
     async function onChange(updated: TournamentRoundDto) {
         updatedRound = updated;
-    }
-
-    function setPreventScroll(_: boolean) {
-    }
-
-    async function setDraggingSide(_: TournamentSideDto) {
-    }
-
-    async function setNewMatch(_: TournamentMatchDto) {
     }
 
     async function renderComponent(containerProps: ITournamentContainerProps, props: ITournamentRoundMatchProps, account?: UserDto) {
@@ -124,6 +102,7 @@ describe('TournamentRoundMatch', () => {
             }
             return !any(exceptSides, (s: TournamentSideDto) => s.name === side.name);
         };
+        const containerProps = new tournamentContainerPropsBuilder();
 
         beforeEach(() => {
             returnFromExceptSelected = {};
@@ -131,19 +110,10 @@ describe('TournamentRoundMatch', () => {
 
         describe('when logged out', () => {
             const account = undefined;
-            const defaultTournamentContainerProps: ITournamentContainerProps = {
-                tournamentData: tournamentBuilder().build(),
-                saveTournament,
-                setTournamentData,
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                setNewMatch,
-            };
 
             it('when has next round', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA, 1).sideB(sideB, 2).build();
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: true,
                     match: match,
                     hasNextRound: true,
@@ -170,7 +140,7 @@ describe('TournamentRoundMatch', () => {
 
             it('when has next round and no scores', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA).sideB(sideB).build();
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: true,
                     match: match,
                     hasNextRound: true,
@@ -195,7 +165,7 @@ describe('TournamentRoundMatch', () => {
 
             it('sideA winner', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA, 3).sideB(sideB, 2).build();
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: true,
                     match: match,
                     hasNextRound: true,
@@ -219,7 +189,7 @@ describe('TournamentRoundMatch', () => {
 
             it('sideA outright winner shows 0 value score for sideB', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA, 3).sideB(sideB, 0).build();
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: true,
                     match: match,
                     hasNextRound: false,
@@ -241,7 +211,7 @@ describe('TournamentRoundMatch', () => {
 
             it('sideB winner', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA, 2).sideB(sideB, 3).build();
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: true,
                     match: match,
                     hasNextRound: true,
@@ -265,7 +235,7 @@ describe('TournamentRoundMatch', () => {
 
             it('sideB outright winner shows 0 value score for sideA', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA, 0).sideB(sideB, 3).build();
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: true,
                     match: match,
                     hasNextRound: false,
@@ -287,7 +257,7 @@ describe('TournamentRoundMatch', () => {
 
             it('when no next round', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA, 1).sideB(sideB, 2).build();
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: true,
                     match: match,
                     hasNextRound: false,
@@ -312,7 +282,7 @@ describe('TournamentRoundMatch', () => {
 
             it('cannot open sayg if not exists', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA, 1).sideB(sideB, 2).build();
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: true,
                     match: match,
                     hasNextRound: false,
@@ -341,22 +311,13 @@ describe('TournamentRoundMatch', () => {
                     recordScoresAsYouGo: true,
                 }
             };
-            const defaultTournamentContainerProps: ITournamentContainerProps = {
-                tournamentData: tournamentBuilder().build(),
-                saveTournament,
-                setTournamentData,
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                setNewMatch,
-            };
 
             it('when no next round', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA, 1).sideB(sideB, 2).build();
                 returnFromExceptSelected['sideA'] = [sideC, sideD];
                 returnFromExceptSelected['sideB'] = [sideD, sideE];
 
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: false,
                     match: match,
                     hasNextRound: false,
@@ -381,7 +342,7 @@ describe('TournamentRoundMatch', () => {
 
             it('can open match options', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA, 1).sideB(sideB, 2).build();
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: false,
                     match: match,
                     hasNextRound: false,
@@ -402,7 +363,7 @@ describe('TournamentRoundMatch', () => {
 
             it('sideA outright winner shows 0 value score for sideB', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA, 3).sideB(sideB, 0).build();
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: false,
                     match: match,
                     hasNextRound: false,
@@ -424,7 +385,7 @@ describe('TournamentRoundMatch', () => {
 
             it('sideB outright winner shows 0 value score for sideA', async () => {
                 const match = tournamentMatchBuilder().sideA(sideA, 0).sideB(sideB, 3).build();
-                await renderComponent(defaultTournamentContainerProps, {
+                await renderComponent(containerProps.build(), {
                     readOnly: false,
                     match: match,
                     hasNextRound: false,
@@ -477,15 +438,7 @@ describe('TournamentRoundMatch', () => {
                 recordScoresAsYouGo: true,
             }
         };
-        const defaultTournamentContainerProps: ITournamentContainerProps = {
-            tournamentData: tournamentBuilder().build(),
-            saveTournament,
-            setTournamentData,
-            preventScroll: false,
-            setPreventScroll,
-            setDraggingSide,
-            setNewMatch,
-        };
+        const containerProps = new tournamentContainerPropsBuilder();
 
         beforeEach(() => {
             returnFromExceptSelected = {};
@@ -494,7 +447,7 @@ describe('TournamentRoundMatch', () => {
 
         it('can open match options dialog', async () => {
             const match = tournamentMatchBuilder().sideA(sideA, 1).sideB(sideB, 2).build();
-            await renderComponent(defaultTournamentContainerProps, {
+            await renderComponent(containerProps.build(), {
                 readOnly: false,
                 match: match,
                 hasNextRound: false,
@@ -519,7 +472,7 @@ describe('TournamentRoundMatch', () => {
 
         it('can close match options dialog', async () => {
             const match = tournamentMatchBuilder().sideA(sideA, 1).sideB(sideB, 2).build();
-            await renderComponent(defaultTournamentContainerProps, {
+            await renderComponent(containerProps.build(), {
                 readOnly: false,
                 match: match,
                 hasNextRound: false,
@@ -545,7 +498,7 @@ describe('TournamentRoundMatch', () => {
             const match = tournamentMatchBuilder().sideA(sideA, 1).sideB(sideB, 2).build();
             returnFromExceptSelected['sideA'] = [sideB, sideD];
             returnFromExceptSelected['sideB'] = [sideA, sideE];
-            await renderComponent(defaultTournamentContainerProps, {
+            await renderComponent(containerProps.build(), {
                 readOnly: false,
                 match: match,
                 hasNextRound: false,
@@ -572,7 +525,7 @@ describe('TournamentRoundMatch', () => {
             const match = tournamentMatchBuilder().sideA(sideA, 1).sideB(sideB, 2).build();
             returnFromExceptSelected['sideA'] = [sideB, sideD];
             returnFromExceptSelected['sideB'] = [sideA, sideE];
-            await renderComponent(defaultTournamentContainerProps, {
+            await renderComponent(containerProps.build(), {
                 readOnly: false,
                 match: match,
                 hasNextRound: false,
@@ -599,7 +552,7 @@ describe('TournamentRoundMatch', () => {
             const match = tournamentMatchBuilder().sideA(sideA, 1).sideB(sideB, 2).build();
             returnFromExceptSelected['sideA'] = [sideB, sideD];
             returnFromExceptSelected['sideB'] = [sideA, sideE];
-            await renderComponent(defaultTournamentContainerProps, {
+            await renderComponent(containerProps.build(), {
                 readOnly: false,
                 match: match,
                 hasNextRound: false,
@@ -628,7 +581,7 @@ describe('TournamentRoundMatch', () => {
             const match = tournamentMatchBuilder().sideA(sideA, 1).sideB(sideB, 2).build();
             returnFromExceptSelected['sideA'] = [sideB, sideD];
             returnFromExceptSelected['sideB'] = [sideA, sideE];
-            await renderComponent(defaultTournamentContainerProps, {
+            await renderComponent(containerProps.build(), {
                 readOnly: false,
                 match: match,
                 hasNextRound: false,

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentRoundMatch.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentRoundMatch.test.tsx
@@ -75,6 +75,9 @@ describe('TournamentRoundMatch', () => {
     function setPreventScroll(_: boolean) {
     }
 
+    async function setDraggingSide(_: TournamentSideDto) {
+    }
+
     async function renderComponent(containerProps: ITournamentContainerProps, props: ITournamentRoundMatchProps, account?: UserDto) {
         context = await renderApp(
             iocProps({tournamentApi, saygApi}),
@@ -130,6 +133,7 @@ describe('TournamentRoundMatch', () => {
                 setTournamentData,
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             };
 
             it('when has next round', async () => {
@@ -338,6 +342,7 @@ describe('TournamentRoundMatch', () => {
                 setTournamentData,
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             };
 
             it('when no next round', async () => {
@@ -472,6 +477,7 @@ describe('TournamentRoundMatch', () => {
             setTournamentData,
             preventScroll: false,
             setPreventScroll,
+            setDraggingSide,
         };
 
         beforeEach(() => {

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentRoundMatch.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentRoundMatch.test.tsx
@@ -30,6 +30,7 @@ import {playerBuilder} from "../../helpers/builders/players";
 import {matchOptionsBuilder} from "../../helpers/builders/games";
 import {ISaygApi} from "../../interfaces/apis/ISaygApi";
 import {ITournamentGameApi} from "../../interfaces/apis/ITournamentGameApi";
+import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 describe('TournamentRoundMatch', () => {
     let context: TestContext;
@@ -76,6 +77,9 @@ describe('TournamentRoundMatch', () => {
     }
 
     async function setDraggingSide(_: TournamentSideDto) {
+    }
+
+    async function setNewMatch(_: TournamentMatchDto) {
     }
 
     async function renderComponent(containerProps: ITournamentContainerProps, props: ITournamentRoundMatchProps, account?: UserDto) {
@@ -134,6 +138,7 @@ describe('TournamentRoundMatch', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                setNewMatch,
             };
 
             it('when has next round', async () => {
@@ -343,6 +348,7 @@ describe('TournamentRoundMatch', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                setNewMatch,
             };
 
             it('when no next round', async () => {
@@ -478,6 +484,7 @@ describe('TournamentRoundMatch', () => {
             preventScroll: false,
             setPreventScroll,
             setDraggingSide,
+            setNewMatch,
         };
 
         beforeEach(() => {

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentRoundMatch.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentRoundMatch.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import {useState} from "react";
 import {BootstrapDropdown, IBootstrapDropdownItem} from "../common/BootstrapDropdown";
 import {Dialog} from "../common/Dialog";
 import {EditMatchOptions} from "../common/EditMatchOptions";
@@ -8,7 +8,6 @@ import {TournamentRoundDto} from "../../interfaces/models/dtos/Game/TournamentRo
 import {GameMatchOptionDto} from "../../interfaces/models/dtos/Game/GameMatchOptionDto";
 import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
 import {UntypedPromise} from "../../interfaces/UntypedPromise";
-import {useTournament} from "./TournamentContainer";
 
 export interface ITournamentRoundMatchProps {
     readOnly?: boolean;
@@ -33,7 +32,6 @@ export function TournamentRoundMatch({ readOnly, match, hasNextRound, sides, exc
     const scoreBRecorded: boolean = hasScore(match.scoreB);
     const hasBothScores: boolean = scoreARecorded && scoreBRecorded;
     const [matchOptionsDialogOpen, setMatchOptionsDialogOpen] = useState<boolean>(false);
-    const {draggingSide} = useTournament();
 
     function sideSelection(side: TournamentSideDto): IBootstrapDropdownItem {
         return {
@@ -89,26 +87,8 @@ export function TournamentRoundMatch({ readOnly, match, hasNextRound, sides, exc
         return (scoreA !== undefined && scoreA > (numberOfLegs / 2.0)) || false;
     }
 
-    async function dropSideA() {
-        if (draggingSide) {
-            await updateMatch('sideA', draggingSide.id);
-        }
-    }
-
-    async function dropSideB() {
-        if (draggingSide) {
-            await updateMatch('sideB', draggingSide.id);
-        }
-    }
-
-    function preventDefault(event: React.DragEvent) {
-        if (draggingSide) {
-            event.preventDefault();
-        }
-    }
-
     return (<tr className="bg-light">
-        <td className={hasBothScores && isWinner(scoreA) ? 'bg-winner' : ''} onDrop={dropSideA} onDragOver={preventDefault}>
+        <td className={hasBothScores && isWinner(scoreA) ? 'bg-winner' : ''}>
             {readOnly || hasNextRound
                 ? (match.sideA.name || sides.filter(s => s.id === match.sideA.id)[0].name)
                 : (<BootstrapDropdown
@@ -126,7 +106,7 @@ export function TournamentRoundMatch({ readOnly, match, hasNextRound, sides, exc
         <td className={hasBothScores && isWinner(scoreB) ? 'narrow-column bg-winner' : 'narrow-column'}>
             {scoreB || (scoreBRecorded ? '0' : '')}
         </td>
-        <td className={hasBothScores && isWinner(scoreB) ? 'bg-winner' : ''} onDrop={dropSideB} onDragOver={preventDefault}>
+        <td className={hasBothScores && isWinner(scoreB) ? 'bg-winner' : ''}>
             {readOnly || hasNextRound
                 ? (match.sideB.name || sides.filter(s => s.id === match.sideB.id)[0].name)
                 : (<BootstrapDropdown

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentRoundMatch.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentRoundMatch.tsx
@@ -1,4 +1,4 @@
-import {useState} from "react";
+import React, {useState} from "react";
 import {BootstrapDropdown, IBootstrapDropdownItem} from "../common/BootstrapDropdown";
 import {Dialog} from "../common/Dialog";
 import {EditMatchOptions} from "../common/EditMatchOptions";
@@ -8,6 +8,7 @@ import {TournamentRoundDto} from "../../interfaces/models/dtos/Game/TournamentRo
 import {GameMatchOptionDto} from "../../interfaces/models/dtos/Game/GameMatchOptionDto";
 import {TournamentSideDto} from "../../interfaces/models/dtos/Game/TournamentSideDto";
 import {UntypedPromise} from "../../interfaces/UntypedPromise";
+import {useTournament} from "./TournamentContainer";
 
 export interface ITournamentRoundMatchProps {
     readOnly?: boolean;
@@ -32,6 +33,7 @@ export function TournamentRoundMatch({ readOnly, match, hasNextRound, sides, exc
     const scoreBRecorded: boolean = hasScore(match.scoreB);
     const hasBothScores: boolean = scoreARecorded && scoreBRecorded;
     const [matchOptionsDialogOpen, setMatchOptionsDialogOpen] = useState<boolean>(false);
+    const {draggingSide} = useTournament();
 
     function sideSelection(side: TournamentSideDto): IBootstrapDropdownItem {
         return {
@@ -87,8 +89,26 @@ export function TournamentRoundMatch({ readOnly, match, hasNextRound, sides, exc
         return (scoreA !== undefined && scoreA > (numberOfLegs / 2.0)) || false;
     }
 
+    async function dropSideA() {
+        if (draggingSide) {
+            await updateMatch('sideA', draggingSide.id);
+        }
+    }
+
+    async function dropSideB() {
+        if (draggingSide) {
+            await updateMatch('sideB', draggingSide.id);
+        }
+    }
+
+    function preventDefault(event: React.DragEvent) {
+        if (draggingSide) {
+            event.preventDefault();
+        }
+    }
+
     return (<tr className="bg-light">
-        <td className={hasBothScores && isWinner(scoreA) ? 'bg-winner' : ''}>
+        <td className={hasBothScores && isWinner(scoreA) ? 'bg-winner' : ''} onDrop={dropSideA} onDragOver={preventDefault}>
             {readOnly || hasNextRound
                 ? (match.sideA.name || sides.filter(s => s.id === match.sideA.id)[0].name)
                 : (<BootstrapDropdown
@@ -106,7 +126,7 @@ export function TournamentRoundMatch({ readOnly, match, hasNextRound, sides, exc
         <td className={hasBothScores && isWinner(scoreB) ? 'narrow-column bg-winner' : 'narrow-column'}>
             {scoreB || (scoreBRecorded ? '0' : '')}
         </td>
-        <td className={hasBothScores && isWinner(scoreB) ? 'bg-winner' : ''}>
+        <td className={hasBothScores && isWinner(scoreB) ? 'bg-winner' : ''} onDrop={dropSideB} onDragOver={preventDefault}>
             {readOnly || hasNextRound
                 ? (match.sideB.name || sides.filter(s => s.id === match.sideB.id)[0].name)
                 : (<BootstrapDropdown

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentSide.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentSide.test.tsx
@@ -21,7 +21,7 @@ import {divisionBuilder} from "../../helpers/builders/divisions";
 import {teamBuilder} from "../../helpers/builders/teams";
 import {sideBuilder, tournamentBuilder} from "../../helpers/builders/tournaments";
 import {ISaveSideOptions} from "./EditSide";
-import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
+import {tournamentContainerPropsBuilder} from "./tournamentContainerPropsBuilder";
 
 describe('TournamentSide', () => {
     let context: TestContext;
@@ -50,23 +50,6 @@ describe('TournamentSide', () => {
         removed = true;
     }
 
-    function setPreventScroll(_: boolean) {
-    }
-
-    async function setDraggingSide(_: TournamentSideDto) {
-    }
-
-    async function setNewMatch(_: TournamentMatchDto) {
-    }
-
-    function nullTournamentData(): TournamentGameDto {
-        return {
-            date: '',
-            id: '',
-            address: '',
-        }
-    }
-
     async function renderComponent(containerProps: ITournamentContainerProps, props: ITournamentSideProps, teams?: TeamDto[]) {
         context = await renderApp(
             iocProps(),
@@ -86,9 +69,12 @@ describe('TournamentSide', () => {
         const season: SeasonDto = seasonBuilder('SEASON').build();
         const division: DivisionDto = divisionBuilder('DIVISION').build();
         const team: TeamDto = teamBuilder('TEAM').build();
+        const containerProps = new tournamentContainerPropsBuilder({
+            season,
+        });
 
         it('single player (with not found division id) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: sideBuilder('SIDE NAME')
                     .withPlayer('PLAYER', undefined, division.id)
                     .build(),
@@ -109,7 +95,7 @@ describe('TournamentSide', () => {
         });
 
         it('single player (with found division id) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: sideBuilder('SIDE NAME')
                     .withPlayer('PLAYER', undefined, division.id)
                     .build(),
@@ -128,7 +114,7 @@ describe('TournamentSide', () => {
         });
 
         it('single player (without division id) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: sideBuilder('SIDE NAME')
                     .withPlayer('PLAYER')
                     .build(),
@@ -147,7 +133,7 @@ describe('TournamentSide', () => {
         });
 
         it('single player with side name same as player name', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: sideBuilder('PLAYER A')
                     .withPlayer('PLAYER A')
                     .build(),
@@ -171,7 +157,7 @@ describe('TournamentSide', () => {
                 .withPlayer('PLAYER 2', undefined, division.id)
                 .build();
 
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: side,
                 readOnly: false,
                 onChange,
@@ -194,7 +180,7 @@ describe('TournamentSide', () => {
                 .noShow()
                 .build();
 
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: side,
                 readOnly: false,
                 onChange,
@@ -212,7 +198,7 @@ describe('TournamentSide', () => {
         });
 
         it('team (with different side name) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -229,7 +215,7 @@ describe('TournamentSide', () => {
         });
 
         it('team (with not-found division and different side name) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -251,7 +237,7 @@ describe('TournamentSide', () => {
                 .noShow()
                 .build();
 
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: side,
                 readOnly: false,
                 onChange,
@@ -267,7 +253,7 @@ describe('TournamentSide', () => {
         });
 
         it('team (with same side name) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: sideBuilder(team.name)
                     .teamId(team.id)
                     .build(),
@@ -286,7 +272,7 @@ describe('TournamentSide', () => {
         });
 
         it('no-show team (with same side name) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: sideBuilder(team.name)
                     .teamId(team.id)
                     .noShow()
@@ -308,7 +294,7 @@ describe('TournamentSide', () => {
 
         it('team (with missing team data) side', async () => {
             const missingTeam = teamBuilder('MISSING').build();
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: sideBuilder(team.name)
                     .teamId(missingTeam.id)
                     .build(),
@@ -332,10 +318,13 @@ describe('TournamentSide', () => {
     describe('interactivity', () => {
         const season: SeasonDto = seasonBuilder('SEASON').build();
         const team: TeamDto = teamBuilder('TEAM').build();
+        const containerProps = new tournamentContainerPropsBuilder({
+            season,
+        });
 
         it('can edit side', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -353,7 +342,7 @@ describe('TournamentSide', () => {
         });
 
         it('cannot edit side when readonly', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -369,7 +358,7 @@ describe('TournamentSide', () => {
         it('can apply side changes', async () => {
             const sideId = createTemporaryId();
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 side: sideBuilder('SIDE NAME', sideId)
                     .teamId(team.id)
                     .build(),
@@ -399,7 +388,7 @@ describe('TournamentSide', () => {
 
         it('can close edit side dialog', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -419,7 +408,7 @@ describe('TournamentSide', () => {
 
         it('can delete side from within edit side dialog', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -441,7 +430,7 @@ describe('TournamentSide', () => {
 
         it('can delete side', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -460,7 +449,7 @@ describe('TournamentSide', () => {
 
         it('does not delete side if user does not confirm', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.withTournament(tournamentData).build(), {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -479,7 +468,7 @@ describe('TournamentSide', () => {
         });
 
         it('cannot edit side when readonly', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
+            await renderComponent(containerProps.build(), {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentSide.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentSide.test.tsx
@@ -378,7 +378,7 @@ describe('TournamentSide', () => {
             await doClick(findButton(context.container, '✏️'));
             const dialog = context.container.querySelector('.modal-dialog');
             await doChange(dialog!, 'input[name="name"]', 'NEW NAME', context.user);
-            await doClick(findButton(dialog, 'Save'));
+            await doClick(findButton(dialog, 'Update'));
 
             reportedError.verifyNoError();
             expect(updatedData).toEqual({

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentSide.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentSide.test.tsx
@@ -21,6 +21,7 @@ import {divisionBuilder} from "../../helpers/builders/divisions";
 import {teamBuilder} from "../../helpers/builders/teams";
 import {sideBuilder, tournamentBuilder} from "../../helpers/builders/tournaments";
 import {ISaveSideOptions} from "./EditSide";
+import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 describe('TournamentSide', () => {
     let context: TestContext;
@@ -53,6 +54,9 @@ describe('TournamentSide', () => {
     }
 
     async function setDraggingSide(_: TournamentSideDto) {
+    }
+
+    async function setNewMatch(_: TournamentMatchDto) {
     }
 
     function nullTournamentData(): TournamentGameDto {

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentSide.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentSide.test.tsx
@@ -52,6 +52,9 @@ describe('TournamentSide', () => {
     function setPreventScroll(_: boolean) {
     }
 
+    async function setDraggingSide(_: TournamentSideDto) {
+    }
+
     function nullTournamentData(): TournamentGameDto {
         return {
             date: '',
@@ -81,7 +84,7 @@ describe('TournamentSide', () => {
         const team: TeamDto = teamBuilder('TEAM').build();
 
         it('single player (with not found division id) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .withPlayer('PLAYER', undefined, division.id)
                     .build(),
@@ -102,7 +105,7 @@ describe('TournamentSide', () => {
         });
 
         it('single player (with found division id) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .withPlayer('PLAYER', undefined, division.id)
                     .build(),
@@ -121,7 +124,7 @@ describe('TournamentSide', () => {
         });
 
         it('single player (without division id) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .withPlayer('PLAYER')
                     .build(),
@@ -140,7 +143,7 @@ describe('TournamentSide', () => {
         });
 
         it('single player with side name same as player name', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('PLAYER A')
                     .withPlayer('PLAYER A')
                     .build(),
@@ -164,7 +167,7 @@ describe('TournamentSide', () => {
                 .withPlayer('PLAYER 2', undefined, division.id)
                 .build();
 
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: side,
                 readOnly: false,
                 onChange,
@@ -187,7 +190,7 @@ describe('TournamentSide', () => {
                 .noShow()
                 .build();
 
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: side,
                 readOnly: false,
                 onChange,
@@ -205,7 +208,7 @@ describe('TournamentSide', () => {
         });
 
         it('team (with different side name) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -222,7 +225,7 @@ describe('TournamentSide', () => {
         });
 
         it('team (with not-found division and different side name) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -244,7 +247,7 @@ describe('TournamentSide', () => {
                 .noShow()
                 .build();
 
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: side,
                 readOnly: false,
                 onChange,
@@ -260,7 +263,7 @@ describe('TournamentSide', () => {
         });
 
         it('team (with same side name) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder(team.name)
                     .teamId(team.id)
                     .build(),
@@ -279,7 +282,7 @@ describe('TournamentSide', () => {
         });
 
         it('no-show team (with same side name) side', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder(team.name)
                     .teamId(team.id)
                     .noShow()
@@ -301,7 +304,7 @@ describe('TournamentSide', () => {
 
         it('team (with missing team data) side', async () => {
             const missingTeam = teamBuilder('MISSING').build();
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder(team.name)
                     .teamId(missingTeam.id)
                     .build(),
@@ -328,7 +331,7 @@ describe('TournamentSide', () => {
 
         it('can edit side', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -346,7 +349,7 @@ describe('TournamentSide', () => {
         });
 
         it('cannot edit side when readonly', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -362,7 +365,7 @@ describe('TournamentSide', () => {
         it('can apply side changes', async () => {
             const sideId = createTemporaryId();
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME', sideId)
                     .teamId(team.id)
                     .build(),
@@ -392,7 +395,7 @@ describe('TournamentSide', () => {
 
         it('can close edit side dialog', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -412,7 +415,7 @@ describe('TournamentSide', () => {
 
         it('can delete side from within edit side dialog', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -434,7 +437,7 @@ describe('TournamentSide', () => {
 
         it('can delete side', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -453,7 +456,7 @@ describe('TournamentSide', () => {
 
         it('does not delete side if user does not confirm', async () => {
             const tournamentData: TournamentGameDto = tournamentBuilder().build();
-            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData, preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),
@@ -472,7 +475,7 @@ describe('TournamentSide', () => {
         });
 
         it('cannot edit side when readonly', async () => {
-            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll}, {
+            await renderComponent({season, tournamentData: nullTournamentData(), preventScroll: false, setPreventScroll, setDraggingSide}, {
                 side: sideBuilder('SIDE NAME')
                     .teamId(team.id)
                     .build(),

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentSide.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentSide.tsx
@@ -8,7 +8,6 @@ import {UntypedPromise} from "../../interfaces/UntypedPromise";
 export interface ITournamentSideProps {
     side: TournamentSideDto;
     onChange?(editSide: TournamentSideDto, options: ISaveSideOptions): UntypedPromise;
-    winner?: boolean;
     readOnly?: boolean;
     onRemove(): UntypedPromise;
     showEditSide?: boolean;
@@ -16,7 +15,7 @@ export interface ITournamentSideProps {
     onStartDrag?(side: TournamentSideDto): UntypedPromise;
 }
 
-export function TournamentSide({side, onChange, winner, readOnly, onRemove, showEditSide, showDeleteSide, onStartDrag}: ITournamentSideProps) {
+export function TournamentSide({side, onChange, readOnly, onRemove, showEditSide, showDeleteSide, onStartDrag}: ITournamentSideProps) {
     const [editSide, setEditSide] = useState<TournamentSideDto | null>(null);
 
     function renderPlayers() {
@@ -58,7 +57,7 @@ export function TournamentSide({side, onChange, winner, readOnly, onRemove, show
         }
     }
 
-    return (<div className={`d-flex flex-row p-1 m-1 ${winner ? 'bg-winner' : 'bg-light'}`}
+    return (<div className="d-flex flex-row p-1 m-1 bg-light"
                  draggable={!!onStartDrag}
                  onDragStart={async () => await onStartDrag!(side)}
                  style={{flexBasis: '100px', flexGrow: 1, flexShrink: 1}}>

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentSide.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentSide.tsx
@@ -13,9 +13,10 @@ export interface ITournamentSideProps {
     onRemove(): UntypedPromise;
     showEditSide?: boolean;
     showDeleteSide?: boolean;
+    onStartDrag?(side: TournamentSideDto): UntypedPromise;
 }
 
-export function TournamentSide({side, onChange, winner, readOnly, onRemove, showEditSide, showDeleteSide}: ITournamentSideProps) {
+export function TournamentSide({side, onChange, winner, readOnly, onRemove, showEditSide, showDeleteSide, onStartDrag}: ITournamentSideProps) {
     const [editSide, setEditSide] = useState<TournamentSideDto | null>(null);
 
     function renderPlayers() {
@@ -58,6 +59,8 @@ export function TournamentSide({side, onChange, winner, readOnly, onRemove, show
     }
 
     return (<div className={`d-flex flex-row p-1 m-1 ${winner ? 'bg-winner' : 'bg-light'}`}
+                 draggable={!!onStartDrag}
+                 onDragStart={async () => await onStartDrag!(side)}
                  style={{flexBasis: '100px', flexGrow: 1, flexShrink: 1}}>
         <strong className={side.noShow ? 'text-decoration-line-through' : ''}>{side.name}</strong>
         {renderPlayers()}

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.test.tsx
@@ -30,6 +30,7 @@ import {saygBuilder} from "../../../helpers/builders/sayg";
 import {START_SCORING} from "../tournaments";
 import {UntypedPromise} from "../../../interfaces/UntypedPromise";
 import {TournamentSideDto} from "../../../interfaces/models/dtos/Game/TournamentSideDto";
+import {TournamentMatchDto} from "../../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 describe('MasterDraw', () => {
     let context: TestContext;
@@ -92,6 +93,9 @@ describe('MasterDraw', () => {
     async function setDraggingSide(_: TournamentSideDto) {
     }
 
+    async function setNewMatch(_: TournamentMatchDto) {
+    }
+
     async function renderComponent(props: IMasterDrawProps, containerProps: ITournamentContainerProps, account?: UserDto) {
         context = await renderApp(
             iocProps({tournamentApi, saygApi}),
@@ -107,7 +111,9 @@ describe('MasterDraw', () => {
             tournamentData: tournamentBuilder().build(),
             preventScroll: false,
             setPreventScroll(_: boolean) {},
-            async setDraggingSide(_?: TournamentSideDto) {},
+            setDraggingSide,
+            newMatch: {},
+            setNewMatch,
         };
 
         it('matches', async () => {
@@ -181,6 +187,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             });
             reportedError.verifyNoError();
 
@@ -204,6 +212,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             });
             reportedError.verifyNoError();
 
@@ -231,6 +241,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             });
             reportedError.verifyNoError();
 
@@ -258,6 +270,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             });
             reportedError.verifyNoError();
 
@@ -285,6 +299,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             });
             reportedError.verifyNoError();
 
@@ -312,6 +328,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             });
             reportedError.verifyNoError();
 
@@ -335,6 +353,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             });
             reportedError.verifyNoError();
 
@@ -358,6 +378,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             });
             reportedError.verifyNoError();
 
@@ -380,6 +402,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             });
             reportedError.verifyNoError();
 
@@ -402,6 +426,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             });
             reportedError.verifyNoError();
 
@@ -439,6 +465,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, account);
             reportedError.verifyNoError();
 
@@ -481,6 +509,8 @@ describe('MasterDraw', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, account);
             reportedError.verifyNoError();
             await doClick(findButton(context.container.querySelector('div[datatype="master-draw"]'), START_SCORING));

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.test.tsx
@@ -28,9 +28,7 @@ import {ISaygApi} from "../../../interfaces/apis/ISaygApi";
 import {RecordedScoreAsYouGoDto} from "../../../interfaces/models/dtos/Game/Sayg/RecordedScoreAsYouGoDto";
 import {saygBuilder} from "../../../helpers/builders/sayg";
 import {START_SCORING} from "../tournaments";
-import {UntypedPromise} from "../../../interfaces/UntypedPromise";
-import {TournamentSideDto} from "../../../interfaces/models/dtos/Game/TournamentSideDto";
-import {TournamentMatchDto} from "../../../interfaces/models/dtos/Game/TournamentMatchDto";
+import {tournamentContainerPropsBuilder} from "../tournamentContainerPropsBuilder";
 
 describe('MasterDraw', () => {
     let context: TestContext;
@@ -80,22 +78,6 @@ describe('MasterDraw', () => {
         editTournament = value;
     }
 
-    async function saveTournament(_?: boolean): Promise<TournamentGameDto | undefined> {
-        return undefined;
-    }
-
-    async function setTournamentData(_: TournamentGameDto): UntypedPromise {
-    }
-
-    function setPreventScroll(_: boolean) {
-    }
-
-    async function setDraggingSide(_: TournamentSideDto) {
-    }
-
-    async function setNewMatch(_: TournamentMatchDto) {
-    }
-
     async function renderComponent(props: IMasterDrawProps, containerProps: ITournamentContainerProps, account?: UserDto) {
         context = await renderApp(
             iocProps({tournamentApi, saygApi}),
@@ -104,17 +86,12 @@ describe('MasterDraw', () => {
             (<TournamentContainer {...containerProps}>
                 <MasterDraw {...props} />
             </TournamentContainer>));
+
+        reportedError.verifyNoError();
     }
 
     describe('renders', () => {
-        const defaultContainerProps: ITournamentContainerProps = {
-            tournamentData: tournamentBuilder().build(),
-            preventScroll: false,
-            setPreventScroll(_: boolean) {},
-            setDraggingSide,
-            newMatch: {},
-            setNewMatch,
-        };
+        const containerProps = new tournamentContainerPropsBuilder({ setEditTournament });
 
         it('matches', async () => {
             const match1 = tournamentMatchBuilder().sideA('A').sideB('B').build();
@@ -128,9 +105,8 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, defaultContainerProps);
+            }, containerProps.build());
 
-            reportedError.verifyNoError();
             const table = context.container.querySelector('table.table')!;
             const rows = Array.from(table.querySelectorAll('tbody tr'));
             expect(rows.length).toEqual(2);
@@ -146,9 +122,8 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'Board 1',
-            }, defaultContainerProps);
+            }, containerProps.build());
 
-            reportedError.verifyNoError();
             const tournamentProperties = context.container.querySelector('div.d-flex > div:nth-child(2)')!;
             expect(tournamentProperties.textContent).toContain('Gender: GENDER');
             expect(tournamentProperties.textContent).toContain('Date: ' + renderDate('2023-05-06'));
@@ -163,9 +138,8 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: '',
-            }, defaultContainerProps);
+            }, containerProps.build());
 
-            reportedError.verifyNoError();
             const tournamentProperties = context.container.querySelector('div.d-flex > div:nth-child(2)')!;
             expect(tournamentProperties.textContent).toContain('Gender: GENDER');
             expect(tournamentProperties.textContent).not.toContain('Notes:');
@@ -173,6 +147,8 @@ describe('MasterDraw', () => {
     });
 
     describe('interactivity', () => {
+        const containerProps = new tournamentContainerPropsBuilder({ setEditTournament })
+
         it('can edit tournament from heading', async () => {
             await renderComponent({
                 matches: [],
@@ -181,16 +157,7 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                setEditTournament,
-                tournamentData: tournamentBuilder().build(),
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            });
-            reportedError.verifyNoError();
+            }, containerProps.build());
 
             await doClick(context.container.querySelector('div[datatype="master-draw"] > h2')!);
 
@@ -206,16 +173,7 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                setEditTournament,
-                tournamentData: tournamentBuilder().build(),
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            });
-            reportedError.verifyNoError();
+            }, containerProps.build());
 
             await doClick(context.container.querySelector('div[datatype="master-draw"] thead tr:first-child')!);
 
@@ -235,16 +193,7 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                setEditTournament,
-                tournamentData: tournamentBuilder().build(),
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            });
-            reportedError.verifyNoError();
+            }, containerProps.build());
 
             await doClick(context.container.querySelector('div[datatype="master-draw"] tbody td:nth-child(1)')!);
 
@@ -264,16 +213,7 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                setEditTournament,
-                tournamentData: tournamentBuilder().build(),
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            });
-            reportedError.verifyNoError();
+            }, containerProps.build());
 
             await doClick(context.container.querySelector('div[datatype="master-draw"] tbody tr:first-child td:nth-child(2)')!);
 
@@ -293,16 +233,7 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                setEditTournament,
-                tournamentData: tournamentBuilder().build(),
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            });
-            reportedError.verifyNoError();
+            }, containerProps.build());
 
             await doClick(context.container.querySelector('div[datatype="master-draw"] tbody tr:first-child td:nth-child(3)')!);
 
@@ -322,16 +253,7 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                setEditTournament,
-                tournamentData: tournamentBuilder().build(),
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            });
-            reportedError.verifyNoError();
+            }, containerProps.build());
 
             await doClick(context.container.querySelector('div[datatype="master-draw"] tbody tr:first-child td:nth-child(4)')!);
 
@@ -347,16 +269,7 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                setEditTournament,
-                tournamentData: tournamentBuilder().build(),
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            });
-            reportedError.verifyNoError();
+            }, containerProps.build());
 
             await doClick(context.container.querySelector('div[datatype="master-draw"] tfoot td')!);
 
@@ -372,16 +285,7 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                setEditTournament,
-                tournamentData: tournamentBuilder().build(),
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            });
-            reportedError.verifyNoError();
+            }, containerProps.build());
 
             await doClick(context.container.querySelector('div[datatype="details"]')!);
 
@@ -390,6 +294,8 @@ describe('MasterDraw', () => {
         });
 
         it('cannot edit tournament from heading when not permitted', async () => {
+            const readonlyContainerProps = containerProps.withTournament(tournamentBuilder().singleRound().build()).build();
+            readonlyContainerProps.setEditTournament = undefined;
             await renderComponent({
                 matches: [],
                 host: 'HOST',
@@ -397,15 +303,7 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                tournamentData: tournamentBuilder().build(),
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            });
-            reportedError.verifyNoError();
+            }, readonlyContainerProps);
 
             await doClick(context.container.querySelector('div[datatype="master-draw"] > h2')!);
 
@@ -421,19 +319,12 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                tournamentData: tournamentBuilder().build(),
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            });
-            reportedError.verifyNoError();
+            }, containerProps.build());
 
             await doClick(context.container.querySelector('div[datatype="master-draw"] > div')!);
 
             reportedError.verifyNoError();
+            // TODO: This test might not be working correctly, i'd expect `editTournament` to be set, as `setEditTournament` is provided
             expect(editTournament).toEqual(null);
         });
 
@@ -457,18 +348,8 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                setEditTournament,
-                tournamentData: tournamentBuilder().singleRound().build(),
-                saveTournament,
-                setTournamentData,
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, account);
-            reportedError.verifyNoError();
+            }, containerProps
+                .withTournament(tournamentBuilder().singleRound().build()).build(), account);
 
             await doClick(findButton(context.container.querySelector('div[datatype="master-draw"]'), START_SCORING));
 
@@ -501,18 +382,12 @@ describe('MasterDraw', () => {
                 gender: 'GENDER',
                 date: '2023-05-06',
                 type: 'TYPE',
-            }, {
-                setEditTournament,
-                tournamentData: tournamentBuilder(tournamentId).round((r: ITournamentRoundBuilder) => r.withMatch(match)).singleRound().build(),
-                saveTournament,
-                setTournamentData,
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, account);
-            reportedError.verifyNoError();
+            }, containerProps
+                .withTournament(tournamentBuilder(tournamentId)
+                    .round((r: ITournamentRoundBuilder) => r.withMatch(match))
+                    .singleRound()
+                    .build())
+                .build(), account);
             await doClick(findButton(context.container.querySelector('div[datatype="master-draw"]'), START_SCORING));
             reportedError.verifyNoError();
             const dialog = context.container.querySelector('.modal-dialog');

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.test.tsx
@@ -29,6 +29,7 @@ import {RecordedScoreAsYouGoDto} from "../../../interfaces/models/dtos/Game/Sayg
 import {saygBuilder} from "../../../helpers/builders/sayg";
 import {START_SCORING} from "../tournaments";
 import {UntypedPromise} from "../../../interfaces/UntypedPromise";
+import {TournamentSideDto} from "../../../interfaces/models/dtos/Game/TournamentSideDto";
 
 describe('MasterDraw', () => {
     let context: TestContext;
@@ -88,6 +89,9 @@ describe('MasterDraw', () => {
     function setPreventScroll(_: boolean) {
     }
 
+    async function setDraggingSide(_: TournamentSideDto) {
+    }
+
     async function renderComponent(props: IMasterDrawProps, containerProps: ITournamentContainerProps, account?: UserDto) {
         context = await renderApp(
             iocProps({tournamentApi, saygApi}),
@@ -103,6 +107,7 @@ describe('MasterDraw', () => {
             tournamentData: tournamentBuilder().build(),
             preventScroll: false,
             setPreventScroll(_: boolean) {},
+            async setDraggingSide(_?: TournamentSideDto) {},
         };
 
         it('matches', async () => {
@@ -175,6 +180,7 @@ describe('MasterDraw', () => {
                 tournamentData: tournamentBuilder().build(),
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             });
             reportedError.verifyNoError();
 
@@ -197,6 +203,7 @@ describe('MasterDraw', () => {
                 tournamentData: tournamentBuilder().build(),
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             });
             reportedError.verifyNoError();
 
@@ -223,6 +230,7 @@ describe('MasterDraw', () => {
                 tournamentData: tournamentBuilder().build(),
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             });
             reportedError.verifyNoError();
 
@@ -249,6 +257,7 @@ describe('MasterDraw', () => {
                 tournamentData: tournamentBuilder().build(),
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             });
             reportedError.verifyNoError();
 
@@ -275,6 +284,7 @@ describe('MasterDraw', () => {
                 tournamentData: tournamentBuilder().build(),
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             });
             reportedError.verifyNoError();
 
@@ -301,6 +311,7 @@ describe('MasterDraw', () => {
                 tournamentData: tournamentBuilder().build(),
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             });
             reportedError.verifyNoError();
 
@@ -323,6 +334,7 @@ describe('MasterDraw', () => {
                 tournamentData: tournamentBuilder().build(),
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             });
             reportedError.verifyNoError();
 
@@ -345,6 +357,7 @@ describe('MasterDraw', () => {
                 tournamentData: tournamentBuilder().build(),
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             });
             reportedError.verifyNoError();
 
@@ -366,6 +379,7 @@ describe('MasterDraw', () => {
                 tournamentData: tournamentBuilder().build(),
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             });
             reportedError.verifyNoError();
 
@@ -387,6 +401,7 @@ describe('MasterDraw', () => {
                 tournamentData: tournamentBuilder().build(),
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             });
             reportedError.verifyNoError();
 
@@ -423,6 +438,7 @@ describe('MasterDraw', () => {
                 setTournamentData,
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             }, account);
             reportedError.verifyNoError();
 
@@ -464,6 +480,7 @@ describe('MasterDraw', () => {
                 setTournamentData,
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             }, account);
             reportedError.verifyNoError();
             await doClick(findButton(context.container.querySelector('div[datatype="master-draw"]'), START_SCORING));

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/SuperLeaguePrintout.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/SuperLeaguePrintout.test.tsx
@@ -31,6 +31,7 @@ import {CHECKOUT_2_DART} from "../../../helpers/constants";
 import {checkoutWith, enterScores} from "../../../helpers/sayg";
 import {START_SCORING} from "../tournaments";
 import {TournamentSideDto} from "../../../interfaces/models/dtos/Game/TournamentSideDto";
+import {TournamentMatchDto} from "../../../interfaces/models/dtos/Game/TournamentMatchDto";
 
 describe('SuperLeaguePrintout', () => {
     let context: TestContext;
@@ -79,6 +80,9 @@ describe('SuperLeaguePrintout', () => {
     }
 
     async function setDraggingSide(_: TournamentSideDto) {
+    }
+
+    async function setNewMatch(_: TournamentMatchDto) {
     }
 
     async function patchData(): Promise<boolean> {
@@ -159,6 +163,8 @@ describe('SuperLeaguePrintout', () => {
                 preventScroll: false,
                 setPreventScroll,
                 setDraggingSide,
+                newMatch: {},
+                setNewMatch,
             }, { division }, access);
 
             reportedError.verifyNoError();
@@ -202,6 +208,8 @@ describe('SuperLeaguePrintout', () => {
                     preventScroll: false,
                     setPreventScroll,
                     setDraggingSide,
+                    newMatch: {},
+                    setNewMatch,
                 }, { division }, access);
 
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
@@ -236,6 +244,8 @@ describe('SuperLeaguePrintout', () => {
                     preventScroll: false,
                     setPreventScroll,
                     setDraggingSide,
+                    newMatch: {},
+                    setNewMatch,
                 }, { division }, access);
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
                 expect(context.container.querySelector('div[datatype="match-report"] > div > div:nth-child(1)')!.textContent).toEqual('Legs won: 2');
@@ -289,6 +299,8 @@ describe('SuperLeaguePrintout', () => {
                     preventScroll: false,
                     setPreventScroll,
                     setDraggingSide,
+                    newMatch: {},
+                    setNewMatch,
                 }, { division }, access);
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
 
@@ -324,6 +336,8 @@ describe('SuperLeaguePrintout', () => {
                     preventScroll: false,
                     setPreventScroll,
                     setDraggingSide,
+                    newMatch: {},
+                    setNewMatch,
                 }, { division }, access);
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '⏸️ Paused');
@@ -363,6 +377,8 @@ describe('SuperLeaguePrintout', () => {
                     preventScroll: false,
                     setPreventScroll,
                     setDraggingSide,
+                    newMatch: {},
+                    setNewMatch,
                 }, { division }, access);
                 await doClick(findButton(context.container, START_SCORING));
                 const dialog = context.container.querySelector('div.modal-dialog')!;
@@ -405,6 +421,8 @@ describe('SuperLeaguePrintout', () => {
                     preventScroll: false,
                     setPreventScroll,
                     setDraggingSide,
+                    newMatch: {},
+                    setNewMatch,
                 }, { division, patchData }, access);
                 await doClick(findButton(context.container, START_SCORING));
                 const dialog = context.container.querySelector('div.modal-dialog')!;

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/SuperLeaguePrintout.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/SuperLeaguePrintout.test.tsx
@@ -30,6 +30,7 @@ import {IClientActionResultDto} from "../../common/IClientActionResultDto";
 import {CHECKOUT_2_DART} from "../../../helpers/constants";
 import {checkoutWith, enterScores} from "../../../helpers/sayg";
 import {START_SCORING} from "../tournaments";
+import {TournamentSideDto} from "../../../interfaces/models/dtos/Game/TournamentSideDto";
 
 describe('SuperLeaguePrintout', () => {
     let context: TestContext;
@@ -75,6 +76,9 @@ describe('SuperLeaguePrintout', () => {
     });
 
     function setPreventScroll(_: boolean) {
+    }
+
+    async function setDraggingSide(_: TournamentSideDto) {
     }
 
     async function patchData(): Promise<boolean> {
@@ -154,6 +158,7 @@ describe('SuperLeaguePrintout', () => {
                 tournamentData,
                 preventScroll: false,
                 setPreventScroll,
+                setDraggingSide,
             }, { division }, access);
 
             reportedError.verifyNoError();
@@ -196,6 +201,7 @@ describe('SuperLeaguePrintout', () => {
                     tournamentData,
                     preventScroll: false,
                     setPreventScroll,
+                    setDraggingSide,
                 }, { division }, access);
 
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
@@ -229,6 +235,7 @@ describe('SuperLeaguePrintout', () => {
                     tournamentData,
                     preventScroll: false,
                     setPreventScroll,
+                    setDraggingSide,
                 }, { division }, access);
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
                 expect(context.container.querySelector('div[datatype="match-report"] > div > div:nth-child(1)')!.textContent).toEqual('Legs won: 2');
@@ -281,6 +288,7 @@ describe('SuperLeaguePrintout', () => {
                     tournamentData,
                     preventScroll: false,
                     setPreventScroll,
+                    setDraggingSide,
                 }, { division }, access);
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
 
@@ -315,6 +323,7 @@ describe('SuperLeaguePrintout', () => {
                     tournamentData,
                     preventScroll: false,
                     setPreventScroll,
+                    setDraggingSide,
                 }, { division }, access);
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '⏸️ Paused');
@@ -353,6 +362,7 @@ describe('SuperLeaguePrintout', () => {
                     tournamentData,
                     preventScroll: false,
                     setPreventScroll,
+                    setDraggingSide,
                 }, { division }, access);
                 await doClick(findButton(context.container, START_SCORING));
                 const dialog = context.container.querySelector('div.modal-dialog')!;
@@ -394,6 +404,7 @@ describe('SuperLeaguePrintout', () => {
                     tournamentData,
                     preventScroll: false,
                     setPreventScroll,
+                    setDraggingSide,
                 }, { division, patchData }, access);
                 await doClick(findButton(context.container, START_SCORING));
                 const dialog = context.container.querySelector('div.modal-dialog')!;

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/SuperLeaguePrintout.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/SuperLeaguePrintout.test.tsx
@@ -30,8 +30,7 @@ import {IClientActionResultDto} from "../../common/IClientActionResultDto";
 import {CHECKOUT_2_DART} from "../../../helpers/constants";
 import {checkoutWith, enterScores} from "../../../helpers/sayg";
 import {START_SCORING} from "../tournaments";
-import {TournamentSideDto} from "../../../interfaces/models/dtos/Game/TournamentSideDto";
-import {TournamentMatchDto} from "../../../interfaces/models/dtos/Game/TournamentMatchDto";
+import {tournamentContainerPropsBuilder} from "../tournamentContainerPropsBuilder";
 
 describe('SuperLeaguePrintout', () => {
     let context: TestContext;
@@ -75,15 +74,6 @@ describe('SuperLeaguePrintout', () => {
 
         document.exitFullscreen = noop;
     });
-
-    function setPreventScroll(_: boolean) {
-    }
-
-    async function setDraggingSide(_: TournamentSideDto) {
-    }
-
-    async function setNewMatch(_: TournamentMatchDto) {
-    }
 
     async function patchData(): Promise<boolean> {
         return patchSuccess;
@@ -134,6 +124,7 @@ describe('SuperLeaguePrintout', () => {
         const access: AccessDto = {
             useWebSockets: true,
         };
+        const containerProps = new tournamentContainerPropsBuilder();
 
         it('print out', async () => {
             const saygData1: RecordedScoreAsYouGoDto = saygBuilder()
@@ -158,14 +149,7 @@ describe('SuperLeaguePrintout', () => {
             saygApiResponseMap[saygData1.id] = saygData1;
             saygApiResponseMap[saygData2.id] = saygData2;
 
-            await renderComponent({
-                tournamentData,
-                preventScroll: false,
-                setPreventScroll,
-                setDraggingSide,
-                newMatch: {},
-                setNewMatch,
-            }, { division }, access);
+            await renderComponent(containerProps.withTournament(tournamentData).build(), { division }, access);
 
             reportedError.verifyNoError();
             const headings = Array.from(context.container.querySelectorAll('h2'));
@@ -180,6 +164,7 @@ describe('SuperLeaguePrintout', () => {
             const access: AccessDto = {
                 useWebSockets: true,
             };
+            const containerProps = new tournamentContainerPropsBuilder();
 
             it('can start live updates', async () => {
                 const saygData1: RecordedScoreAsYouGoDto = saygBuilder()
@@ -203,14 +188,7 @@ describe('SuperLeaguePrintout', () => {
                 saygApiResponseMap = {};
                 saygApiResponseMap[saygData1.id] = saygData1;
                 saygApiResponseMap[saygData2.id] = saygData2;
-                await renderComponent({
-                    tournamentData,
-                    preventScroll: false,
-                    setPreventScroll,
-                    setDraggingSide,
-                    newMatch: {},
-                    setNewMatch,
-                }, { division }, access);
+                await renderComponent(containerProps.withTournament(tournamentData).build(), { division }, access);
 
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
 
@@ -239,14 +217,7 @@ describe('SuperLeaguePrintout', () => {
                 saygApiResponseMap = {};
                 saygApiResponseMap[saygData1.id] = saygData1;
                 saygApiResponseMap[saygData2.id] = saygData2;
-                await renderComponent({
-                    tournamentData,
-                    preventScroll: false,
-                    setPreventScroll,
-                    setDraggingSide,
-                    newMatch: {},
-                    setNewMatch,
-                }, { division }, access);
+                await renderComponent(containerProps.withTournament(tournamentData).build(), { division }, access);
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
                 expect(context.container.querySelector('div[datatype="match-report"] > div > div:nth-child(1)')!.textContent).toEqual('Legs won: 2');
                 expect(context.container.querySelector('div[datatype="match-report"] > div > div:nth-child(2)')!.textContent).toEqual('Legs won: 2');
@@ -294,14 +265,7 @@ describe('SuperLeaguePrintout', () => {
                 saygApiResponseMap = {};
                 saygApiResponseMap[saygData1.id] = saygData1;
                 saygApiResponseMap[saygData2.id] = saygData2;
-                await renderComponent({
-                    tournamentData,
-                    preventScroll: false,
-                    setPreventScroll,
-                    setDraggingSide,
-                    newMatch: {},
-                    setNewMatch,
-                }, { division }, access);
+                await renderComponent(containerProps.withTournament(tournamentData).build(), { division }, access);
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
 
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '⏸️ Paused');
@@ -331,14 +295,7 @@ describe('SuperLeaguePrintout', () => {
                 saygApiResponseMap = {};
                 saygApiResponseMap[saygData1.id] = saygData1;
                 saygApiResponseMap[saygData2.id] = saygData2;
-                await renderComponent({
-                    tournamentData,
-                    preventScroll: false,
-                    setPreventScroll,
-                    setDraggingSide,
-                    newMatch: {},
-                    setNewMatch,
-                }, { division }, access);
+                await renderComponent(containerProps.withTournament(tournamentData).build(), { division }, access);
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '▶️ Live');
                 await doSelectOption(context.container.querySelector('.dropdown-menu'), '⏸️ Paused');
                 expect(Object.keys(socketFactory.subscriptions)).toEqual([]);
@@ -354,6 +311,7 @@ describe('SuperLeaguePrintout', () => {
                 manageTournaments: true,
                 recordScoresAsYouGo: true,
             };
+            const containerProps = new tournamentContainerPropsBuilder();
 
             it('does not reload sayg data if patch cannot be applied', async () => {
                 saygApiResponseMap = {};
@@ -372,14 +330,7 @@ describe('SuperLeaguePrintout', () => {
                             .sideB('PLAYER B')))
                     .build();
                 const division: DivisionDto = divisionBuilder('DIVISION').build();
-                await renderComponent({
-                    tournamentData,
-                    preventScroll: false,
-                    setPreventScroll,
-                    setDraggingSide,
-                    newMatch: {},
-                    setNewMatch,
-                }, { division }, access);
+                await renderComponent(containerProps.withTournament(tournamentData).build(), { division }, access);
                 await doClick(findButton(context.container, START_SCORING));
                 const dialog = context.container.querySelector('div.modal-dialog')!;
                 expect(saygDataRequests[saygData1.id]).toEqual(2); // data is loaded as the dialog opens
@@ -416,14 +367,7 @@ describe('SuperLeaguePrintout', () => {
                             .sideB('PLAYER B')))
                     .build();
                 const division: DivisionDto = divisionBuilder('DIVISION').build();
-                await renderComponent({
-                    tournamentData,
-                    preventScroll: false,
-                    setPreventScroll,
-                    setDraggingSide,
-                    newMatch: {},
-                    setNewMatch,
-                }, { division, patchData }, access);
+                await renderComponent(containerProps.withTournament(tournamentData).build(), { division, patchData }, access);
                 await doClick(findButton(context.container, START_SCORING));
                 const dialog = context.container.querySelector('div.modal-dialog')!;
                 expect(saygDataRequests[saygData1.id]).toEqual(2); // data is loaded as the dialog opens

--- a/CourageScores/ClientApp/src/components/tournaments/tournamentContainerPropsBuilder.ts
+++ b/CourageScores/ClientApp/src/components/tournaments/tournamentContainerPropsBuilder.ts
@@ -1,4 +1,6 @@
-﻿import {ITournamentContainerProps} from "./TournamentContainer";
+﻿/* istanbul ignore file */
+
+import {ITournamentContainerProps} from "./TournamentContainer";
 import {TournamentGameDto} from "../../interfaces/models/dtos/Game/TournamentGameDto";
 import {DivisionDto} from "../../interfaces/models/dtos/DivisionDto";
 import {GameMatchOptionDto} from "../../interfaces/models/dtos/Game/GameMatchOptionDto";

--- a/CourageScores/ClientApp/src/components/tournaments/tournamentContainerPropsBuilder.ts
+++ b/CourageScores/ClientApp/src/components/tournaments/tournamentContainerPropsBuilder.ts
@@ -1,0 +1,78 @@
+﻿import {ITournamentContainerProps} from "./TournamentContainer";
+import {TournamentGameDto} from "../../interfaces/models/dtos/Game/TournamentGameDto";
+import {DivisionDto} from "../../interfaces/models/dtos/DivisionDto";
+import {GameMatchOptionDto} from "../../interfaces/models/dtos/Game/GameMatchOptionDto";
+import {noop} from "../../helpers/tests";
+import {TeamPlayerDto} from "../../interfaces/models/dtos/Team/TeamPlayerDto";
+import {ITournamentPlayerMap} from "./Tournament";
+import {tournamentBuilder} from "../../helpers/builders/tournaments";
+import {UntypedPromise} from "../../interfaces/UntypedPromise";
+import {TournamentMatchDto} from "../../interfaces/models/dtos/Game/TournamentMatchDto";
+
+export class tournamentContainerPropsBuilder
+{
+    private readonly props: ITournamentContainerProps;
+
+    constructor(initProps?: Partial<ITournamentContainerProps>) {
+        this.props = Object.assign({
+            preventScroll: false,
+            setPreventScroll: noop,
+            setDraggingSide: noop,
+            saveTournament: noop,
+            setEditTournament: noop,
+            setTournamentData: noop,
+            setWarnBeforeEditDialogClose: noop,
+            newMatch: {
+                id: '',
+            },
+            setNewMatch: noop,
+            tournamentData: tournamentBuilder().build(),
+        }, initProps);
+    }
+
+    public withTournament(tournamentData: TournamentGameDto): tournamentContainerPropsBuilder {
+        return new tournamentContainerPropsBuilder(Object.assign({}, this.props, {
+            tournamentData
+        }));
+    }
+
+    public withDivision(division: DivisionDto): tournamentContainerPropsBuilder {
+        return new tournamentContainerPropsBuilder(Object.assign({}, this.props, {
+            division
+        }));
+    }
+
+    public withMatchOptionDefaults(defaults: GameMatchOptionDto): tournamentContainerPropsBuilder {
+        return new tournamentContainerPropsBuilder(Object.assign({}, this.props, {
+            matchOptionDefaults: defaults,
+        }));
+    }
+
+    public withAllPlayers(allPlayers: TeamPlayerDto[]): tournamentContainerPropsBuilder {
+        return new tournamentContainerPropsBuilder(Object.assign({}, this.props, {
+            allPlayers,
+        }));
+    }
+
+    public withAlreadyPlaying(alreadyPlaying: ITournamentPlayerMap): tournamentContainerPropsBuilder {
+        return new tournamentContainerPropsBuilder(Object.assign({}, this.props, {
+            alreadyPlaying,
+        }));
+    }
+
+    public withSetNewMatch(setNewMatch: (match: TournamentMatchDto) => UntypedPromise): tournamentContainerPropsBuilder {
+        return new tournamentContainerPropsBuilder(Object.assign({}, this.props, {
+            setNewMatch,
+        }));
+    }
+
+    public withNewMatch(newMatch: TournamentMatchDto): tournamentContainerPropsBuilder {
+        return new tournamentContainerPropsBuilder(Object.assign({}, this.props, {
+            newMatch,
+        }));
+    }
+
+    public build(): ITournamentContainerProps {
+        return this.props;
+    }
+}


### PR DESCRIPTION
Related to #1376

- [x] dragging/selecting a side for a new match should remove the ability to delete the side
    - [x] should not be able to drag already selected side
 - [x] remove winner highlight, not helpful in superleague fixtures 