### PR TITLE
v3.2.34

### DIFF
--- a/CourageScores.Tests/Services/Health/Checks/SameNumberOfWeeksTests.cs
+++ b/CourageScores.Tests/Services/Health/Checks/SameNumberOfWeeksTests.cs
@@ -1,0 +1,91 @@
+﻿using CourageScores.Models.Dtos.Health;
+using CourageScores.Services.Health;
+using CourageScores.Services.Health.Checks;
+using NUnit.Framework;
+
+namespace CourageScores.Tests.Services.Health.Checks;
+
+[TestFixture]
+public class SameNumberOfWeeksTests
+{
+    private readonly HealthCheckContext _context = new HealthCheckContext(new SeasonHealthDto());
+    private readonly SameNumberOfWeeks _check = new SameNumberOfWeeks();
+    private readonly CancellationToken _token = CancellationToken.None;
+
+    [Test]
+    public async Task RunCheck_GivenNoDivisions_ReturnsSuccess()
+    {
+        var result = await _check.RunCheck([], _context, _token);
+
+        Assert.That(result.Success, Is.True);
+    }
+
+    [Test]
+    public async Task RunCheck_GivenOneDivision_ReturnsSuccess()
+    {
+        var division1 = MakeDivision("Division 1", 4);
+
+        var result = await _check.RunCheck([division1], _context, _token);
+
+        Assert.That(result.Success, Is.True);
+    }
+
+    [Test]
+    public async Task RunCheck_GivenTwoDivisionsAndNoWeeks_ReturnsSuccess()
+    {
+        var division1 = MakeDivision("Division 1", 0);
+        var division2 = MakeDivision("Division 2", 0);
+
+        var result = await _check.RunCheck([division1, division2], _context, _token);
+
+        Assert.That(result.Success, Is.True);
+    }
+
+    [Test]
+    public async Task RunCheck_GivenTwoDivisionsWithSameNumberOfWeeks_ReturnsSuccess()
+    {
+        var division1 = MakeDivision("Division 1", 4);
+        var division2 = MakeDivision("Division 2", 4);
+
+        var result = await _check.RunCheck([division1, division2], _context, _token);
+
+        Assert.That(result.Success, Is.True);
+    }
+
+    [Test]
+    public async Task RunCheck_GivenTwoDivisionsWithDifferingNumberOfWeeks_ReturnsFailure()
+    {
+        var division1 = MakeDivision("Division 1", 4);
+        var division2 = MakeDivision("Division 2", 5);
+
+        var result = await _check.RunCheck([division1, division2], _context, _token);
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Errors, Is.EquivalentTo(["Some divisions have a different number of weeks, expected: 4 weeks, found 5 weeks in Division 2"]));
+    }
+
+    [Test]
+    public async Task RunCheck_GivenThreeDivisionsWhereOneHasADifferentNumber_ReturnsFailureAndIndicatesTheOutlier()
+    {
+        var division1 = MakeDivision("Division 1", 4);
+        var division2 = MakeDivision("Division 2", 4);
+        var division3 = MakeDivision("Division 3", 5);
+
+        var result = await _check.RunCheck([division1, division2, division3], _context, _token);
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Errors, Is.EquivalentTo(["Some divisions have a different number of weeks, expected: 4 weeks, found 5 weeks in Division 3"]));
+    }
+
+    private static DivisionHealthDto MakeDivision(string name, int noOfWeeks)
+    {
+        return new DivisionHealthDto
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Dates = Enumerable.Range(0, noOfWeeks)
+                .Select(_ => new DivisionDateHealthDto())
+                .ToList(),
+        };
+    }
+}

--- a/CourageScores.Tests/Services/Season/Creation/AddressAssignmentStrategyTests.cs
+++ b/CourageScores.Tests/Services/Season/Creation/AddressAssignmentStrategyTests.cs
@@ -171,7 +171,7 @@ public class AddressAssignmentStrategyTests
         Assert.That(result, Is.False);
         Assert.That(context.Result.Errors, Is.EquivalentTo(new[]
         {
-            "Shared address has more teams than the template supports",
+            "Shared address has more teams 1 x (C) than the template supports None",
         }));
     }
 
@@ -350,7 +350,7 @@ public class AddressAssignmentStrategyTests
         Assert.That(result, Is.False);
         Assert.That(context.Result.Errors, Is.EquivalentTo(new[]
         {
-            "Division 1: Shared address has more teams than the template supports",
+            "Division 1: Shared address has more teams 3 x (A, B, C) than the template supports 2 x (A, B)",
         }));
     }
 

--- a/CourageScores/ClientApp/src/components/Tv.test.tsx
+++ b/CourageScores/ClientApp/src/components/Tv.test.tsx
@@ -6,6 +6,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../helpers/tests';
 import { Tv } from './Tv';
 import { ILiveApi } from '../interfaces/apis/ILiveApi';
@@ -14,7 +15,6 @@ import { createTemporaryId } from '../helpers/projection';
 import { LiveDataType } from '../interfaces/models/dtos/Live/LiveDataType';
 import { PublicationMode } from '../interfaces/models/dtos/Live/PublicationMode';
 import { IAppContainerProps } from './common/AppContainer';
