### PR TITLE
#1598: Find the team for the tournament season only

### DIFF
--- a/CourageScores/ClientApp/src/components/common/MultiPlayerSelection.tsx
+++ b/CourageScores/ClientApp/src/components/common/MultiPlayerSelection.tsx
@@ -10,6 +10,7 @@ import { SeasonDto } from '../../interfaces/models/dtos/Season/SeasonDto';
 import { DivisionDto } from '../../interfaces/models/dtos/DivisionDto';
 import { Link } from 'react-router';
 import { UntypedPromise } from '../../interfaces/UntypedPromise';
+import { findTeam } from '../../helpers/teams';
 
 export interface IMultiPlayerSelectionProps {
     onAddPlayer?(player: ISelectablePlayer, score: number): UntypedPromise;
@@ -99,22 +100,15 @@ export function MultiPlayerSelection({
     }
 
     function getTeamName(playerId: string): string | null {
-        const team = teams.find((t) => {
-            const teamSeason: TeamSeasonDto = t.seasons!.find(
-                (ts: TeamSeasonDto) =>
-                    ts.seasonId === season!.id && !ts.deleted,
-            )!;
-            if (!teamSeason) {
-                return null;
-            }
-
+        const predicate = (teamSeason: TeamSeasonDto) => {
             return any(
                 teamSeason.players!,
                 (p: TeamPlayerDto) => p.id === playerId,
             );
-        });
+        };
 
-        return team ? team.name : null;
+        const found = findTeam(teams, predicate, season!.id);
+        return found?.team.name ?? null;
     }
 
     try {

--- a/CourageScores/ClientApp/src/components/common/MultiPlayerSelection.tsx
+++ b/CourageScores/ClientApp/src/components/common/MultiPlayerSelection.tsx
@@ -4,7 +4,6 @@ import { any } from '../../helpers/collections';
 import { useApp } from './AppContainer';
 import { TeamPlayerDto } from '../../interfaces/models/dtos/Team/TeamPlayerDto';
 import { NotablePlayerDto } from '../../interfaces/models/dtos/Game/NotablePlayerDto';
-import { TeamDto } from '../../interfaces/models/dtos/Team/TeamDto';
 import { TeamSeasonDto } from '../../interfaces/models/dtos/Team/TeamSeasonDto';
 import { GamePlayerDto } from '../../interfaces/models/dtos/Game/GamePlayerDto';
 import { SeasonDto } from '../../interfaces/models/dtos/Season/SeasonDto';
@@ -100,11 +99,11 @@ export function MultiPlayerSelection({
     }
 
     function getTeamName(playerId: string): string | null {
-        const team: TeamDto = teams.filter((t) => {
-            const teamSeason: TeamSeasonDto = t.seasons!.filter(
+        const team = teams.find((t) => {
+            const teamSeason: TeamSeasonDto = t.seasons!.find(
                 (ts: TeamSeasonDto) =>
                     ts.seasonId === season!.id && !ts.deleted,
-            )[0];
+            )!;
             if (!teamSeason) {
                 return null;
             }
@@ -113,7 +112,7 @@ export function MultiPlayerSelection({
                 teamSeason.players!,
                 (p: TeamPlayerDto) => p.id === playerId,
             );
-        })[0];
+        });
 
         return team ? team.name : null;
     }

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
@@ -22,6 +22,7 @@ import { usePreferences } from '../common/PreferencesContainer';
 import { ToggleFavouriteTeam } from '../common/ToggleFavouriteTeam';
 import { DivisionDto } from '../../interfaces/models/dtos/DivisionDto';
 import { UntypedPromise } from '../../interfaces/UntypedPromise';
+import { getTeamsInSeason } from '../../helpers/teams';
 
 export interface IDivisionFixtureProps {
     fixture: IEditableDivisionFixtureDto;
@@ -210,15 +211,11 @@ export function DivisionFixture({
     }
 
     function renderKnockoutAwayTeams() {
-        const options: IBootstrapDropdownItem[] = allTeams
-            .filter((t: TeamDto) => t.id !== fixture.homeTeam.id)
-            .filter((t: TeamDto) =>
-                any(
-                    t.seasons!,
-                    (ts) => ts.seasonId === season!.id && !ts.deleted,
-                ),
-            )
-            .map((t: TeamDto): IBootstrapDropdownItem => {
+        const allTeamsExceptHome = allTeams.filter(
+            (t) => t.id !== fixture.homeTeam.id,
+        );
+        const options = getTeamsInSeason(allTeamsExceptHome, season!.id).map(
+            (t: TeamDto): IBootstrapDropdownItem => {
                 const otherFixtureSameDate: DivisionFixtureDto | null =
                     isSelectedInAnotherFixtureOnThisDate(t);
                 const unavailableReason: string | null = otherFixtureSameDate
@@ -234,7 +231,8 @@ export function DivisionFixture({
                         : t.name,
                     disabled: !!otherFixtureSameDate,
                 };
-            });
+            },
+        );
 
         return (
             <BootstrapDropdown

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixture.tsx
@@ -18,7 +18,6 @@ import { DivisionFixtureDateDto } from '../../interfaces/models/dtos/Division/Di
 import { DivisionTeamDto } from '../../interfaces/models/dtos/Division/DivisionTeamDto';
 import { TeamDto } from '../../interfaces/models/dtos/Team/TeamDto';
 import { IEditableDivisionFixtureDateDto } from './IEditableDivisionFixtureDateDto';
-import { TeamSeasonDto } from '../../interfaces/models/dtos/Team/TeamSeasonDto';
 import { usePreferences } from '../common/PreferencesContainer';
 import { ToggleFavouriteTeam } from '../common/ToggleFavouriteTeam';
 import { DivisionDto } from '../../interfaces/models/dtos/DivisionDto';
@@ -216,8 +215,7 @@ export function DivisionFixture({
             .filter((t: TeamDto) =>
                 any(
                     t.seasons!,
-                    (ts: TeamSeasonDto) =>
-                        ts.seasonId === season!.id && !ts.deleted,
+                    (ts) => ts.seasonId === season!.id && !ts.deleted,
                 ),
             )
             .map((t: TeamDto): IBootstrapDropdownItem => {

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixtures.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixtures.tsx
@@ -19,7 +19,6 @@ import { DivisionDataDto } from '../../interfaces/models/dtos/Division/DivisionD
 import { EditFixtureDateNoteDto } from '../../interfaces/models/dtos/EditFixtureDateNoteDto';
 import { IEditableDivisionFixtureDateDto } from './IEditableDivisionFixtureDateDto';
 import { TeamDto } from '../../interfaces/models/dtos/Team/TeamDto';
-import { TeamSeasonDto } from '../../interfaces/models/dtos/Team/TeamSeasonDto';
 import { DivisionFixtureDateDto } from '../../interfaces/models/dtos/Division/DivisionFixtureDateDto';
 import { DivisionFixtureDto } from '../../interfaces/models/dtos/Division/DivisionFixtureDto';
 import { IFilter } from './IFilter';
@@ -31,6 +30,7 @@ import { hasAccess } from '../../helpers/conditions';
 import { useDependencies } from '../common/IocContainer';
 import { LoadingSpinnerSmall } from '../common/LoadingSpinnerSmall';
 import { Link } from 'react-router';
+import { getTeamsInSeason } from '../../helpers/teams';
 
 export interface IDivisionFixturesProps {
     setNewFixtures(fixtures: DivisionFixtureDateDto[]): UntypedPromise;
@@ -106,15 +106,7 @@ export function DivisionFixtures({ setNewFixtures }: IDivisionFixturesProps) {
         date: string,
         isKnockout: boolean,
     ): IEditableDivisionFixtureDateDto {
-        const seasonalTeams: TeamDto[] = teams.filter((t: TeamDto) => {
-            return any(
-                t.seasons,
-                (ts: TeamSeasonDto) =>
-                    ts.seasonId === season!.id &&
-                    ts.divisionId === divisionId &&
-                    !ts.deleted,
-            );
-        });
+        const seasonalTeams = getTeamsInSeason(teams, season!.id, divisionId);
 
         return {
             isNew: true,

--- a/CourageScores/ClientApp/src/components/division_fixtures/TournamentFixture.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/TournamentFixture.tsx
@@ -13,7 +13,6 @@ import { DivisionTournamentFixtureDetailsDto } from '../../interfaces/models/dto
 import { usePreferences } from '../common/PreferencesContainer';
 import { ToggleFavouriteTeam } from '../common/ToggleFavouriteTeam';
 import { Link } from 'react-router';
-import { TeamDto } from '../../interfaces/models/dtos/Team/TeamDto';
 import { TournamentMatchDto } from '../../interfaces/models/dtos/Game/TournamentMatchDto';
 import { UntypedPromise } from '../../interfaces/UntypedPromise';
 import { hasAccess } from '../../helpers/conditions';
@@ -164,9 +163,7 @@ export function TournamentFixture({
 
     function renderWinner(winningSide: TournamentSideDto) {
         if (winningSide.teamId) {
-            const team: TeamDto = teams.filter(
-                (t) => t.id === winningSide.teamId,
-            )[0];
+            const team = teams.find((t) => t.id === winningSide.teamId);
 
             if (team) {
                 return (

--- a/CourageScores/ClientApp/src/components/division_players/EditPlayerDetails.tsx
+++ b/CourageScores/ClientApp/src/components/division_players/EditPlayerDetails.tsx
@@ -161,12 +161,10 @@ export function EditPlayerDetails({
 
     function getDivisionIdForTeam(): string {
         const teamId = newTeamId || (team ? team.id : null) || player.teamId;
-        const theTeam: TeamDto = teams.filter(
-            (t: TeamDto) => t.id === teamId,
-        )[0];
-        const teamSeason: TeamSeasonDto = theTeam.seasons!.filter(
-            (ts: TeamSeasonDto) => ts.seasonId === seasonId,
-        )[0];
+        const theTeam = teams.find((t: TeamDto) => t.id === teamId);
+        const teamSeason = theTeam?.seasons!.find(
+            (ts) => ts.seasonId === seasonId,
+        );
         if (teamSeason && teamSeason.divisionId) {
             return teamSeason.divisionId;
         }
@@ -225,9 +223,9 @@ export function EditPlayerDetails({
     }
 
     function teamSeasonForSameDivision(team: TeamDto): boolean {
-        const teamSeason: TeamSeasonDto = team.seasons!.filter(
+        const teamSeason = team.seasons!.find(
             (ts: TeamSeasonDto) => ts.seasonId === seasonId && !ts.deleted,
-        )[0];
+        );
         if (!teamSeason) {
             return false;
         }

--- a/CourageScores/ClientApp/src/components/division_teams/AssignTeamToSeasons.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/AssignTeamToSeasons.tsx
@@ -10,7 +10,6 @@ import { SeasonDto } from '../../interfaces/models/dtos/Season/SeasonDto';
 import { DivisionTeamDto } from '../../interfaces/models/dtos/Division/DivisionTeamDto';
 import { IClientActionResultDto } from '../common/IClientActionResultDto';
 import { ModifyTeamSeasonDto } from '../../interfaces/models/dtos/Team/ModifyTeamSeasonDto';
-import { TeamSeasonDto } from '../../interfaces/models/dtos/Team/TeamSeasonDto';
 import { UntypedPromise } from '../../interfaces/UntypedPromise';
 
 export interface IAssignTeamToSeasonsProps {
@@ -35,13 +34,9 @@ export function AssignTeamToSeasons({
     } = useDivisionData();
     const { seasons, teams, onError, reloadAll } = useApp();
     const { teamApi } = useDependencies();
-    const team: TeamDto = teams.filter(
-        (t: TeamDto) => t.id === teamOverview.id,
-    )[0];
+    const team = teams.find((t) => t.id === teamOverview.id)!;
     const initialSeasonIds: string[] = team
-        ? team
-              .seasons!.filter((ts) => !ts.deleted)
-              .map((ts: TeamSeasonDto) => ts.seasonId!)
+        ? team.seasons!.filter((ts) => !ts.deleted).map((ts) => ts.seasonId!)
         : [];
     const [selectedSeasonIds, setSelectedSeasonIds]: [
         string[],

--- a/CourageScores/ClientApp/src/components/division_teams/AssignTeamToSeasons.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/AssignTeamToSeasons.tsx
@@ -11,6 +11,7 @@ import { DivisionTeamDto } from '../../interfaces/models/dtos/Division/DivisionT
 import { IClientActionResultDto } from '../common/IClientActionResultDto';
 import { ModifyTeamSeasonDto } from '../../interfaces/models/dtos/Team/ModifyTeamSeasonDto';
 import { UntypedPromise } from '../../interfaces/UntypedPromise';
+import { getTeamSeasons } from '../../helpers/teams';
 
 export interface IAssignTeamToSeasonsProps {
     teamOverview: DivisionTeamDto;
@@ -36,7 +37,7 @@ export function AssignTeamToSeasons({
     const { teamApi } = useDependencies();
     const team = teams.find((t) => t.id === teamOverview.id)!;
     const initialSeasonIds: string[] = team
-        ? team.seasons!.filter((ts) => !ts.deleted).map((ts) => ts.seasonId!)
+        ? getTeamSeasons(team).map((ts) => ts.seasonId!)
         : [];
     const [selectedSeasonIds, setSelectedSeasonIds]: [
         string[],

--- a/CourageScores/ClientApp/src/components/division_teams/TeamOverview.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/TeamOverview.tsx
@@ -21,7 +21,7 @@ export function TeamOverview({ teamId }: ITeamOverviewProps) {
         name: divisionName,
     } = useDivisionData();
     const { teams } = useApp();
-    const team = teams.filter((t) => t.id === teamId)[0];
+    const team = teams.find((t) => t.id === teamId);
     const fixtures = divisionDataFixtures!
         .map((fixtureDate) => {
             return {

--- a/CourageScores/ClientApp/src/components/scores/Score.tsx
+++ b/CourageScores/ClientApp/src/components/scores/Score.tsx
@@ -294,9 +294,7 @@ export function Score() {
         teamType: string,
         matches: GameMatchDto[],
     ): (TeamPlayerDto & ISelectablePlayer)[] | undefined {
-        const teamData: TeamDto = teams.filter(
-            (t: TeamDto) => t.id === teamId,
-        )[0];
+        const teamData = teams.find((t: TeamDto) => t.id === teamId);
 
         if (!teamData) {
             onError(`${teamType} team could not be found - ${teamId}`);
@@ -309,10 +307,9 @@ export function Score() {
         }
 
         const teamSeasons: { [p: string]: TeamSeasonDto } = Object.fromEntries(
-            teamData.seasons.map((season: TeamSeasonDto) => [
-                season.seasonId,
-                season,
-            ]),
+            teamData.seasons
+                .filter((ts) => !ts.deleted)
+                .map((season: TeamSeasonDto) => [season.seasonId, season]),
         );
 
         if (!teamSeasons[seasonId]) {
@@ -829,8 +826,8 @@ export function Score() {
             `${fixtureData.home.name} vs ${fixtureData.away.name} - ${renderDate(fixtureData.date)}`,
         );
         const accountTeam = account
-            ? teams.filter((t) => t.id === account.teamId)[0]
-            : null;
+            ? teams.find((t) => t.id === account.teamId)
+            : undefined;
 
         return (
             <div>

--- a/CourageScores/ClientApp/src/components/scores/Score.tsx
+++ b/CourageScores/ClientApp/src/components/scores/Score.tsx
@@ -49,7 +49,6 @@ import { TeamPlayerDto } from '../../interfaces/models/dtos/Team/TeamPlayerDto';
 import { GameMatchOptionDto } from '../../interfaces/models/dtos/Game/GameMatchOptionDto';
 import { GameTeamDto } from '../../interfaces/models/dtos/Game/GameTeamDto';
 import { IClientActionResultDto } from '../common/IClientActionResultDto';
-import { TeamSeasonDto } from '../../interfaces/models/dtos/Team/TeamSeasonDto';
 import { ISelectablePlayer } from '../common/PlayerSelection';
 import { RecordScoresDto } from '../../interfaces/models/dtos/Game/RecordScoresDto';
 import { PhotoManager } from '../common/PhotoManager';
@@ -58,6 +57,7 @@ import { ConfiguredFeatureDto } from '../../interfaces/models/dtos/ConfiguredFea
 import { useBranding } from '../common/BrandingContainer';
 import { NavLink } from '../common/NavLink';
 import { hasAccess } from '../../helpers/conditions';
+import { getTeamSeasons } from '../../helpers/teams';
 
 export interface ICreatePlayerFor {
     side: string;
@@ -136,12 +136,10 @@ export function Score() {
             }
 
             try {
-                const updatedTeamSeason: TeamSeasonDto =
-                    updatedTeamDetails.seasons!.filter(
-                        (ts: TeamSeasonDto) =>
-                            ts.seasonId === fixtureData!.seasonId &&
-                            !ts.deleted,
-                    )[0];
+                const updatedTeamSeason = getTeamSeasons(
+                    updatedTeamDetails,
+                    fixtureData!.seasonId,
+                )[0];
                 if (!updatedTeamSeason) {
                     /* istanbul ignore next */
                     console.log(updatedTeamDetails);
@@ -306,24 +304,18 @@ export function Score() {
             return;
         }
 
-        const teamSeasons: { [p: string]: TeamSeasonDto } = Object.fromEntries(
-            teamData.seasons
-                .filter((ts) => !ts.deleted)
-                .map((season: TeamSeasonDto) => [season.seasonId, season]),
-        );
-
-        if (!teamSeasons[seasonId]) {
+        const teamSeason = getTeamSeasons(teamData, seasonId)[0];
+        if (!teamSeason) {
             onError(
                 `${teamType} team has not registered for this season: ${seasonId}`,
             );
             return;
         }
 
-        const players: (ISelectablePlayer & IRenamedPlayer)[] = teamSeasons[
-            seasonId
-        ].players!.map(
-            (p: TeamPlayerDto) => p as ISelectablePlayer & IRenamedPlayer,
-        ); // copy the players list
+        const players: (ISelectablePlayer & IRenamedPlayer)[] =
+            teamSeason.players!.map(
+                (p: TeamPlayerDto) => p as ISelectablePlayer & IRenamedPlayer,
+            ); // copy the players list
 
         for (const match of matches) {
             const matchPlayers: ICaptainMatchPlayer[] =

--- a/CourageScores/ClientApp/src/components/scores/ScoreCardHeading.tsx
+++ b/CourageScores/ClientApp/src/components/scores/ScoreCardHeading.tsx
@@ -26,10 +26,10 @@ export function ScoreCardHeading({
 }: IScoreCardHeadingProps) {
     const { account, onError, teams } = useApp();
     const { division, season } = useLeagueFixture();
-    const submissionTeam: TeamDto | null =
+    const submissionTeam: TeamDto | undefined =
         account && access === 'clerk' && account.teamId
-            ? teams.filter((t) => t.id === account.teamId)[0]
-            : null;
+            ? teams.find((t) => t.id === account.teamId)
+            : undefined;
     const opposingTeam =
         submissionTeam && data.home.id === submissionTeam.id
             ? data.away

--- a/CourageScores/ClientApp/src/components/tournaments/EditSide.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditSide.tsx
@@ -20,6 +20,7 @@ import { TournamentGameDto } from '../../interfaces/models/dtos/Game/TournamentG
 import { DivisionTournamentFixtureDetailsDto } from '../../interfaces/models/dtos/Division/DivisionTournamentFixtureDetailsDto';
 import { UntypedPromise } from '../../interfaces/UntypedPromise';
 import { hasAccess } from '../../helpers/conditions';
+import { getTeamSeasons } from '../../helpers/teams';
 
 export interface IEditSideProps {
     side: TournamentSideDto;
@@ -81,10 +82,8 @@ export function EditSide({
             .sort(sortBy('text')),
     );
     const allPossiblePlayers: ITeamPlayerMap[] = teams.flatMap((t: TeamDto) => {
-        const teamSeason = t.seasons!.find(
-            (ts) => ts.seasonId === season!.id && !ts.deleted,
-        );
-        if (teamSeason && isTeamSeasonForDivision(teamSeason)) {
+        const teamSeason = getTeamSeasons(t, season!.id, divisionId)[0];
+        if (teamSeason) {
             return (
                 teamSeason.players!.map((p: TeamPlayerDto): ITeamPlayerMap => {
                     return { id: p.id, name: p.name, team: t };
@@ -122,22 +121,8 @@ export function EditSide({
     }
 
     function teamSeasonForSameDivision(team: TeamDto): boolean {
-        const teamSeason = team.seasons!.find(
-            (ts: TeamSeasonDto) => ts.seasonId === season!.id && !ts.deleted,
-        );
-        if (!teamSeason) {
-            return false;
-        }
-
-        return isTeamSeasonForDivision(teamSeason);
-    }
-
-    function isTeamSeasonForDivision(teamSeason: TeamSeasonDto): boolean {
-        return !(
-            divisionId &&
-            teamSeason.divisionId &&
-            teamSeason.divisionId !== divisionId
-        );
+        const teamSeason = getTeamSeasons(team, season!.id, divisionId);
+        return any(teamSeason);
     }
 
     function getOtherSidePlayerSelectedIn(
@@ -322,9 +307,7 @@ export function EditSide({
     }
 
     function getDivisionForTeamSeason(team: TeamDto): string {
-        const teamSeason: TeamSeasonDto = team.seasons!.filter(
-            (ts: TeamSeasonDto) => ts.seasonId === season!.id,
-        )[0];
+        const teamSeason: TeamSeasonDto = getTeamSeasons(team, season!.id)[0];
         if (teamSeason && teamSeason.divisionId) {
             return teamSeason.divisionId;
         }

--- a/CourageScores/ClientApp/src/components/tournaments/EditSide.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/EditSide.tsx
@@ -81,9 +81,9 @@ export function EditSide({
             .sort(sortBy('text')),
     );
     const allPossiblePlayers: ITeamPlayerMap[] = teams.flatMap((t: TeamDto) => {
-        const teamSeason: TeamSeasonDto = t.seasons!.filter(
-            (ts: TeamSeasonDto) => ts.seasonId === season!.id && !ts.deleted,
-        )[0];
+        const teamSeason = t.seasons!.find(
+            (ts) => ts.seasonId === season!.id && !ts.deleted,
+        );
         if (teamSeason && isTeamSeasonForDivision(teamSeason)) {
             return (
                 teamSeason.players!.map((p: TeamPlayerDto): ITeamPlayerMap => {
@@ -122,9 +122,9 @@ export function EditSide({
     }
 
     function teamSeasonForSameDivision(team: TeamDto): boolean {
-        const teamSeason: TeamSeasonDto = team.seasons!.filter(
+        const teamSeason = team.seasons!.find(
             (ts: TeamSeasonDto) => ts.seasonId === season!.id && !ts.deleted,
-        )[0];
+        );
         if (!teamSeason) {
             return false;
         }
@@ -217,7 +217,7 @@ export function EditSide({
         try {
             const newSide: TournamentSideDto = Object.assign({}, side);
             if (teamId) {
-                const team = teams.filter((t: TeamDto) => t.id === teamId)[0];
+                const team = teams.find((t: TeamDto) => t.id === teamId)!;
                 newSide.name = newSide.name || team.name;
 
                 newSide.teamId = team.id;

--- a/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/PrintableSheet.tsx
@@ -209,7 +209,7 @@ export function PrintableSheet({ editable, patchData }: IPrintableSheetProps) {
 
     function getLinkToSide(side: TournamentSideDto) {
         if (side && side.teamId && division) {
-            const team: TeamDto = teams.filter((t) => t.id === side.teamId)[0];
+            const team = teams.find((t) => t.id === side.teamId);
 
             return (
                 <Link
@@ -241,10 +241,10 @@ export function PrintableSheet({ editable, patchData }: IPrintableSheetProps) {
     } {
         const teamAndDivisionMapping = teams
             .map((t) => {
-                const teamSeason: TeamSeasonDto = t.seasons!.filter(
+                const teamSeason = t.seasons!.find(
                     (ts: TeamSeasonDto) =>
                         ts.seasonId === season!.id && !ts.deleted,
-                )[0];
+                );
                 if (!teamSeason) {
                     return null;
                 }

--- a/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
@@ -235,11 +235,11 @@ export function Tournament() {
             )
             .map(
                 (t: TeamDto) =>
-                    t.seasons!.filter(
+                    t.seasons!.find(
                         (ts: TeamSeasonDto) =>
                             ts.seasonId === tournamentData.seasonId &&
                             !ts.deleted,
-                    )[0],
+                    )!,
             )
             .filter((teamSeasonDto: TeamSeasonDto) => teamSeasonDto)
             .flatMap((teamSeason: TeamSeasonDto) =>

--- a/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/Tournament.tsx
@@ -44,6 +44,7 @@ import { useBranding } from '../common/BrandingContainer';
 import { renderDate } from '../../helpers/rendering';
 import { isEqual } from '../common/ObjectComparer';
 import { retry } from '../../helpers/retry';
+import { getTeamsInSeason } from '../../helpers/teams';
 
 export interface ITournamentPlayerMap {
     [id: string]: DivisionTournamentFixtureDetailsDto;
@@ -229,18 +230,12 @@ export function Tournament() {
                   .map((side: TournamentSideDto) => side.teamId!)
             : [];
 
-        const players: ISelectablePlayer[] = teams
-            .filter((t: TeamDto) =>
+        const players: ISelectablePlayer[] = getTeamsInSeason(
+            teams.filter((t: TeamDto) =>
                 any(selectedTournamentTeams, (id: string) => id === t.id),
-            )
-            .map(
-                (t: TeamDto) =>
-                    t.seasons!.find(
-                        (ts: TeamSeasonDto) =>
-                            ts.seasonId === tournamentData.seasonId &&
-                            !ts.deleted,
-                    )!,
-            )
+            ),
+            tournamentData.seasonId,
+        )
             .filter((teamSeasonDto: TeamSeasonDto) => teamSeasonDto)
             .flatMap((teamSeason: TeamSeasonDto) =>
                 teamSeason.players!.map(

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.tsx
@@ -81,10 +81,10 @@ export function TournamentDetails({
     function getTeamIdForPlayer(player: TournamentPlayerDto): string | null {
         const teamToSeasonMaps = teams.map((t: TeamDto) => {
             return {
-                teamSeason: t.seasons!.filter(
+                teamSeason: t.seasons!.find(
                     (ts: TeamSeasonDto) =>
                         ts.seasonId === tournamentData.seasonId && !ts.deleted,
-                )[0],
+                ),
                 team: t,
             };
         });

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.tsx
@@ -8,13 +8,11 @@ import {
 import { TournamentMatchDto } from '../../interfaces/models/dtos/Game/TournamentMatchDto';
 import { any, distinct } from '../../helpers/collections';
 import { TournamentPlayerDto } from '../../interfaces/models/dtos/Game/TournamentPlayerDto';
-import { TeamDto } from '../../interfaces/models/dtos/Team/TeamDto';
-import { TeamPlayerDto } from '../../interfaces/models/dtos/Team/TeamPlayerDto';
 import { useApp } from '../common/AppContainer';
 import { TournamentGameDto } from '../../interfaces/models/dtos/Game/TournamentGameDto';
-import { TeamSeasonDto } from '../../interfaces/models/dtos/Team/TeamSeasonDto';
 import { TournamentRoundDto } from '../../interfaces/models/dtos/Game/TournamentRoundDto';
 import { UntypedPromise } from '../../interfaces/UntypedPromise';
+import { findTeam } from '../../helpers/teams';
 
 export interface ITournamentDetailsProps {
     tournamentData: TournamentGameDto;
@@ -79,29 +77,13 @@ export function TournamentDetails({
     }
 
     function getTeamIdForPlayer(player: TournamentPlayerDto): string | null {
-        const teamToSeasonMaps = teams.map((t: TeamDto) => {
-            return {
-                teamSeason: t.seasons!.find(
-                    (ts: TeamSeasonDto) =>
-                        ts.seasonId === tournamentData.seasonId && !ts.deleted,
-                ),
-                team: t,
-            };
-        });
-        const teamsWithPlayer = teamToSeasonMaps.filter(
-            (map) =>
-                map.teamSeason &&
-                any(
-                    map.teamSeason!.players!,
-                    (p: TeamPlayerDto) => p.id === player.id,
-                ),
+        const found = findTeam(
+            teams,
+            (ts) => any(ts.players, (p) => p.id === player.id),
+            tournamentData.seasonId,
         );
 
-        if (any(teamsWithPlayer)) {
-            return teamsWithPlayer[0].team.id;
-        }
-
-        return null;
+        return found?.team.id ?? null;
     }
 
     return (

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/EditSuperleagueMatch.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/EditSuperleagueMatch.tsx
@@ -24,6 +24,7 @@ import { TeamSeasonDto } from '../../../interfaces/models/dtos/Team/TeamSeasonDt
 import { useTournament } from '../TournamentContainer';
 import { DivisionTournamentFixtureDetailsDto } from '../../../interfaces/models/dtos/Division/DivisionTournamentFixtureDetailsDto';
 import { hasAccess } from '../../../helpers/conditions';
+import { getTeamSeasons } from '../../../helpers/teams';
 
 interface TeamAndSeason {
     team: TeamDto;
@@ -99,12 +100,14 @@ export function EditSuperleagueMatch({
     function getTeamSeason(name?: string): TeamAndSeason | undefined {
         const seasonId = tournamentData.seasonId;
         const teamsByName = teams.filter((t: TeamDto) => t.name === name);
-        return teamsByName
-            .flatMap(
-                (team) =>
-                    team.seasons?.map((ts) => ({ team, season: ts })) ?? [],
-            )
-            .find((a) => a.season.seasonId === seasonId && !a.season.deleted);
+
+        return teamsByName.flatMap(
+            (team) =>
+                getTeamSeasons(team, seasonId).map((ts) => ({
+                    team,
+                    season: ts,
+                })) ?? [],
+        )[0];
     }
 
     function getPlayersForTeamName(

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/EditSuperleagueMatch.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/EditSuperleagueMatch.tsx
@@ -115,9 +115,9 @@ export function EditSuperleagueMatch({
             match.sideB.players || [],
         );
 
-        const team = getTeamSeason(name)!;
-        return team.season
-            .players!.filter(
+        const team = getTeamSeason(name);
+        return (team?.season?.players ?? [])
+            .filter(
                 (p) =>
                     !any(alreadySelected, (selected) => selected.id === p.id),
             )

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.tsx
@@ -50,10 +50,10 @@ export function MasterDraw({
     ];
     const teamOptions: IBootstrapDropdownItem[] = teams
         .filter((t: TeamDto) => {
-            return !!t.seasons?.filter(
+            return !!t.seasons?.find(
                 (ts: TeamSeasonDto) =>
                     ts.seasonId === tournamentData.seasonId && !ts.deleted,
-            )[0];
+            );
         })
         .map((t: TeamDto): IBootstrapDropdownItem => {
             return {

--- a/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/superleague/MasterDraw.tsx
@@ -16,7 +16,7 @@ import { useState } from 'react';
 import { createTemporaryId } from '../../../helpers/projection';
 import { any, isEmpty } from '../../../helpers/collections';
 import { useTournament } from '../TournamentContainer';
-import { TeamSeasonDto } from '../../../interfaces/models/dtos/Team/TeamSeasonDto';
+import { getTeamsInSeason } from '../../../helpers/teams';
 
 export interface IMasterDrawProps {
     patchData?(
@@ -48,19 +48,14 @@ export function MasterDraw({
         { text: 'Men', value: 'men' },
         { text: 'Women', value: 'women' },
     ];
-    const teamOptions: IBootstrapDropdownItem[] = teams
-        .filter((t: TeamDto) => {
-            return !!t.seasons?.find(
-                (ts: TeamSeasonDto) =>
-                    ts.seasonId === tournamentData.seasonId && !ts.deleted,
-            );
-        })
-        .map((t: TeamDto): IBootstrapDropdownItem => {
+    const teamOptions = getTeamsInSeason(teams, tournamentData.seasonId).map(
+        (t: TeamDto): IBootstrapDropdownItem => {
             return {
                 text: t.name,
                 value: t.name,
             };
-        });
+        },
+    );
 
     async function updateAndSaveTournamentData(data: TournamentGameDto) {
         await setTournamentData(data, true);

--- a/CourageScores/ClientApp/src/helpers/teams.ts
+++ b/CourageScores/ClientApp/src/helpers/teams.ts
@@ -1,0 +1,47 @@
+﻿import { TeamDto } from '../interfaces/models/dtos/Team/TeamDto';
+import { any } from './collections';
+import { TeamSeasonDto } from '../interfaces/models/dtos/Team/TeamSeasonDto';
+
+export function getTeamSeasons(
+    t: TeamDto,
+    seasonId?: string,
+    divisionId?: string,
+): TeamSeasonDto[] {
+    return (
+        t.seasons?.filter(
+            (ts) =>
+                (!seasonId || ts.seasonId === seasonId) &&
+                (!divisionId ||
+                    ts.divisionId === divisionId ||
+                    !ts.divisionId) &&
+                !ts.deleted,
+        ) ?? []
+    );
+}
+
+export function getTeamsInSeason(
+    teams: TeamDto[],
+    seasonId?: string,
+    divisionId?: string,
+): TeamDto[] {
+    return teams.filter((t) => {
+        return any(getTeamSeasons(t, seasonId, divisionId));
+    });
+}
+
+export function findTeam(
+    teams: TeamDto[],
+    predicate: (ts: TeamSeasonDto) => boolean,
+    seasonId?: string,
+    divisionId?: string,
+): { team: TeamDto; teamSeason: TeamSeasonDto } | undefined {
+    return teams
+        .map((t) => {
+            const teamSeasons = getTeamSeasons(t, seasonId, divisionId);
+            const relevantTeamSeasons = teamSeasons.filter(predicate);
+            return relevantTeamSeasons.length > 0
+                ? { team: t, teamSeason: relevantTeamSeasons[0] }
+                : null;
+        })
+        .filter((map) => !!map)[0];
+}


### PR DESCRIPTION
Related to #1598

- [x] extract `getTeam` function so it can be reused elsewhere
- [x] check all other usages of `app.teams` to ensure they correctly locate team by name and correct season