-import { UserDto } from '../interfaces/models/dtos/Identity/UserDto';
 
 describe('Tv', () => {
     let context: TestContext;
@@ -71,14 +71,9 @@ describe('Tv', () => {
     });
 
     describe('when not permitted', () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                useWebSockets: false,
-            },
-        };
+        const account = user({
+            useWebSockets: false,
+        });
 
         it('does not render login link', async () => {
             await renderComponent(appProps({ account }));
@@ -106,14 +101,9 @@ describe('Tv', () => {
     });
 
     describe('when permitted', () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                useWebSockets: true,
-            },
-        };
+        const account = user({
+            useWebSockets: true,
+        });
 
         it('requests links', async () => {
             await renderComponent(appProps({ account }));

--- a/CourageScores/ClientApp/src/components/admin/Templates.test.tsx
+++ b/CourageScores/ClientApp/src/components/admin/Templates.test.tsx
@@ -6,6 +6,7 @@ import {
     brandingProps,
     cleanUp,
     ErrorState,
+    IComponent,
     iocProps,
     noop,
     renderApp,
@@ -17,6 +18,13 @@ import { IClientActionResultDto } from '../common/IClientActionResultDto';
 import { SeasonHealthCheckResultDto } from '../../interfaces/models/dtos/Health/SeasonHealthCheckResultDto';
 import { EditTemplateDto } from '../../interfaces/models/dtos/Season/Creation/EditTemplateDto';
 import { ISeasonTemplateApi } from '../../interfaces/apis/ISeasonTemplateApi';
+
+const mockedUsedNavigate = jest.fn();
+
+jest.mock('react-router', () => ({
+    ...jest.requireActual('react-router'),
+    useNavigate: () => mockedUsedNavigate,
+}));
 
 describe('Templates', () => {
     let context: TestContext;
@@ -92,6 +100,16 @@ describe('Templates', () => {
         );
     }
 
+    function assertMessages(
+        items: IComponent[],
+        type: 'danger' | 'warning' | 'success',
+        expected: string[][],
+    ) {
+        expect(
+            items.map((li) => li.all(`span.bg-${type}`).map((s) => s.text())),
+        ).toEqual(expected);
+    }
+
     describe('renders', () => {
         it('renders templates', async () => {
             const template: TemplateDto = {
@@ -113,21 +131,9 @@ describe('Templates', () => {
             expect(
                 templateItems.map((li) => li.required('small').text()),
             ).toEqual(['DESCRIPTION']);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-danger').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-warning').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-success').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
+            assertMessages(templateItems, 'danger', [[]]);
+            assertMessages(templateItems, 'warning', [[]]);
+            assertMessages(templateItems, 'success', [[]]);
         });
 
         it('renders selected template by id', async () => {
@@ -193,21 +199,9 @@ describe('Templates', () => {
             expect(templateItems.map((li) => li.optional('small'))).toEqual([
                 undefined,
             ]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-danger').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-warning').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-success').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
+            assertMessages(templateItems, 'danger', [[]]);
+            assertMessages(templateItems, 'warning', [[]]);
+            assertMessages(templateItems, 'success', [[]]);
         });
 
         it('template with some errors', async () => {
@@ -228,21 +222,9 @@ describe('Templates', () => {
             expect(
                 templateItems.map((li) => li.required('label').text()),
             ).toEqual(['TEMPLATE']);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-danger').map((s) => s.text()),
-                ),
-            ).toEqual([['1']]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-warning').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-success').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
+            assertMessages(templateItems, 'danger', [['1']]);
+            assertMessages(templateItems, 'warning', [[]]);
+            assertMessages(templateItems, 'success', [[]]);
         });
 
         it('template with some check errors', async () => {
@@ -269,21 +251,9 @@ describe('Templates', () => {
             expect(
                 templateItems.map((li) => li.required('label').text()),
             ).toEqual(['TEMPLATE']);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-danger').map((s) => s.text()),
-                ),
-            ).toEqual([['1']]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-warning').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-success').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
+            assertMessages(templateItems, 'danger', [['1']]);
+            assertMessages(templateItems, 'warning', [[]]);
+            assertMessages(templateItems, 'success', [[]]);
         });
 
         it('template with an unsuccessful check', async () => {
@@ -310,21 +280,9 @@ describe('Templates', () => {
             expect(
                 templateItems.map((li) => li.required('label').text()),
             ).toEqual(['TEMPLATE']);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-danger').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-warning').map((s) => s.text()),
-                ),
-            ).toEqual([['1']]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-success').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
+            assertMessages(templateItems, 'danger', [[]]);
+            assertMessages(templateItems, 'warning', [['1']]);
+            assertMessages(templateItems, 'success', [[]]);
         });
 
         it('template with an successful check', async () => {
@@ -351,21 +309,9 @@ describe('Templates', () => {
             expect(
                 templateItems.map((li) => li.required('label').text()),
             ).toEqual(['TEMPLATE']);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-danger').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-warning').map((s) => s.text()),
-                ),
-            ).toEqual([[]]);
-            expect(
-                templateItems.map((li) =>
-                    li.all('span.bg-success').map((s) => s.text()),
-                ),
-            ).toEqual([['1']]);
+            assertMessages(templateItems, 'danger', [[]]);
+            assertMessages(templateItems, 'warning', [[]]);
+            assertMessages(templateItems, 'success', [['1']]);
         });
     });
 
@@ -393,6 +339,9 @@ describe('Templates', () => {
             expect(templateItems.map((li) => li.className())).toEqual([
                 'list-group-item flex-column active',
             ]);
+            expect(mockedUsedNavigate).toHaveBeenCalledWith(
+                '/admin/templates/?select=TEMPLATE',
+            );
         });
 
         it('can deselect template', async () => {
@@ -419,6 +368,7 @@ describe('Templates', () => {
                 'list-group-item flex-column',
             ]);
             expect(context.optional('textarea')).toBeFalsy();
+            expect(mockedUsedNavigate).toHaveBeenCalledWith('/admin/templates');
         });
 
         it('can save template', async () => {

--- a/CourageScores/ClientApp/src/components/admin/Templates.tsx
+++ b/CourageScores/ClientApp/src/components/admin/Templates.tsx
@@ -288,7 +288,7 @@ export function Templates() {
             return;
         }
 
-        await changeSelected(JSON.parse(json));
+        await changeSelected(Object.assign({}, selected, JSON.parse(json)));
     }
 
     async function updateTemplate(newTemplate: TemplateDto) {

--- a/CourageScores/ClientApp/src/components/admin/Templates.tsx
+++ b/CourageScores/ClientApp/src/components/admin/Templates.tsx
@@ -10,11 +10,12 @@ import {
     TemplateTextEditor,
 } from './TemplateTextEditor';
 import { TemplateVisualEditor } from './TemplateVisualEditor';
-import { useLocation } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { TemplateDto } from '../../interfaces/models/dtos/Season/Creation/TemplateDto';
 import { IClientActionResultDto } from '../common/IClientActionResultDto';
 import { SeasonHealthCheckResultDto } from '../../interfaces/models/dtos/Health/SeasonHealthCheckResultDto';
 import { EditTemplateDto } from '../../interfaces/models/dtos/Season/Creation/EditTemplateDto';
+import { UntypedPromise } from '../../interfaces/UntypedPromise';
 
 export function Templates() {
     const EMPTY_TEMPLATE: EditTemplateDto = {
@@ -38,6 +39,19 @@ export function Templates() {
         useState<boolean>(false);
     const location = useLocation();
     const [copied, setCopied] = useState<boolean>(false);
+    const navigate = useNavigate();
+
+    async function changeSelected(
+        selected: EditTemplateDto | null,
+    ): UntypedPromise {
+        setSelected(selected);
+        if (selected) {
+            navigate(`/admin/templates/?select=${selected.name}`);
+            setValid(true);
+        } else {
+            navigate(`/admin/templates`);
+        }
+    }
 
     async function loadTemplates() {
         try {
@@ -54,14 +68,14 @@ export function Templates() {
                     (t) => t.id === idish || t.name === idish,
                 )[0];
                 if (templateToSelect) {
-                    setSelected(templateToSelect);
+                    await changeSelected(templateToSelect);
                 }
             } else if (selected) {
                 // replace the selected template with what has just been (re)loaded
                 const newSelectedItem: TemplateDto[] = templates.filter(
                     (t) => t.id === selected.id,
                 );
-                setSelected(
+                await changeSelected(
                     newSelectedItem.length === 1 ? newSelectedItem[0] : null,
                 );
             }
@@ -118,25 +132,25 @@ export function Templates() {
         if (selected && response && response.result) {
             const newTemplate: EditTemplateDto = Object.assign({}, selected);
             newTemplate.templateHealth = response.result;
-            setSelected(newTemplate);
+            await changeSelected(newTemplate);
         }
     }
 
     function toggleSelected(t: TemplateDto) {
         return () => {
             if (isSelected(t)) {
-                setSelected(null);
+                changeSelected(null);
                 return;
             }
 
-            setSelected(Object.assign({}, t));
+            changeSelected(Object.assign({}, t));
             setEditingTemplate(t);
         };
     }
 
     function setEditingTemplate(t: EditTemplateDto) {
         setValid(true);
-        setSelected(Object.assign({}, t));
+        changeSelected(Object.assign({}, t));
         setCopied(false);
     }
 
@@ -248,7 +262,7 @@ export function Templates() {
         try {
             const result = await templateApi.delete(selected!.id!);
             if (result.success) {
-                setSelected(null);
+                await changeSelected(null);
                 await loadTemplates();
             } else {
                 setSaveError(result);
@@ -274,11 +288,11 @@ export function Templates() {
             return;
         }
 
-        setSelected(JSON.parse(json));
+        await changeSelected(JSON.parse(json));
     }
 
     async function updateTemplate(newTemplate: TemplateDto) {
-        setSelected(newTemplate);
+        await changeSelected(newTemplate);
         setShouldRefreshHealth(true);
     }
 
@@ -304,7 +318,10 @@ export function Templates() {
                                 name="name"
                                 className="form-control"
                                 value={selected.name || ''}
-                                onChange={valueChanged(selected, setSelected)}
+                                onChange={valueChanged(
+                                    selected,
+                                    changeSelected,
+                                )}
                             />
                         </div>
                         <div className="input-group mb-3">
@@ -317,7 +334,10 @@ export function Templates() {
                                 name="description"
                                 className="form-control"
                                 value={selected.description || ''}
-                                onChange={valueChanged(selected, setSelected)}
+                                onChange={valueChanged(
+                                    selected,
+                                    changeSelected,
+                                )}
                             />
                         </div>
                         <div className="form-check form-switch input-group-prepend mb-2">

--- a/CourageScores/ClientApp/src/components/admin/UserAdmin.test.tsx
+++ b/CourageScores/ClientApp/src/components/admin/UserAdmin.test.tsx
@@ -7,6 +7,7 @@
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { UserAdmin } from './UserAdmin';
 import { AdminContainer } from './AdminContainer';
@@ -94,14 +95,9 @@ describe('UserAdmin', () => {
     });
 
     it('renders user with no access', async () => {
-        const account: UserDto = {
-            givenName: '',
-            emailAddress: 'a@b.com',
-            name: 'Admin',
-            access: {
-                manageAccess: true,
-            },
-        };
+        const account = user({
+            manageAccess: true,
+        });
         const otherAccount: UserDto = {
             givenName: '',
             emailAddress: 'c@d.com',
@@ -238,22 +234,12 @@ describe('UserAdmin', () => {
     });
 
     it('can change access for self', async () => {
-        const account: UserDto = {
-            givenName: '',
-            emailAddress: 'a@b.com',
-            name: 'Admin',
-            access: {
-                manageAccess: true,
-            },
-        };
-        const otherAccount: UserDto = {
-            givenName: '',
-            emailAddress: 'c@d.com',
-            name: 'Other user',
-            access: {
-                manageAccess: true,
-            },
-        };
+        const account = user({
+            manageAccess: true,
+        });
+        const otherAccount = user({
+            manageAccess: true,
+        });
         await renderComponent([account, otherAccount], account);
         await getAccess('manageGames').click();
 

--- a/CourageScores/ClientApp/src/components/analysis/AnalyseScores.test.tsx
+++ b/CourageScores/ClientApp/src/components/analysis/AnalyseScores.test.tsx
@@ -7,8 +7,8 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
-import { UserDto } from '../../interfaces/models/dtos/Identity/UserDto';
 import { IDivisionApi } from '../../interfaces/apis/IDivisionApi';
 import { ISaygApi } from '../../interfaces/apis/ISaygApi';
 import { SeasonDto } from '../../interfaces/models/dtos/Season/SeasonDto';
@@ -67,14 +67,9 @@ describe('AnalyseScores', () => {
     });
 
     async function renderComponent(query?: string, seasonName?: string) {
-        const account: UserDto = {
-            access: {
-                analyseMatches: true,
-            },
-            name: '',
-            givenName: '',
-            emailAddress: '',
-        };
+        const account = user({
+            analyseMatches: true,
+        });
         context = await renderApp(
             iocProps({ divisionApi, saygApi }),
             brandingProps(),

--- a/CourageScores/ClientApp/src/components/common/DebugOptions.test.tsx
+++ b/CourageScores/ClientApp/src/components/common/DebugOptions.test.tsx
@@ -5,6 +5,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { DebugOptions } from './DebugOptions';
 import { UserDto } from '../../interfaces/models/dtos/Identity/UserDto';
@@ -36,12 +37,7 @@ describe('DebugOptions', () => {
     });
 
     it('does not render when no access', async () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {},
-        };
+        const account = user({});
 
         await renderComponent(account, <span>item</span>);
 
@@ -49,14 +45,9 @@ describe('DebugOptions', () => {
     });
 
     it('does not render when not permitted', async () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                showDebugOptions: false,
-            },
-        };
+        const account = user({
+            showDebugOptions: false,
+        });
 
         await renderComponent(account, <span>item</span>);
 
@@ -64,14 +55,9 @@ describe('DebugOptions', () => {
     });
 
     it('does not render when permitted', async () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                showDebugOptions: true,
-            },
-        };
+        const account = user({
+            showDebugOptions: true,
+        });
 
         await renderComponent(account, <span>item</span>);
 
@@ -79,14 +65,9 @@ describe('DebugOptions', () => {
     });
 
     it('can expand dropdown', async () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                showDebugOptions: true,
-            },
-        };
+        const account = user({
+            showDebugOptions: true,
+        });
         await renderComponent(account, <span>item</span>);
 
         await context.required('.dropdown-toggle').click();
@@ -95,14 +76,9 @@ describe('DebugOptions', () => {
     });
 
     it('can collapse dropdown', async () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                showDebugOptions: true,
-            },
-        };
+        const account = user({
+            showDebugOptions: true,
+        });
         await renderComponent(account, <span>item</span>);
         await context.required('.dropdown-menu').click();
 

--- a/CourageScores/ClientApp/src/components/common/ExportDataButton.test.tsx
+++ b/CourageScores/ClientApp/src/components/common/ExportDataButton.test.tsx
@@ -7,6 +7,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { ExportDataButton, IExportDataButtonProps } from './ExportDataButton';
 import { UserDto } from '../../interfaces/models/dtos/Identity/UserDto';
@@ -58,14 +59,9 @@ describe('ExportDataButton', () => {
     });
 
     describe('when logged in, not permitted to export', () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                exportData: false,
-            },
-        };
+        const account = user({
+            exportData: false,
+        });
 
         it('renders nothing', async () => {
             await renderComponent({}, account);
@@ -75,14 +71,9 @@ describe('ExportDataButton', () => {
     });
 
     describe('when logged in, permitted to export', () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                exportData: true,
-            },
-        };
+        const account = user({
+            exportData: true,
+        });
 
         it('when nothing to export, does not render button', async () => {
             await renderComponent({}, account);

--- a/CourageScores/ClientApp/src/components/common/PhotoManager.test.tsx
+++ b/CourageScores/ClientApp/src/components/common/PhotoManager.test.tsx
@@ -6,6 +6,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { IPhotoManagerProps, PhotoManager } from './PhotoManager';
 import { IAppContainerProps } from './AppContainer';
@@ -71,14 +72,9 @@ describe('PhotoManager', () => {
     }
 
     describe('renders', () => {
-        const account: UserDto = {
-            name: 'USER',
-            givenName: '',
-            emailAddress: '',
-            access: {
-                deleteAnyPhoto: true,
-            },
-        };
+        const account = user({
+            deleteAnyPhoto: true,
+        });
         const myPhoto: PhotoReferenceDto = {
             id: createTemporaryId(),
             contentType: 'image/png',

--- a/CourageScores/ClientApp/src/components/common/RefreshControl.test.tsx
+++ b/CourageScores/ClientApp/src/components/common/RefreshControl.test.tsx
@@ -7,6 +7,7 @@ import {
     noop,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { IRefreshControlProps, RefreshControl } from './RefreshControl';
 import { LiveContainer, useLive } from '../../live/LiveContainer';
@@ -53,14 +54,9 @@ describe('RefreshControl', () => {
     }
 
     describe('renders', () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                useWebSockets: true,
-            },
-        };
+        const account = user({
+            useWebSockets: true,
+        });
 
         it('nothing when logged out', async () => {
             const id = createTemporaryId();
@@ -73,10 +69,7 @@ describe('RefreshControl', () => {
         it('nothing when not permitted', async () => {
             const id = createTemporaryId();
 
-            await renderComponent(
-                { id, type: LiveDataType.sayg },
-                { givenName: '', name: '', emailAddress: '', access: {} },
-            );
+            await renderComponent({ id, type: LiveDataType.sayg }, user({}));
 
             expect(context.optional('.dropdown-menu')).toBeFalsy();
         });
@@ -124,14 +117,9 @@ describe('RefreshControl', () => {
     });
 
     describe('interactivity', () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                useWebSockets: true,
-            },
-        };
+        const account = user({
+            useWebSockets: true,
+        });
 
         it('enables live', async () => {
             const id = createTemporaryId();

--- a/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixtureDate.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/DivisionFixtureDate.test.tsx
@@ -6,6 +6,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { createTemporaryId } from '../../helpers/projection';
 import { renderDate } from '../../helpers/rendering';
@@ -571,15 +572,10 @@ describe('DivisionFixtureDate', () => {
             .address('ANOTHER ADDRESS')
             .forSeason(season, division)
             .build();
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                manageGames: true,
-                manageNotes: true,
-            },
-        };
+        const account = user({
+            manageGames: true,
+            manageNotes: true,
+        });
 
         it('renders without potential league fixtures when any tournaments exist', async () => {
             const fixtureDate = fixtureDateBuilder('2023-05-06T00:00:00')

--- a/CourageScores/ClientApp/src/components/division_fixtures/FixtureDateNote.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/FixtureDateNote.test.tsx
@@ -6,6 +6,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { FixtureDateNote, IFixtureDateNoteProps } from './FixtureDateNote';
 import { DivisionDataContainer } from '../league/DivisionDataContainer';
@@ -82,14 +83,9 @@ describe('FixtureDateNote', () => {
         });
 
         it('when logged in, without ability to delete', async () => {
-            const account: UserDto = {
-                givenName: '',
-                name: '',
-                emailAddress: '',
-                access: {
-                    manageNotes: true,
-                },
-            };
+            const account = user({
+                manageNotes: true,
+            });
             await renderComponent(
                 {
                     note: noteBuilder().note('**some markdown**').build(),
@@ -105,14 +101,9 @@ describe('FixtureDateNote', () => {
         });
 
         it('when logged in, with ability to delete', async () => {
-            const account: UserDto = {
-                givenName: '',
-                name: '',
-                emailAddress: '',
-                access: {
-                    manageNotes: true,
-                },
-            };
+            const account = user({
+                manageNotes: true,
+            });
             await renderComponent(
                 {
                     note: noteBuilder().note('**some markdown**').build(),
@@ -128,14 +119,9 @@ describe('FixtureDateNote', () => {
         });
 
         it('when logged in, without ability to edit', async () => {
-            const account: UserDto = {
-                givenName: '',
-                name: '',
-                emailAddress: '',
-                access: {
-                    manageNotes: true,
-                },
-            };
+            const account = user({
+                manageNotes: true,
+            });
             await renderComponent(
                 {
                     note: noteBuilder().note('**some markdown**').build(),
@@ -151,14 +137,9 @@ describe('FixtureDateNote', () => {
 
     describe('interactivity', () => {
         it('can delete note', async () => {
-            const account: UserDto = {
-                givenName: '',
-                name: '',
-                emailAddress: '',
-                access: {
-                    manageNotes: true,
-                },
-            };
+            const account = user({
+                manageNotes: true,
+            });
             const note = noteBuilder().note('**some markdown**').build();
             await renderComponent({ note, setEditNote }, account);
             context.prompts.respondToConfirm(
@@ -175,14 +156,9 @@ describe('FixtureDateNote', () => {
         });
 
         it('prevents delete if user does not agree', async () => {
-            const account: UserDto = {
-                givenName: '',
-                name: '',
-                emailAddress: '',
-                access: {
-                    manageNotes: true,
-                },
-            };
+            const account = user({
+                manageNotes: true,
+            });
             const note = noteBuilder().note('**some markdown**').build();
             await renderComponent({ note, setEditNote }, account);
             context.prompts.respondToConfirm(
@@ -199,14 +175,9 @@ describe('FixtureDateNote', () => {
         });
 
         it('alerts if unable to delete', async () => {
-            const account: UserDto = {
-                givenName: '',
-                name: '',
-                emailAddress: '',
-                access: {
-                    manageNotes: true,
-                },
-            };
+            const account = user({
+                manageNotes: true,
+            });
             const note = noteBuilder().note('**some markdown**').build();
             await renderComponent({ note, setEditNote }, account);
             deleteResult = { success: false };
@@ -221,14 +192,9 @@ describe('FixtureDateNote', () => {
         });
 
         it('can edit note', async () => {
-            const account: UserDto = {
-                givenName: '',
-                name: '',
-                emailAddress: '',
-                access: {
-                    manageNotes: true,
-                },
-            };
+            const account = user({
+                manageNotes: true,
+            });
             const note = noteBuilder().note('**some markdown**').build();
             await renderComponent({ note, setEditNote }, account);
 

--- a/CourageScores/ClientApp/src/components/division_fixtures/TournamentFixture.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_fixtures/TournamentFixture.test.tsx
@@ -9,6 +9,7 @@ import {
     noop,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { createTemporaryId } from '../../helpers/projection';
 import {
@@ -572,14 +573,9 @@ describe('TournamentFixture', () => {
         const season: SeasonDto = seasonBuilder('SEASON').build();
         const division: DivisionDto = divisionBuilder('DIVISION').build();
         const player: DivisionPlayerDto = playerBuilder('PLAYER').build();
-        const account: UserDto = {
-            name: '',
-            givenName: '',
-            emailAddress: '',
-            access: {
-                manageTournaments: true,
-            },
-        };
+        const account = user({
+            manageTournaments: true,
+        });
 
         it('can delete tournament', async () => {
             const tournament = tournamentBuilder()

--- a/CourageScores/ClientApp/src/components/division_players/DivisionPlayer.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_players/DivisionPlayer.test.tsx
@@ -7,6 +7,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { DivisionPlayer, IDivisionPlayerProps } from './DivisionPlayer';
 import {
@@ -411,14 +412,9 @@ describe('DivisionPlayer', () => {
     });
 
     describe('when logged in', () => {
-        const account: UserDto = {
-            name: '',
-            givenName: '',
-            emailAddress: '',
-            access: {
-                managePlayers: true,
-            },
-        };
+        const account = user({
+            managePlayers: true,
+        });
         const division: DivisionDto = divisionBuilder('DIVISION').build();
         const season: SeasonDto = seasonBuilder('SEASON')
             .withDivision(division)

--- a/CourageScores/ClientApp/src/components/division_players/DivisionPlayers.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_players/DivisionPlayers.test.tsx
@@ -8,6 +8,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { createTemporaryId } from '../../helpers/projection';
 import {
@@ -356,14 +357,9 @@ describe('DivisionPlayers', () => {
 
     describe('when logged in', () => {
         beforeEach(() => {
-            account = {
-                name: '',
-                emailAddress: '',
-                givenName: '',
-                access: {
-                    managePlayers: true,
-                },
-            };
+            account = user({
+                managePlayers: true,
+            });
         });
 
         it('renders players with heading and venue', async () => {

--- a/CourageScores/ClientApp/src/components/division_reports/DivisionReports.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_reports/DivisionReports.test.tsx
@@ -8,6 +8,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { createTemporaryId } from '../../helpers/projection';
 import {
@@ -84,14 +85,9 @@ describe('DivisionReports', () => {
     }
 
     describe('when logged in', () => {
-        const account: UserDto = {
-            name: '',
-            givenName: '',
-            emailAddress: '',
-            access: {
-                runReports: true,
-            },
-        };
+        const account = user({
+            runReports: true,
+        });
 
         it('renders component', async () => {
             const divisionId = createTemporaryId();

--- a/CourageScores/ClientApp/src/components/division_teams/AssignTeamToSeasons.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/AssignTeamToSeasons.tsx
@@ -25,7 +25,11 @@ export function AssignTeamToSeasons({
     teamOverview,
     onClose,
 }: IAssignTeamToSeasonsProps) {
-    const { id: divisionId, season: currentSeason } = useDivisionData();
+    const {
+        id: divisionId,
+        season: currentSeason,
+        onReloadDivision,
+    } = useDivisionData();
     const { divisions, seasons, teams, onError, reloadAll } = useApp();
     const { teamApi } = useDependencies();
     const team = teams.find((t) => t.id === teamOverview.id)!;
@@ -68,6 +72,8 @@ export function AssignTeamToSeasons({
             if (response.success) {
                 // reload all
                 await reloadAll();
+                // reload this division too
+                await onReloadDivision();
             } else {
                 setSaveError(response);
             }

--- a/CourageScores/ClientApp/src/components/division_teams/DivisionTeam.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/DivisionTeam.test.tsx
@@ -7,6 +7,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { createTemporaryId } from '../../helpers/projection';
 import { DivisionTeam } from './DivisionTeam';
@@ -244,14 +245,9 @@ describe('DivisionTeam', () => {
     });
 
     describe('when logged in', () => {
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                manageTeams: true,
-            },
-        };
+        const account = user({
+            manageTeams: true,
+        });
         const division = divisionBuilder('DIVISION').build();
         const season = seasonBuilder('SEASON').withDivision(division).build();
 

--- a/CourageScores/ClientApp/src/components/division_teams/DivisionTeams.test.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/DivisionTeams.test.tsx
@@ -8,6 +8,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { createTemporaryId } from '../../helpers/projection';
 import {
@@ -181,14 +182,9 @@ describe('DivisionTeams', () => {
 
     describe('when logged in', () => {
         beforeEach(() => {
-            account = {
-                name: '',
-                emailAddress: '',
-                givenName: '',
-                access: {
-                    manageTeams: true,
-                },
-            };
+            account = user({
+                manageTeams: true,
+            });
         });
 
         it('renders teams', async () => {

--- a/CourageScores/ClientApp/src/components/division_teams/EditTeamDetails.tsx
+++ b/CourageScores/ClientApp/src/components/division_teams/EditTeamDetails.tsx
@@ -6,7 +6,7 @@ import {
 } from '../common/BootstrapDropdown';
 import { useDependencies } from '../common/IocContainer';
 import { useApp } from '../common/AppContainer';
-import { handleChange } from '../../helpers/events';
+import { handleChange, stateChanged } from '../../helpers/events';
 import { LoadingSpinnerSmall } from '../common/LoadingSpinnerSmall';
 import { TeamDto } from '../../interfaces/models/dtos/Team/TeamDto';
 import { DivisionDto } from '../../interfaces/models/dtos/DivisionDto';
@@ -36,6 +36,7 @@ export function EditTeamDetails({
     const { divisions, onError } = useApp();
     const { teamApi } = useDependencies();
     const [saving, setSaving] = useState<boolean>(false);
+    const [createAnother, setCreateAnother] = useState<boolean>(false);
     const [saveError, setSaveError] =
         useState<IClientActionResultDto<TeamDto> | null>(null);
     const divisionOptions: IBootstrapDropdownItem[] = divisions.map(
@@ -74,7 +75,7 @@ export function EditTeamDetails({
                 if (onChange) {
                     await onChange('updated', response.result!.updated!);
                 }
-                if (onSaved) {
+                if (onSaved && !createAnother) {
                     await onSaved(response.result!);
                 }
             } else {
@@ -145,6 +146,25 @@ export function EditTeamDetails({
                         Cancel
                     </button>
                 </div>
+
+                {team.id ? null : (
+                    <div className="form-check form-switch margin-right">
+                        <input
+                            disabled={saving}
+                            type="checkbox"
+                            name="createAnother"
+                            id="createAnother"
+                            checked={createAnother}
+                            onChange={stateChanged(setCreateAnother)}
+                            className="form-check-input"
+                        />
+                        <label
+                            className="form-check-label"
+                            htmlFor="createAnother">
+                            Create another
+                        </label>
+                    </div>
+                )}
                 <button className="btn btn-primary" onClick={saveChanges}>
                     {saving ? <LoadingSpinnerSmall /> : null}
                     {team.id ? 'Save team' : 'Add team'}

--- a/CourageScores/ClientApp/src/components/layout/NavMenu.test.tsx
+++ b/CourageScores/ClientApp/src/components/layout/NavMenu.test.tsx
@@ -6,6 +6,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { NavMenu } from './NavMenu';
 import { ISettings } from '../../api/settings';
@@ -469,12 +470,7 @@ describe('NavMenu', () => {
         };
 
         it('should not show admin link', async () => {
-            const nonAdminAccount: UserDto = {
-                name: '',
-                emailAddress: '',
-                access: {},
-                givenName: 'Not an admin',
-            };
+            const nonAdminAccount = user({});
             await renderComponent(
                 settings,
                 appProps({

--- a/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
@@ -23,6 +23,13 @@ import { seasonBuilder } from '../../helpers/builders/seasons';
 import { IDivisionApi } from '../../interfaces/apis/IDivisionApi';
 import { ISeasonApi } from '../../interfaces/apis/ISeasonApi';
 
+const mockedUsedNavigate = jest.fn();
+
+jest.mock('react-router', () => ({
+    ...jest.requireActual('react-router'),
+    useNavigate: () => mockedUsedNavigate,
+}));
+
 describe('DivisionControls', () => {
     let context: TestContext;
     let reportedError: ErrorState;
@@ -33,6 +40,8 @@ describe('DivisionControls', () => {
     let updatedDivision: EditDivisionDto | null;
     let seasonApiResult: IClientActionResultDto<SeasonDto> | null;
     let divisionApiResult: IClientActionResultDto<DivisionDto> | null;
+    const updatedDivisionNameSuffix = ' NEW NAME';
+    const updatedSeasonNameSuffix = ' NEW NAME';
 
     const seasonApi = api<ISeasonApi>({
         update: async (
@@ -43,7 +52,7 @@ describe('DivisionControls', () => {
                 seasonApiResult || {
                     success: true,
                     result: {
-                        name: data.name,
+                        name: data.name + updatedSeasonNameSuffix,
                     } as SeasonDto,
                 }
             );
@@ -58,7 +67,7 @@ describe('DivisionControls', () => {
                 divisionApiResult || {
                     success: true,
                     result: {
-                        name: data.name,
+                        name: data.name + updatedDivisionNameSuffix,
                     } as DivisionDto,
                 }
             );
@@ -70,6 +79,7 @@ describe('DivisionControls', () => {
     });
 
     beforeEach(() => {
+        jest.resetAllMocks();
         reportedError = new ErrorState();
         changedDivisionOrSeason = undefined;
         reloadDivisionsCalled = false;
@@ -804,9 +814,17 @@ describe('DivisionControls', () => {
 
                 reportedError.verifyNoError();
                 expect(updatedSeason!.name).toEqual('NEW SEASON');
+                expect(mockedUsedNavigate).toHaveBeenCalledWith('/test?');
+                reportedError.verifyNoError();
+                expect(
+                    context.optional('.btn-group .modal-dialog'),
+                ).toBeFalsy();
+                expect(changedDivisionOrSeason).toEqual(false);
+                expect(reloadSeasonsCalled).toEqual(true);
+                expect(updatedSeason).not.toBeNull();
             });
 
-            it('can save season details', async () => {
+            it('updates season name in address', async () => {
                 await renderComponent(
                     {
                         originalSeasonData: season5,
@@ -815,21 +833,25 @@ describe('DivisionControls', () => {
                     account,
                     seasons,
                     divisions,
+                    '/teams/:season',
+                    '/teams/Season%205/?division=Division+5',
                 );
                 reportedError.verifyNoError();
                 await getSeasonButtonGroup()
                     .button(`Season 5 ${seasonDates(season5)}✏`)
                     .click();
+                const newName = 'NEW SEASON';
 
+                await context
+                    .required('.btn-group .modal-dialog')
+                    .input('name')
+                    .change(newName);
                 await context.button('Update season').click();
 
-                reportedError.verifyNoError();
-                expect(
-                    context.optional('.btn-group .modal-dialog'),
-                ).toBeFalsy();
-                expect(changedDivisionOrSeason).toEqual(false);
-                expect(reloadSeasonsCalled).toEqual(true);
-                expect(updatedSeason).not.toBeNull();
+                const expected = encodeURI(newName + updatedSeasonNameSuffix);
+                expect(mockedUsedNavigate).toHaveBeenCalledWith(
+                    `/teams/${expected}/?division=Division+5`,
+                );
             });
 
             it('handles error when saving season details', async () => {
@@ -940,9 +962,17 @@ describe('DivisionControls', () => {
 
                 reportedError.verifyNoError();
                 expect(updatedDivision!.name).toEqual('NEW DIVISION');
+                expect(mockedUsedNavigate).toHaveBeenCalledWith('/test?');
+                reportedError.verifyNoError();
+                expect(
+                    context.optional('.btn-group .modal-dialog'),
+                ).toBeFalsy();
+                expect(changedDivisionOrSeason).toEqual(false);
+                expect(reloadDivisionsCalled).toEqual(true);
+                expect(updatedDivision).not.toBeNull();
             });
 
-            it('can save division details', async () => {
+            it('updates division name in address', async () => {
                 await renderComponent(
                     {
                         originalSeasonData: season5,
@@ -951,19 +981,24 @@ describe('DivisionControls', () => {
                     account,
                     seasons,
                     divisions,
+                    '/teams/:season',
+                    '/teams/Season%205/?division=Division+5',
                 );
                 reportedError.verifyNoError();
                 await getDivisionButtonGroup().button('Division 5✏').click();
+                const newName = 'NEW DIVISION';
 
+                await context
+                    .required('.btn-group .modal-dialog')
+                    .input('name')
+                    .change(newName);
                 await context.button('Update division').click();
 
-                reportedError.verifyNoError();
-                expect(
-                    context.optional('.btn-group .modal-dialog'),
-                ).toBeFalsy();
-                expect(changedDivisionOrSeason).toEqual(false);
-                expect(reloadDivisionsCalled).toEqual(true);
-                expect(updatedDivision).not.toBeNull();
+                const expectedRaw = newName + updatedDivisionNameSuffix;
+                const expected = expectedRaw.replaceAll(' ', '+');
+                expect(mockedUsedNavigate).toHaveBeenCalledWith(
+                    `/teams/Season%205/?division=${expected}`,
+                );
             });
 
             it('handles error when saving division details', async () => {

--- a/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
@@ -41,6 +41,9 @@ describe('DivisionControls', () => {
             return (
                 seasonApiResult || {
                     success: true,
+                    result: {
+                        name: data.name,
+                    } as SeasonDto,
                 }
             );
         },

--- a/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
@@ -56,6 +56,9 @@ describe('DivisionControls', () => {
             return (
                 divisionApiResult || {
                     success: true,
+                    result: {
+                        name: data.name,
+                    } as DivisionDto,
                 }
             );
         },

--- a/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
@@ -8,6 +8,7 @@ import {
     iocProps,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { DivisionControls, IDivisionControlsProps } from './DivisionControls';
 import { renderDate } from '../../helpers/rendering';
@@ -328,15 +329,10 @@ describe('DivisionControls', () => {
     });
 
     describe('when logged in', () => {
-        const account: UserDto = {
-            name: '',
-            givenName: '',
-            emailAddress: '',
-            access: {
-                manageDivisions: true,
-                manageSeasons: true,
-            },
-        };
+        const account = user({
+            manageDivisions: true,
+            manageSeasons: true,
+        });
         const division3: DivisionDto = divisionBuilder('Division 3').build();
         const division4: DivisionDto = divisionBuilder('Division 4').build();
         const season3: SeasonDto = seasonBuilder('Season 3')
@@ -740,15 +736,10 @@ describe('DivisionControls', () => {
         });
 
         describe('when logged in', () => {
-            const account: UserDto = {
-                name: '',
-                givenName: '',
-                emailAddress: '',
-                access: {
-                    manageDivisions: true,
-                    manageSeasons: true,
-                },
-            };
+            const account = user({
+                manageDivisions: true,
+                manageSeasons: true,
+            });
 
             it('can show edit season dialog', async () => {
                 await renderComponent(

--- a/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionControls.test.tsx
@@ -44,33 +44,25 @@ describe('DivisionControls', () => {
     const updatedSeasonNameSuffix = ' NEW NAME';
 
     const seasonApi = api<ISeasonApi>({
-        update: async (
-            data: EditSeasonDto,
-        ): Promise<IClientActionResultDto<SeasonDto>> => {
+        update: async (data: EditSeasonDto) => {
             updatedSeason = data;
-            return (
-                seasonApiResult || {
-                    success: true,
-                    result: {
-                        name: data.name + updatedSeasonNameSuffix,
-                    } as SeasonDto,
-                }
-            );
+            return (seasonApiResult || {
+                success: true,
+                result: {
+                    name: data.name + updatedSeasonNameSuffix,
+                } as SeasonDto,
+            }) as IClientActionResultDto<SeasonDto>;
         },
     });
     const divisionApi = api<IDivisionApi>({
-        update: async (
-            data: EditDivisionDto,
-        ): Promise<IClientActionResultDto<DivisionDto>> => {
+        update: async (data: EditDivisionDto) => {
             updatedDivision = data;
-            return (
-                divisionApiResult || {
-                    success: true,
-                    result: {
-                        name: data.name + updatedDivisionNameSuffix,
-                    } as DivisionDto,
-                }
-            );
+            return (divisionApiResult || {
+                success: true,
+                result: {
+                    name: data.name + updatedDivisionNameSuffix,
+                } as DivisionDto,
+            }) as IClientActionResultDto<DivisionDto>;
         },
     });
 
@@ -90,10 +82,8 @@ describe('DivisionControls', () => {
         divisionApiResult = null;
     });
 
-    async function divisionOrSeasonChanged(
-        preventReloadIfIdsAreTheSame?: boolean,
-    ) {
-        changedDivisionOrSeason = preventReloadIfIdsAreTheSame;
+    async function divisionOrSeasonChanged(preventReload?: boolean) {
+        changedDivisionOrSeason = preventReload;
     }
 
     async function renderComponent(
@@ -138,11 +128,9 @@ describe('DivisionControls', () => {
             .map((i) => i.text());
     }
 
-    function getOption(group: IComponent, containingText: string) {
+    function getOption(group: IComponent, contains: string) {
         const items = group.all('div.dropdown-menu .dropdown-item');
-        const item = items.filter(
-            (i) => (i.text() || '').indexOf(containingText) !== -1,
-        )[0];
+        const item = items.filter((i) => i.text().indexOf(contains) !== -1)[0];
         expect(item).toBeTruthy();
         return item;
     }
@@ -166,9 +154,7 @@ describe('DivisionControls', () => {
     }
 
     function getShownData(group: IComponent): IComponent {
-        const buttons = group.all('button');
-        expect(buttons.length).toBeGreaterThanOrEqual(1);
-        return buttons[0];
+        return group.required('button');
     }
 
     async function toggleDropdown(group: IComponent) {
@@ -203,16 +189,13 @@ describe('DivisionControls', () => {
         const divisions = [division1, division2];
 
         describe('when in season', () => {
+            const div1Season1 = {
+                originalSeasonData: season1,
+                originalDivisionData: division1,
+            };
+
             it('shows current season', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season1,
-                        originalDivisionData: division1,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div1Season1, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 const seasonButton = getShownData(getSeasonButtonGroup());
@@ -221,15 +204,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows other seasons', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season1,
-                        originalDivisionData: division1,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div1Season1, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 expect(getOptions(getSeasonButtonGroup())).toEqual([
@@ -239,15 +214,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows current division', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season1,
-                        originalDivisionData: division1,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div1Season1, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 const divisionButton = getShownData(getDivisionButtonGroup());
@@ -255,15 +222,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows other divisions', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season1,
-                        originalDivisionData: division1,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div1Season1, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 expect(getOptions(getDivisionButtonGroup())).toEqual([
@@ -274,15 +233,12 @@ describe('DivisionControls', () => {
         });
 
         describe('when out of season', () => {
+            const outOfSeason = {
+                originalDivisionData: division1,
+            };
+
             it('prompts user to select a season', async () => {
-                await renderComponent(
-                    {
-                        originalDivisionData: division1,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(outOfSeason, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 const seasonButton = getShownData(getSeasonButtonGroup());
@@ -291,14 +247,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows other seasons', async () => {
-                await renderComponent(
-                    {
-                        originalDivisionData: division1,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(outOfSeason, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 expect(getOptions(getSeasonButtonGroup())).toEqual([
@@ -308,14 +257,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows all divisions', async () => {
-                await renderComponent(
-                    {
-                        originalDivisionData: division1,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(outOfSeason, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 const divisionButton = getShownData(getDivisionButtonGroup());
@@ -323,14 +265,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows no divisions', async () => {
-                await renderComponent(
-                    {
-                        originalDivisionData: division1,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(outOfSeason, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 expect(getOptions(getDivisionButtonGroup())).toEqual([]);
@@ -360,16 +295,13 @@ describe('DivisionControls', () => {
         const divisions = [division3, division4];
 
         describe('when in season', () => {
+            const div3Season3 = {
+                originalSeasonData: season3,
+                originalDivisionData: division3,
+            };
+
             it('shows current season', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season3,
-                        originalDivisionData: division3,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div3Season3, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 const seasonButton = getShownData(getSeasonButtonGroup());
@@ -379,15 +311,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows other seasons', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season3,
-                        originalDivisionData: division3,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div3Season3, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 expect(getOptions(getSeasonButtonGroup())).toEqual([
@@ -398,15 +322,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows current division', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season3,
-                        originalDivisionData: division3,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div3Season3, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 const divisionButton = getShownData(getDivisionButtonGroup());
@@ -414,15 +330,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows other divisions', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season3,
-                        originalDivisionData: division3,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div3Season3, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 expect(getOptions(getDivisionButtonGroup())).toEqual([
@@ -434,15 +342,12 @@ describe('DivisionControls', () => {
         });
 
         describe('when out of season', () => {
+            const outOfSeason = {
+                originalDivisionData: division3,
+            };
+
             it('prompts user to select a season', async () => {
-                await renderComponent(
-                    {
-                        originalDivisionData: division3,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(outOfSeason, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 const seasonButton = getShownData(getSeasonButtonGroup());
@@ -451,14 +356,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows other seasons', async () => {
-                await renderComponent(
-                    {
-                        originalDivisionData: division3,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(outOfSeason, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 expect(getOptions(getSeasonButtonGroup())).toEqual([
@@ -469,14 +367,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows all divisions', async () => {
-                await renderComponent(
-                    {
-                        originalDivisionData: division3,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(outOfSeason, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 const divisionButton = getShownData(getDivisionButtonGroup());
@@ -484,14 +375,7 @@ describe('DivisionControls', () => {
             });
 
             it('shows no divisions', async () => {
-                await renderComponent(
-                    {
-                        originalDivisionData: division3,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(outOfSeason, account, seasons, divisions);
 
                 reportedError.verifyNoError();
                 expect(getOptions(getDivisionButtonGroup())).toEqual([]);
@@ -515,20 +399,20 @@ describe('DivisionControls', () => {
             .build();
         const seasons = [season5, season6];
         const divisions = [division5, division6];
+        const div5Season5 = {
+            originalSeasonData: season5,
+            originalDivisionData: division5,
+        };
 
         describe('common', () => {
             const account: UserDto | undefined = undefined;
+            const div6Season5 = {
+                originalSeasonData: season5,
+                originalDivisionData: division6,
+            };
 
             it('can open season drop down', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
                 const group = getSeasonButtonGroup();
                 assertDropdownOpen(group, false);
@@ -539,15 +423,7 @@ describe('DivisionControls', () => {
             });
 
             it('can open division drop down', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
                 const group = getDivisionButtonGroup();
                 assertDropdownOpen(group, false);
@@ -558,15 +434,7 @@ describe('DivisionControls', () => {
             });
 
             it('can close season drop down', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
                 const group = getSeasonButtonGroup();
                 assertDropdownOpen(group, false);
@@ -584,8 +452,7 @@ describe('DivisionControls', () => {
 
                 await renderComponent(
                     {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
+                        ...div5Season5,
                         overrideMode: 'OVERRIDE',
                     },
                     account,
@@ -614,10 +481,7 @@ describe('DivisionControls', () => {
                     '/division/DIVISION_ID/team:TEAM_ID/SEASON_ID';
 
                 await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
+                    div5Season5,
                     account,
                     seasons,
                     divisions,
@@ -644,10 +508,7 @@ describe('DivisionControls', () => {
                     '/division/DIVISION_ID/player:PLAYER_ID/SEASON_ID';
 
                 await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
+                    div5Season5,
                     account,
                     seasons,
                     divisions,
@@ -674,10 +535,7 @@ describe('DivisionControls', () => {
                     '/division/DIVISION_ID/player:PLAYER_ID/SEASON_ID';
 
                 await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division6,
-                    },
+                    div6Season5,
                     account,
                     seasons,
                     divisions,
@@ -699,8 +557,7 @@ describe('DivisionControls', () => {
 
                 await renderComponent(
                     {
-                        originalSeasonData: season5,
-                        originalDivisionData: division6,
+                        ...div6Season5,
                         overrideMode: 'fixtures',
                     },
                     account,
@@ -725,8 +582,7 @@ describe('DivisionControls', () => {
 
                 await renderComponent(
                     {
-                        originalSeasonData: season5,
-                        originalDivisionData: division6,
+                        ...div6Season5,
                         overrideMode: 'fixtures',
                     },
                     account,
@@ -752,15 +608,7 @@ describe('DivisionControls', () => {
             });
 
             it('can show edit season dialog', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
 
                 await getSeasonButtonGroup()
@@ -772,15 +620,7 @@ describe('DivisionControls', () => {
             });
 
             it('can show add season dialog', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
 
                 await getSeasonButtonGroup()
@@ -792,15 +632,7 @@ describe('DivisionControls', () => {
             });
 
             it('can change season details', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
                 await getSeasonButtonGroup()
                     .button(`Season 5 ${seasonDates(season5)}✏`)
@@ -826,10 +658,7 @@ describe('DivisionControls', () => {
 
             it('updates season name in address', async () => {
                 await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
+                    div5Season5,
                     account,
                     seasons,
                     divisions,
@@ -855,15 +684,7 @@ describe('DivisionControls', () => {
             });
 
             it('handles error when saving season details', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
                 await getSeasonButtonGroup()
                     .button(`Season 5 ${seasonDates(season5)}✏`)
@@ -882,15 +703,7 @@ describe('DivisionControls', () => {
             });
 
             it('can close add/edit season dialog', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
                 await getSeasonButtonGroup()
                     .button(`Season 5 ${seasonDates(season5)}✏`)
@@ -904,15 +717,7 @@ describe('DivisionControls', () => {
             });
 
             it('can show edit division dialog', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
 
                 await getDivisionButtonGroup().button('Division 5✏').click();
@@ -922,15 +727,7 @@ describe('DivisionControls', () => {
             });
 
             it('can show add division dialog', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
 
                 await getDivisionButtonGroup()
@@ -942,15 +739,7 @@ describe('DivisionControls', () => {
             });
 
             it('can change division details', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
                 await getDivisionButtonGroup().button('Division 5✏').click();
 
@@ -974,10 +763,7 @@ describe('DivisionControls', () => {
 
             it('updates division name in address', async () => {
                 await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
+                    div5Season5,
                     account,
                     seasons,
                     divisions,
@@ -1002,15 +788,7 @@ describe('DivisionControls', () => {
             });
 
             it('handles error when saving division details', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
                 await getDivisionButtonGroup().button('Division 5✏').click();
                 divisionApiResult = {
@@ -1027,15 +805,7 @@ describe('DivisionControls', () => {
             });
 
             it('can close add/edit division dialog', async () => {
-                await renderComponent(
-                    {
-                        originalSeasonData: season5,
-                        originalDivisionData: division5,
-                    },
-                    account,
-                    seasons,
-                    divisions,
-                );
+                await renderComponent(div5Season5, account, seasons, divisions);
                 reportedError.verifyNoError();
                 await getDivisionButtonGroup().button('Division 5✏').click();
 

--- a/CourageScores/ClientApp/src/components/league/DivisionControls.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionControls.tsx
@@ -82,7 +82,13 @@ export function DivisionControls({
                         setDivisionData(data)
                     }
                     onClose={async () => setDivisionData(null)}
-                    onSave={async () => {
+                    onSave={async (division: DivisionDto) => {
+                        if (originalDivisionData) {
+                            updateNameInAddress(
+                                originalDivisionData.name,
+                                division.name,
+                            );
+                        }
                         await reloadDivisions();
                         if (onDivisionOrSeasonChanged) {
                             await onDivisionOrSeasonChanged(false);
@@ -102,7 +108,14 @@ export function DivisionControls({
             encodeURI(oldName),
             encodeURI(newName),
         );
-        const newAddress = `${newPath}${location.search}${location.hash}`;
+        const oldSearch = new URLSearchParams(location.search);
+        const newSearch = new URLSearchParams(location.search);
+        for (const [key, value] of oldSearch.entries()) {
+            if (value === oldName) {
+                newSearch.set(key, newName);
+            }
+        }
+        const newAddress = `${newPath}?${newSearch}${location.hash}`;
         navigate(newAddress);
     }
 
@@ -118,10 +131,12 @@ export function DivisionControls({
                     }
                     onClose={async () => setSeasonData(null)}
                     onSave={async (season: SeasonDto) => {
-                        updateNameInAddress(
-                            originalSeasonData!.name,
-                            season.name,
-                        );
+                        if (originalSeasonData) {
+                            updateNameInAddress(
+                                originalSeasonData.name,
+                                season.name,
+                            );
+                        }
                         await reloadSeasons();
                         if (onDivisionOrSeasonChanged) {
                             await onDivisionOrSeasonChanged(false);

--- a/CourageScores/ClientApp/src/components/league/DivisionControls.tsx
+++ b/CourageScores/ClientApp/src/components/league/DivisionControls.tsx
@@ -3,7 +3,7 @@ import {
     DropdownMenu,
     DropdownToggle,
 } from '../common/ButtonDropdown';
-import { Link, useLocation, useParams } from 'react-router';
+import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import { useState } from 'react';
 import { ErrorDisplay } from '../common/ErrorDisplay';
 import { Dialog } from '../common/Dialog';
@@ -59,6 +59,7 @@ export function DivisionControls({
         null,
     );
     const location = useLocation();
+    const navigate = useNavigate();
 
     function toggleDropdown(name: string) {
         if (openDropdown === null || openDropdown !== name) {
@@ -96,6 +97,15 @@ export function DivisionControls({
         );
     }
 
+    function updateNameInAddress(oldName: string, newName: string) {
+        const newPath = location.pathname.replace(
+            encodeURI(oldName),
+            encodeURI(newName),
+        );
+        const newAddress = `${newPath}${location.search}${location.hash}`;
+        navigate(newAddress);
+    }
+
     function renderEditSeasonDialog() {
         return (
             <Dialog
@@ -107,7 +117,11 @@ export function DivisionControls({
                         setSeasonData(season)
                     }
                     onClose={async () => setSeasonData(null)}
-                    onSave={async () => {
+                    onSave={async (season: SeasonDto) => {
+                        updateNameInAddress(
+                            originalSeasonData!.name,
+                            season.name,
+                        );
                         await reloadSeasons();
                         if (onDivisionOrSeasonChanged) {
                             await onDivisionOrSeasonChanged(false);

--- a/CourageScores/ClientApp/src/components/league/EditDivision.tsx
+++ b/CourageScores/ClientApp/src/components/league/EditDivision.tsx
@@ -11,7 +11,7 @@ import { UntypedPromise } from '../../interfaces/UntypedPromise';
 
 export interface IEditDivisionProps {
     onClose(): UntypedPromise;
-    onSave(): UntypedPromise;
+    onSave(division: DivisionDto): UntypedPromise;
     setSaveError(error: IClientActionResultDto<DivisionDto>): UntypedPromise;
     data: DivisionDataDto;
     onUpdateData(data: DivisionDataDto): UntypedPromise;
@@ -44,15 +44,15 @@ export function EditDivision({
 
         try {
             setSaving(true);
-            const result: IClientActionResultDto<DivisionDto> =
+            const response: IClientActionResultDto<DivisionDto> =
                 await divisionApi.update(
                     Object.assign({ lastUpdated: data.updated }, data),
                 );
 
-            if (result.success) {
-                await onSave();
+            if (response.success) {
+                await onSave(response.result!);
             } else {
-                await setSaveError(result);
+                await setSaveError(response);
             }
         } catch (e) {
             /* istanbul ignore next */

--- a/CourageScores/ClientApp/src/components/league/EditSeason.tsx
+++ b/CourageScores/ClientApp/src/components/league/EditSeason.tsx
@@ -13,7 +13,7 @@ import { SeasonDto } from '../../interfaces/models/dtos/Season/SeasonDto';
 
 export interface IEditSeasonProps {
     onClose(): UntypedPromise;
-    onSave(): UntypedPromise;
+    onSave(season: SeasonDto): UntypedPromise;
     setSaveError(error: IClientActionResultDto<SeasonDto>): UntypedPromise;
     data: EditSeasonDto & SeasonDto;
     onUpdateData(season: EditSeasonDto): UntypedPromise;
@@ -46,14 +46,14 @@ export function EditSeason({
 
         try {
             setSaving(true);
-            const result = await seasonApi.update(
+            const response = await seasonApi.update(
                 Object.assign({ lastUpdated: data.updated }, data),
             );
 
-            if (result.success) {
-                await onSave();
+            if (response.success) {
+                await onSave(response.result!);
             } else {
-                await setSaveError(result);
+                await setSaveError(response);
             }
         } catch (e) {
             /* istanbul ignore next */

--- a/CourageScores/ClientApp/src/components/practice/PracticeMatch.test.tsx
+++ b/CourageScores/ClientApp/src/components/practice/PracticeMatch.test.tsx
@@ -9,6 +9,7 @@ import {
     noop,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { PracticeMatch } from './PracticeMatch';
 import { createTemporaryId } from '../../helpers/projection';
@@ -460,14 +461,13 @@ describe('PracticeMatch', () => {
     });
 
     describe('logged in', () => {
-        const account: UserDto = {
-            givenName: 'GIVEN NAME',
-            name: 'NAME',
-            emailAddress: '',
-            access: {
+        const account = user(
+            {
                 useWebSockets: false,
             },
-        };
+            undefined,
+            'GIVEN NAME',
+        );
 
         it('when no data loaded, sets your name to account givenName', async () => {
             await renderComponent(account, '');

--- a/CourageScores/ClientApp/src/components/sayg/MatchStatistics.test.tsx
+++ b/CourageScores/ClientApp/src/components/sayg/MatchStatistics.test.tsx
@@ -10,6 +10,7 @@ import {
     noop,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { ILegBuilder, saygBuilder } from '../../helpers/builders/sayg';
 import {
@@ -22,7 +23,6 @@ import { RecordedScoreAsYouGoDto } from '../../interfaces/models/dtos/Game/Sayg/
 import { UpdateRecordedScoreAsYouGoDto } from '../../interfaces/models/dtos/Game/Sayg/UpdateRecordedScoreAsYouGoDto';
 import { IAppContainerProps } from '../common/AppContainer';
 import { ILiveOptions } from '../../live/ILiveOptions';
-import { UserDto } from '../../interfaces/models/dtos/Identity/UserDto';
 import { ILegDisplayOptions } from './ILegDisplayOptions';
 import { ISaygApi } from '../../interfaces/apis/ISaygApi';
 import { IClientActionResultDto } from '../common/IClientActionResultDto';
@@ -353,14 +353,9 @@ describe('MatchStatistics', () => {
             .opponentName('AWAY')
             .numberOfLegs(3)
             .build();
-        const account: UserDto = {
-            emailAddress: '',
-            givenName: '',
-            name: '',
-            access: {
-                recordScoresAsYouGo: true,
-            },
-        };
+        const account = user({
+            recordScoresAsYouGo: true,
+        });
         await renderComponent(
             {
                 id: saygData.id,
@@ -517,12 +512,7 @@ describe('MatchStatistics', () => {
             canSubscribe: true,
             subscribeAtStartup: [{ id, type: LiveDataType.sayg }],
         };
-        const account: UserDto = {
-            name: '',
-            emailAddress: '',
-            givenName: '',
-            access: { useWebSockets: true },
-        };
+        const account = user({ useWebSockets: true });
         console.log = noop;
         const saygData: RecordedScoreAsYouGoDto = saygBuilder()
             .withLeg(0, (b) =>
@@ -553,14 +543,9 @@ describe('MatchStatistics', () => {
             canSubscribe: true,
             subscribeAtStartup: [],
         };
-        const account: UserDto = {
-            name: '',
-            emailAddress: '',
-            givenName: '',
-            access: {
-                useWebSockets: true,
-            },
-        };
+        const account = user({
+            useWebSockets: true,
+        });
         const saygData: RecordedScoreAsYouGoDto = saygBuilder()
             .withLeg(0, (b) =>
                 b.currentThrow('home').startingScore(501).home().away(),
@@ -595,12 +580,7 @@ describe('MatchStatistics', () => {
             canSubscribe: true,
             subscribeAtStartup: [{ id, type: LiveDataType.sayg }],
         };
-        const account: UserDto = {
-            givenName: '',
-            name: '',
-            emailAddress: '',
-            access: { useWebSockets: true },
-        };
+        const account = user({ useWebSockets: true });
         console.log = noop;
         const saygData: RecordedScoreAsYouGoDto = saygBuilder(id)
             .withLeg(0, (b) =>
@@ -646,14 +626,9 @@ describe('MatchStatistics', () => {
             canSubscribe: true,
             subscribeAtStartup: [{ id: saygId, type: LiveDataType.sayg }],
         };
-        const account: UserDto = {
-            name: '',
-            givenName: '',
-            emailAddress: '',
-            access: {
-                useWebSockets: true,
-            },
-        };
+        const account = user({
+            useWebSockets: true,
+        });
         const saygData: RecordedScoreAsYouGoDto = saygBuilder()
             .withLeg(0, (b) =>
                 b
@@ -706,14 +681,9 @@ describe('MatchStatistics', () => {
             .yourName('HOME')
             .numberOfLegs(3)
             .build();
-        const account: UserDto = {
-            emailAddress: '',
-            name: '',
-            givenName: '',
-            access: {
-                useWebSockets: true,
-            },
-        };
+        const account = user({
+            useWebSockets: true,
+        });
         console.log = noop;
         await renderComponent(
             {
@@ -748,12 +718,7 @@ describe('MatchStatistics', () => {
             canSubscribe: true,
             subscribeAtStartup: [{ id, type: LiveDataType.sayg }],
         };
-        const account: UserDto = {
-            givenName: '',
-            name: '',
-            emailAddress: '',
-            access: { useWebSockets: true },
-        };
+        const account = user({ useWebSockets: true });
         const saygData: RecordedScoreAsYouGoDto = saygBuilder(id)
             .withLeg(0, (b) =>
                 b

--- a/CourageScores/ClientApp/src/components/sayg/SaygLoadingContainer.test.tsx
+++ b/CourageScores/ClientApp/src/components/sayg/SaygLoadingContainer.test.tsx
@@ -9,6 +9,7 @@ import {
     noop,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import { act } from '@testing-library/react';
 import {
@@ -25,7 +26,6 @@ import { RecordedScoreAsYouGoDto } from '../../interfaces/models/dtos/Game/Sayg/
 import { IClientActionResultDto } from '../common/IClientActionResultDto';
 import { ISubscriptions } from '../../live/ISubscriptions';
 import { ILiveOptions } from '../../live/ILiveOptions';
-import { UserDto } from '../../interfaces/models/dtos/Identity/UserDto';
 import { IAppContainerProps } from '../common/AppContainer';
 import { ISaygApi } from '../../interfaces/apis/ISaygApi';
 import { ISubscriptionRequest } from '../../live/ISubscriptionRequest';
@@ -459,12 +459,7 @@ describe('SaygLoadingContainer', () => {
                 .withLeg(0, (l) => l.startingScore(501).home().away())
                 .addTo(saygDataMap)
                 .build();
-            const account: UserDto = {
-                emailAddress: '',
-                name: '',
-                givenName: '',
-                access: { useWebSockets: true },
-            };
+            const account = user({ useWebSockets: true });
             await renderComponent(
                 {
                     children: (
@@ -508,12 +503,7 @@ describe('SaygLoadingContainer', () => {
                 .withLeg(0, (l) => l.startingScore(501).home().away())
                 .addTo(saygDataMap)
                 .build();
-            const account: UserDto = {
-                givenName: '',
-                name: '',
-                emailAddress: '',
-                access: { useWebSockets: true },
-            };
+            const account = user({ useWebSockets: true });
             await renderComponent(
                 {
                     children: (
@@ -570,12 +560,7 @@ describe('SaygLoadingContainer', () => {
             const newSaygData = saygBuilder(saygData.id)
                 .withLeg(0, (l) => l.startingScore(601).home().away())
                 .build();
-            const account: UserDto = {
-                emailAddress: '',
-                name: '',
-                givenName: '',
-                access: { useWebSockets: true },
-            };
+            const account = user({ useWebSockets: true });
             await renderComponent(
                 {
                     children: (
@@ -667,12 +652,7 @@ describe('SaygLoadingContainer', () => {
                 .withLeg(0, (l) => l.startingScore(501).home().away())
                 .addTo(saygDataMap)
                 .build();
-            const account: UserDto = {
-                emailAddress: '',
-                name: '',
-                givenName: '',
-                access: { useWebSockets: true },
-            };
+            const account = user({ useWebSockets: true });
             await renderComponent(
                 {
                     children: (

--- a/CourageScores/ClientApp/src/components/season_creation/PickTemplate.tsx
+++ b/CourageScores/ClientApp/src/components/season_creation/PickTemplate.tsx
@@ -25,8 +25,22 @@ export function PickTemplate({
 }: IPickTemplateProps) {
     const templateOptions: IBootstrapDropdownItem[] =
         templates && templates.result
-            ? templates.result.map(getTemplateOption)
+            ? templates.result.sort(sortCompatibleFirst).map(getTemplateOption)
             : [];
+
+    function sortCompatibleFirst(
+        x: ActionResultDto<TemplateDto>,
+        y: ActionResultDto<TemplateDto>,
+    ) {
+        const xSuccess = x.success ? 1 : 0;
+        const ySuccess = y.success ? 1 : 0;
+
+        const compatibilityEquality = ySuccess - xSuccess;
+
+        return compatibilityEquality === 0
+            ? x.result!.name!.localeCompare(y.result!.name)
+            : compatibilityEquality;
+    }
 
     function getTemplateOption(
         compatibility: ActionResultDto<TemplateDto>,

--- a/CourageScores/ClientApp/src/components/season_creation/ReviewProposalHealth.tsx
+++ b/CourageScores/ClientApp/src/components/season_creation/ReviewProposalHealth.tsx
@@ -11,19 +11,23 @@ export function ReviewProposalHealth({ response }: IReviewProposalHealthProps) {
     function renderError(e: string, i: number) {
         return (
             <li className="text-danger" key={i}>
-                {e}
+                <pre>{e}</pre>
             </li>
         );
     }
 
     function renderWarning(w: string, i: number) {
-        return <li key={i}>{w}</li>;
+        return (
+            <li key={i}>
+                <pre>{w}</pre>
+            </li>
+        );
     }
 
     function renderMessage(m: string, i: number) {
         return (
             <li className="text-secondary" key={i}>
-                {m}
+                <pre>{m}</pre>
             </li>
         );
     }

--- a/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.test.tsx
+++ b/CourageScores/ClientApp/src/components/tournaments/TournamentDetails.test.tsx
@@ -8,6 +8,7 @@ import {
     noop,
     renderApp,
     TestContext,
+    user,
 } from '../../helpers/tests';
 import {
     ITournamentDetailsProps,
@@ -23,7 +24,6 @@ import { IDataApi } from '../../interfaces/apis/IDataApi';
 import { DivisionDto } from '../../interfaces/models/dtos/DivisionDto';
 import { SeasonDto } from '../../interfaces/models/dtos/Season/SeasonDto';
 import { seasonBuilder } from '../../helpers/builders/seasons';
-import { UserDto } from '../../interfaces/models/dtos/Identity/UserDto';
 import { TournamentGameDto } from '../../interfaces/models/dtos/Game/TournamentGameDto';
 import { IAppContainerProps } from '../common/AppContainer';
 
@@ -82,16 +82,11 @@ describe('TournamentDetails', () => {
         .build();
 
     describe('renders', () => {
-        const account: UserDto = {
-            name: '',
-            emailAddress: '',
-            givenName: '',
-            access: {
-                manageTournaments: true,
-                managePlayers: true,
-                recordScoresAsYouGo: true,
-            },
-        };
+        const account = user({
+            manageTournaments: true,
+            managePlayers: true,
+            recordScoresAsYouGo: true,
+        });
 
         it('tournament without any sides', async () => {
             const tournamentData = tournamentBuilder()
@@ -144,27 +139,17 @@ describe('TournamentDetails', () => {
     });
 
     describe('interactivity', () => {
-        const account: UserDto = {
-            name: '',
-            emailAddress: '',
-            givenName: '',
-            access: {
-                manageTournaments: true,
-                managePlayers: true,
-                recordScoresAsYouGo: true,
-            },
-        };
-        const canExportAccount: UserDto = {
-            name: '',
-            emailAddress: '',
-            givenName: '',
-            access: {
-                manageTournaments: true,
-                managePlayers: true,
-                recordScoresAsYouGo: true,
-                exportData: true,
-            },
-        };
+        const account = user({
+            manageTournaments: true,
+            managePlayers: true,
+            recordScoresAsYouGo: true,
+        });
+        const canExportAccount = user({
+            manageTournaments: true,
+            managePlayers: true,
+            recordScoresAsYouGo: true,
+            exportData: true,
+        });
 
         it('can update accolades count', async () => {
             const tournamentData = tournamentBuilder()

--- a/CourageScores/ClientApp/src/helpers/tests.tsx
+++ b/CourageScores/ClientApp/src/helpers/tests.tsx
@@ -439,10 +439,14 @@ export interface IBrowserNavigator {
     share: (data: ShareData) => void;
 }
 
-export function user(access: AccessDto, teamId?: string): UserDto {
+export function user(
+    access: AccessDto,
+    teamId?: string,
+    givenName?: string,
+): UserDto {
     return {
         name: '',
-        givenName: '',
+        givenName: givenName ?? '',
         emailAddress: '',
         access,
         teamId,

--- a/CourageScores/Models/Adapters/Season/Creation/TemplateToHealthCheckAdapter.cs
+++ b/CourageScores/Models/Adapters/Season/Creation/TemplateToHealthCheckAdapter.cs
@@ -15,7 +15,9 @@ public class TemplateToHealthCheckAdapter : ISimpleOnewayAdapter<Template, Seaso
         {
             Name = model.Name,
             StartDate = startDate,
-            Divisions = model.Divisions.Select((d, index) => AdaptDivision(d, $"Division {index + 1}", startDate, GetTeams(model, index))).ToList(),
+            Divisions = model.Divisions
+                .Select((d, index) => AdaptDivision(d, $"Division {index + 1}", startDate, GetTeams(model, index)))
+                .ToList(),
         };
         var dates = dto.Divisions.SelectMany(d => d.Dates).ToArray();
         if (dates.Any())

--- a/CourageScores/Services/Health/Checks/SameNumberOfWeeks.cs
+++ b/CourageScores/Services/Health/Checks/SameNumberOfWeeks.cs
@@ -1,0 +1,38 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using CourageScores.Models.Dtos.Health;
+
+namespace CourageScores.Services.Health.Checks;
+
+public class SameNumberOfWeeks : ISeasonHealthCheck
+{
+    [ExcludeFromCodeCoverage]
+    public string Name => "All fixtures should have the same number of weeks";
+
+    public Task<HealthCheckResultDto> RunCheck(IReadOnlyCollection<DivisionHealthDto> divisions, HealthCheckContext context, CancellationToken token)
+    {
+        if (divisions.Count <= 1)
+        {
+            return Task.FromResult(new HealthCheckResultDto { Success = true });
+        }
+
+        var numberOfWeeksRanked = divisions
+            .GroupBy(division => division.Dates.Count)
+            .ToDictionary(grouping => grouping.Key, grouping => grouping.ToArray());
+
+        if (numberOfWeeksRanked.Count == 1)
+        {
+            return Task.FromResult(new HealthCheckResultDto { Success = true });
+        }
+
+        var mostCommonNumberOfWeeks = numberOfWeeksRanked.OrderByDescending(pair => pair.Value.Length).ThenBy(pair => pair.Key).First().Key;
+        var otherNumberOfWeeks = numberOfWeeksRanked.Where(pair => pair.Key != mostCommonNumberOfWeeks);
+        var otherNumberOfWeeksDetails = otherNumberOfWeeks.Select(pair => $"{pair.Key} weeks in {string.Join(" & ", pair.Value.Select(division => division.Name))}");
+        return Task.FromResult(new HealthCheckResultDto
+        {
+            Errors =
+            [
+                $"Some divisions have a different number of weeks, expected: {mostCommonNumberOfWeeks} weeks, found {string.Join(", ", otherNumberOfWeeksDetails)}",
+            ]
+        });
+    }
+}

--- a/CourageScores/Services/Health/Checks/SameNumberOfWeeks.cs
+++ b/CourageScores/Services/Health/Checks/SameNumberOfWeeks.cs
@@ -6,7 +6,7 @@ namespace CourageScores.Services.Health.Checks;
 public class SameNumberOfWeeks : ISeasonHealthCheck
 {
     [ExcludeFromCodeCoverage]
-    public string Name => "All fixtures should have the same number of weeks";
+    public string Name => "All divisions should have the same number of weeks";
 
     public Task<HealthCheckResultDto> RunCheck(IReadOnlyCollection<DivisionHealthDto> divisions, HealthCheckContext context, CancellationToken token)
     {

--- a/CourageScores/Services/Health/SeasonHealthCheckFactory.cs
+++ b/CourageScores/Services/Health/SeasonHealthCheckFactory.cs
@@ -16,5 +16,6 @@ public class SeasonHealthCheckFactory : ISeasonHealthCheckFactory
         yield return new TeamsPlayingMultipleFixturesOnSameDate();
         yield return new VenuesBeingUsedByMultipleTeamsOnSameDate();
         yield return new ContiguousByes();
+        yield return new SameNumberOfWeeks();
     }
 }

--- a/CourageScores/Services/Season/Creation/AddressAssignmentStrategy.cs
+++ b/CourageScores/Services/Season/Creation/AddressAssignmentStrategy.cs
@@ -215,7 +215,7 @@ public class AddressAssignmentStrategy : IAddressAssignmentStrategy
 
             if (largestSharedSeasonAddress.Length > largestTemplateSeasonSharedAddress.Count)
             {
-                context.Result.Errors.Add($"{messagePrefix}Shared address has more teams than the template supports");
+                context.Result.Errors.Add($"{messagePrefix}Shared address has more teams {FormatIncompatibility(largestSharedSeasonAddress)} than the template supports {FormatIncompatibility(largestTemplateSeasonSharedAddress)}");
                 return Task.FromResult(false);
             }
 
@@ -227,5 +227,25 @@ public class AddressAssignmentStrategy : IAddressAssignmentStrategy
         }
 
         return Task.FromResult(true);
+    }
+
+    private static string FormatIncompatibility(IReadOnlyCollection<TeamPlaceholderDto> placeholders)
+    {
+        if (placeholders.Count == 0)
+        {
+            return "None";
+        }
+
+        return $"{placeholders.Count} x ({string.Join(", ", placeholders.Select(a => a.Key))})";
+    }
+
+    private static string FormatIncompatibility(IReadOnlyCollection<TeamDto> teams)
+    {
+        if (teams.Count == 0)
+        {
+            return "None";
+        }
+
+        return $"{teams.Count} x ({string.Join(", ", teams.Select(a => a.Name))})";
     }
 }

--- a/CourageScores/Services/Season/Creation/FixtureDateAssignmentStrategy.cs
+++ b/CourageScores/Services/Season/Creation/FixtureDateAssignmentStrategy.cs
@@ -19,8 +19,13 @@ public class FixtureDateAssignmentStrategy : IFixtureDateAssignmentStrategy
         {
             token.ThrowIfCancellationRequested();
 
-            var templateDateForDivisions = divisionMappings.Select(mapping => mapping.TemplateDivision.Dates[templateDateIndex]).ToArray();
-            var fixtureDateForDivisions = context.MatchContext.Divisions.Select(d => d.Fixtures.Where(fd => fd.Date == currentDate).ToArray()).ToList();
+            var templateDateForDivisions = divisionMappings
+                .Select(mapping => mapping.TemplateDivision.Dates.ElementAtOrDefault(templateDateIndex))
+                .Cast<DateTemplateDto>()
+                .ToArray();
+            var fixtureDateForDivisions = context.MatchContext.Divisions
+                .Select(d => d.Fixtures.Where(fd => fd.Date == currentDate).ToArray())
+                .ToList();
 
             // there must be no fixtures, notes or tournaments on this date
             if (!AreThereAnyFixturesNotesOrTournaments(fixtureDateForDivisions))
@@ -72,13 +77,16 @@ public class FixtureDateAssignmentStrategy : IFixtureDateAssignmentStrategy
     {
         var divisionMappings = context.MatchContext.GetDivisionMappings(context.Template);
         var success = true;
+        var division = 0;
 
         foreach (var mapping in divisionMappings.Zip(templateDateForDivisions))
         {
             token.ThrowIfCancellationRequested();
 
-            var fixturesToCreate = mapping.Second.Fixtures;
-            var divisionToAddFixturesTo = mapping.First.SeasonDivision;
+            division++;
+            var weekOffset = 1 + (currentDate - context.MatchContext.SeasonDto.StartDate).TotalDays / 7;
+            var fixturesToCreate = mapping.Second.Fixtures ?? throw new NullReferenceException($"No fixtures for week {weekOffset} in division {division}");
+            var divisionToAddFixturesTo = mapping.First.SeasonDivision ?? throw new NullReferenceException($"No second division for week {weekOffset} in division {division}");
             var fixtureDate = divisionToAddFixturesTo.Fixtures.FirstOrDefault(fd => fd.Date == currentDate);
             if (fixtureDate == null)
             {

--- a/CourageScores/Services/Season/Creation/SeasonTemplateService.cs
+++ b/CourageScores/Services/Season/Creation/SeasonTemplateService.cs
@@ -119,7 +119,7 @@ public class SeasonTemplateService : ISeasonTemplateService
         }
         catch (Exception exc)
         {
-            return Error<ProposalResultDto>(exc.Message);
+            return Error<ProposalResultDto>(exc.ToString());
         }
     }
 

--- a/CourageScores/Services/Season/Creation/SeasonTemplateService.cs
+++ b/CourageScores/Services/Season/Creation/SeasonTemplateService.cs
@@ -119,7 +119,7 @@ public class SeasonTemplateService : ISeasonTemplateService
         }
         catch (Exception exc)
         {
-            return Error<ProposalResultDto>(exc.ToString());
+            return Error<ProposalResultDto>(exc.Message);
         }
     }
 


### PR DESCRIPTION
### Changes
- #2146
- #2186
- #2185
- #2184

### Ancillary
- Fix name of check
- Simplify DivisionControls tests
- Add tests to verify template selection in the address
- Only include the message in the error
- Add test for redirection after rename
- Wider use of user() builder in tests
- Persist selected template in url
- Sort compatible templates to be before incompatible
- Throw informative error if template has inconsistent number of dates
- Format incompatible shared-address details in message
- Update errors/warnings to include whitespace