### PR TITLE
#2235: Add basic ui for approving/rejecting sessions

### DIFF
--- a/CourageScores/ClientApp/src/App.tsx
+++ b/CourageScores/ClientApp/src/App.tsx
@@ -30,6 +30,7 @@ import { IFullScreen } from './components/common/IFullScreen.ts';
 import { AnalyseScores } from './components/analysis/AnalyseScores.tsx';
 import { Login } from './components/Login.tsx';
 import { NewSession } from './components/service_account_sessions/NewSession.tsx';
+import { SessionResponse } from './components/service_account_sessions/SessionResponse.tsx';
 
 export interface IAppProps {
     embed?: boolean;
@@ -216,6 +217,10 @@ export function App({ embed, controls, testRoute }: IAppProps) {
                             <Route
                                 path="/new_session/:friendlyName?"
                                 element={<NewSession />}
+                            />
+                            <Route
+                                path="/accept_session/:id"
+                                element={<SessionResponse />}
                             />
                             <Route
                                 path="/division/:divisionId"

--- a/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.test.tsx
+++ b/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.test.tsx
@@ -185,7 +185,7 @@ describe('NewSession', () => {
             ).toEqual(`https://localhost/accept_session/${createdSession.id}`);
             expect(
                 context.required('[data-testid="session-pin"]').text(),
-            ).toHaveLength(4);
+            ).toMatch(/^PIN: [a-z0-9]{4}$/);
         });
 
         it('shows errors when create fails', async () => {
@@ -247,7 +247,7 @@ describe('NewSession', () => {
 
             reportedError.verifyNoError();
             expect(activateSessionId).toEqual(createdSession.id);
-            expect(activateRequest?.pin).toHaveLength(4);
+            expect(activateRequest?.pin).toMatch(/^[a-z0-9]{4}$/);
             expect(allDataReloaded).toEqual(true);
             expect(context.required('h3').text()).toEqual('Session approved');
             expect(
@@ -308,7 +308,7 @@ describe('NewSession', () => {
 
             reportedError.verifyNoError();
             expect(activateSessionId).toEqual(createdSession.id);
-            expect(activateRequest?.pin).toEqual(pin);
+            expect(activateRequest?.pin).toEqual(pin.replace('PIN: ', ''));
             expect(allDataReloaded).toEqual(true);
             expect(context.required('h3').text()).toEqual('Session approved');
         });

--- a/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.test.tsx
+++ b/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.test.tsx
@@ -335,4 +335,28 @@ describe('NewSession', () => {
             expect(context.text()).toContain('Refresh exploded');
         });
     });
+
+    describe('session rejection', () => {
+        it('shows rejection', async () => {
+            createResponse = {
+                success: true,
+                result: session({
+                    rejectedBy: 'Someone',
+                    message: 'Rejection reason',
+                }),
+            };
+            await renderComponent('/new_session/Board%201');
+
+            await context.button('Create session').click();
+
+            reportedError.verifyNoError();
+            expect(allDataReloaded).toEqual(false);
+            expect(context.required('h3').text()).toEqual(
+                'Request rejected by Someone',
+            );
+            expect(context.required('p').text()).toEqual(
+                'Reason: Rejection reason',
+            );
+        });
+    });
 });

--- a/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.test.tsx
+++ b/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.test.tsx
@@ -143,7 +143,7 @@ describe('NewSession', () => {
             await context.input('friendlyName').change('Board 2');
 
             expect(mockedUsedNavigate).toHaveBeenCalledWith(
-                '/new_session/Board 2',
+                '/new_session/Board 2/',
             );
         });
 

--- a/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.tsx
+++ b/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.tsx
@@ -169,41 +169,55 @@ export function NewSession() {
             );
         }
 
-        if (session!.success) {
-            const addressForApprovals = `https://${location.host}/accept_session/${session!.result!.id}`;
-
+        if (!session?.success) {
             return (
-                <div className="position-relative">
-                    <h3>Waiting for approval...</h3>
-                    <div className="d-flex flex-column align-items-center">
-                        <h6>{friendlyName}</h6>
-                        <QRCodeSVG value={addressForApprovals} size={150} />
-                        <pre className="fs-3" data-testid="session-pin">
-                            PIN: {pin}
-                        </pre>
-                        <pre>IP address: {session!.result!.myIpAddress}</pre>
-                        <a
-                            href={addressForApprovals}
-                            rel="noopener noreferrer"
-                            target="_blank">
-                            Open approval link in new tab
-                        </a>
-                    </div>
-                    <div className="position-absolute top-0 right-0">
-                        {refreshing || activating ? (
-                            <LoadingSpinnerSmall />
-                        ) : null}
-                    </div>
+                <div>
+                    <h3>Session was not created</h3>
+                    {renderMessages('text-danger', session!.errors)}
+                    {renderMessages('text-warning', session!.warnings)}
+                    {renderMessages('text-secondary', session!.messages)}
                 </div>
             );
         }
 
+        if (session!.result?.rejectedBy) {
+            return renderRejected();
+        }
+        return renderWaitingForApproval();
+    }
+
+    function renderRejected() {
         return (
             <div>
-                <h3>Session was not created</h3>
-                {renderMessages('text-danger', session!.errors)}
-                {renderMessages('text-warning', session!.warnings)}
-                {renderMessages('text-secondary', session!.messages)}
+                <h3>Request rejected by {session?.result?.rejectedBy}</h3>
+                <p>Reason: {session?.result?.message}</p>
+            </div>
+        );
+    }
+
+    function renderWaitingForApproval() {
+        const addressForApprovals = `https://${location.host}/accept_session/${session!.result!.id}`;
+
+        return (
+            <div className="position-relative">
+                <h3>Waiting for approval...</h3>
+                <div className="d-flex flex-column align-items-center">
+                    <h6>{friendlyName}</h6>
+                    <QRCodeSVG value={addressForApprovals} size={150} />
+                    <pre className="fs-3" data-testid="session-pin">
+                        PIN: {pin}
+                    </pre>
+                    <pre>IP address: {session!.result!.myIpAddress}</pre>
+                    <a
+                        href={addressForApprovals}
+                        rel="noopener noreferrer"
+                        target="_blank">
+                        Open approval link in new tab
+                    </a>
+                </div>
+                <div className="position-absolute top-0 right-0">
+                    {refreshing || activating ? <LoadingSpinnerSmall /> : null}
+                </div>
             </div>
         );
     }

--- a/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.tsx
+++ b/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.tsx
@@ -179,7 +179,7 @@ export function NewSession() {
                         <h6>{friendlyName}</h6>
                         <QRCodeSVG value={addressForApprovals} size={150} />
                         <pre className="fs-3" data-testid="session-pin">
-                            {pin}
+                            PIN: {pin}
                         </pre>
                         <pre>IP address: {session!.result!.myIpAddress}</pre>
                         <a

--- a/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.tsx
+++ b/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.tsx
@@ -43,7 +43,9 @@ export function NewSession() {
     }, [session]);
 
     async function activateSession() {
+        /* istanbul ignore next */
         if (activating) {
+            /* istanbul ignore next */
             return;
         }
 
@@ -110,7 +112,9 @@ export function NewSession() {
     }
 
     async function createSession() {
+        /* istanbul ignore next */
         if (creating) {
+            /* istanbul ignore next */
             return;
         }
 

--- a/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.tsx
+++ b/CourageScores/ClientApp/src/components/service_account_sessions/NewSession.tsx
@@ -101,7 +101,7 @@ export function NewSession() {
     }
 
     function setFriendlyName(name: string) {
-        navigate(`/new_session/${name}`);
+        navigate(`/new_session/${name}/`);
     }
 
     function createPin() {
@@ -145,7 +145,7 @@ export function NewSession() {
                         id="friendlyName"
                         name="friendlyName"
                         className="form-control"
-                        value={friendlyName}
+                        value={friendlyName || ''}
                         onChange={stateChanged(setFriendlyName)}
                     />
                 </div>

--- a/CourageScores/ClientApp/src/components/service_account_sessions/SessionResponse.test.tsx
+++ b/CourageScores/ClientApp/src/components/service_account_sessions/SessionResponse.test.tsx
@@ -1,0 +1,340 @@
+import { act } from '@testing-library/react';
+import {
+    api,
+    appProps,
+    brandingProps,
+    cleanUp,
+    ErrorState,
+    iocProps,
+    renderApp,
+    TestContext,
+} from '../../helpers/tests.tsx';
+import { createTemporaryId } from '../../helpers/projection.ts';
+import { SessionResponse } from './SessionResponse.tsx';
+import { IServiceAccountSessionApi } from '../../interfaces/apis/IServiceAccountSessionApi.ts';
+import { IClientActionResultDto } from '../common/IClientActionResultDto.ts';
+import { ServiceAccountSessionDto } from '../../interfaces/models/dtos/Identity/ServiceAccountSessionDto.ts';
+import { ApproveServiceAccountSessionDto } from '../../interfaces/models/dtos/Identity/ApproveServiceAccountSessionDto.ts';
+import { RejectServiceAccountSessionDto } from '../../interfaces/models/dtos/Identity/RejectServiceAccountSessionDto.ts';
+
+describe('SessionResponse', () => {
+    let context: TestContext;
+    let reportedError: ErrorState;
+    let sessionId: string;
+    let currentSession: ServiceAccountSessionDto | null;
+    let getSessionId: string | null;
+    let approveSessionId: string | null;
+    let approveRequest: ApproveServiceAccountSessionDto | null;
+    let approveResponse: IClientActionResultDto<ServiceAccountSessionDto> | null;
+    let rejectSessionId: string | null;
+    let rejectRequest: RejectServiceAccountSessionDto | null;
+    let rejectResponse: IClientActionResultDto<ServiceAccountSessionDto> | null;
+
+    const serviceAccountSessionApi = api<IServiceAccountSessionApi>({
+        async get(id: string) {
+            getSessionId = id;
+            return currentSession;
+        },
+        async approve(id: string, request: ApproveServiceAccountSessionDto) {
+            approveSessionId = id;
+            approveRequest = request;
+            const response = approveResponse ?? {
+                success: false,
+                errors: ['No approve response configured'],
+            };
+            if (response.result) {
+                currentSession = response.result;
+            }
+            return response;
+        },
+        async reject(id: string, request: RejectServiceAccountSessionDto) {
+            rejectSessionId = id;
+            rejectRequest = request;
+            const response = rejectResponse ?? {
+                success: false,
+                errors: ['No reject response configured'],
+            };
+            if (response.result) {
+                currentSession = response.result;
+            }
+            return response;
+        },
+    });
+
+    afterEach(async () => {
+        await cleanUp(context);
+    });
+
+    beforeEach(() => {
+        reportedError = new ErrorState();
+        sessionId = createTemporaryId();
+        currentSession = null;
+        getSessionId = null;
+        approveSessionId = null;
+        approveRequest = null;
+        approveResponse = null;
+        rejectSessionId = null;
+        rejectRequest = null;
+        rejectResponse = null;
+    });
+
+    async function renderComponent() {
+        context = await renderApp(
+            iocProps({ serviceAccountSessionApi }),
+            brandingProps(),
+            appProps({}, reportedError),
+            <SessionResponse />,
+            '/accept_session/:id',
+            `/accept_session/${sessionId}`,
+        );
+        await act(async () => {
+            await Promise.resolve();
+        });
+    }
+
+    function session(
+        overrides?: Partial<ServiceAccountSessionDto>,
+    ): ServiceAccountSessionDto {
+        return {
+            id: sessionId,
+            friendlyName: 'Board 1',
+            serviceIpAddress: '127.0.0.1',
+            serviceUserAgent: 'a tablet',
+            verificationValue: 'verification',
+            myIpAddress: '127.0.0.1',
+            ...overrides,
+        };
+    }
+
+    describe('load session', () => {
+        it('renders session details', async () => {
+            currentSession = session({ friendlyName: 'TV 1' });
+            await renderComponent();
+
+            reportedError.verifyNoError();
+            expect(getSessionId).toEqual(sessionId);
+            expect(context.required('h3').text()).toEqual(
+                'Service account session',
+            );
+            expect(context.text()).toContain('Friendly name: TV 1');
+            expect(context.text()).toContain('Ip address: 127.0.0.1');
+            expect(context.button('Approve...').enabled()).toEqual(true);
+            expect(context.button('Reject...').enabled()).toEqual(true);
+        });
+    });
+
+    describe('ip address', () => {
+        it('shows matching ip address', async () => {
+            currentSession = session();
+            await renderComponent();
+
+            reportedError.verifyNoError();
+            expect(context.text()).toContain('Ip address: 127.0.0.1✅');
+            expect(context.button('Approve...').enabled()).toEqual(true);
+        });
+
+        it('disables approve when ip address differs', async () => {
+            currentSession = session({ myIpAddress: '192.168.0.10' });
+            await renderComponent();
+
+            reportedError.verifyNoError();
+            expect(context.text()).toContain('❌ - your ip = 192.168.0.10');
+            expect(context.all('.btn-primary')[0].enabled()).toEqual(false);
+            expect(context.text()).toContain('🚫 Your ip address is different');
+        });
+    });
+
+    describe('already responded', () => {
+        it('shows approved by', async () => {
+            currentSession = session({ approvedBy: 'admin@example.com' });
+            await renderComponent();
+
+            reportedError.verifyNoError();
+            expect(context.text()).toContain('Approved by admin@example.com');
+            expect(context.optional('button')).toBeUndefined();
+        });
+
+        it('shows rejected by', async () => {
+            currentSession = session({ rejectedBy: 'admin@example.com' });
+            await renderComponent();
+
+            reportedError.verifyNoError();
+            expect(context.text()).toContain('Rejected by admin@example.com');
+            expect(context.optional('button')).toBeUndefined();
+        });
+    });
+
+    describe('approve', () => {
+        beforeEach(() => {
+            currentSession = session();
+        });
+
+        it('shows approve form', async () => {
+            await renderComponent();
+
+            await context.button('Approve...').click();
+
+            reportedError.verifyNoError();
+            expect(context.required('h4').text()).toEqual('Approve');
+            expect(context.required('#pin').value()).toEqual('');
+            expect(context.button('Approve').enabled()).toEqual(true);
+        });
+
+        it('returns to selection from approve form', async () => {
+            await renderComponent();
+
+            await context.button('Approve...').click();
+            await context.button('← Back').click();
+
+            reportedError.verifyNoError();
+            expect(context.button('Approve...').enabled()).toEqual(true);
+            expect(context.button('Reject...').enabled()).toEqual(true);
+        });
+
+        it('alerts when access template not selected', async () => {
+            await renderComponent();
+
+            await context.button('Approve...').click();
+            await context.required('#pin').change('1234');
+            await context.button('Approve').click();
+
+            reportedError.verifyNoError();
+            context.prompts.alertWasShown('Select the level of access first');
+            expect(approveRequest).toBeNull();
+        });
+
+        it('approves session with pin and access template', async () => {
+            const approvedSession = session({
+                approvedBy: 'admin@example.com',
+            });
+            approveResponse = {
+                success: true,
+                result: approvedSession,
+            };
+            await renderComponent();
+
+            await context.button('Approve...').click();
+            await context.required('#pin').change('1234');
+            await context
+                .required('.dropdown-menu')
+                .select('Superleague Tablet, for entering scores');
+            await context.button('Approve').click();
+
+            reportedError.verifyNoError();
+            expect(approveSessionId).toEqual(sessionId);
+            expect(approveRequest).toEqual({
+                pin: '1234',
+                access: {
+                    useWebSockets: true,
+                    showDebugOptions: true,
+                    enterTournamentResults: true,
+                    recordScoresAsYouGo: true,
+                    kioskMode: true,
+                },
+            });
+            expect(context.text()).toContain('Approved by admin@example.com');
+        });
+
+        it('shows errors when approve fails', async () => {
+            approveResponse = {
+                success: false,
+                errors: ['Approve failed'],
+                warnings: ['Approve warning'],
+                messages: ['Approve message'],
+            };
+            await renderComponent();
+
+            await context.button('Approve...').click();
+            await context.required('#pin').change('1234');
+            await context
+                .required('.dropdown-menu')
+                .select('Superleague TV for displaying live results');
+            await context.button('Approve').click();
+
+            reportedError.verifyNoError();
+            expect(approveRequest?.access).toEqual({
+                showDebugOptions: true,
+                useWebSockets: true,
+            });
+            expect(context.text()).toContain('Approve failed');
+            expect(context.text()).toContain('Approve warning');
+        });
+    });
+
+    describe('reject', () => {
+        beforeEach(() => {
+            currentSession = session();
+        });
+
+        it('shows reject form', async () => {
+            await renderComponent();
+
+            await context.button('Reject...').click();
+
+            reportedError.verifyNoError();
+            expect(context.required('h4').text()).toEqual('Reject');
+            expect(context.input('message').value()).toEqual('');
+            expect(context.button('Reject').enabled()).toEqual(true);
+        });
+
+        it('returns to selection from reject form', async () => {
+            await renderComponent();
+
+            await context.button('Reject...').click();
+            await context.button('← Back').click();
+
+            reportedError.verifyNoError();
+            expect(context.button('Approve...').enabled()).toEqual(true);
+            expect(context.button('Reject...').enabled()).toEqual(true);
+        });
+
+        it('alerts when rejection reason not entered', async () => {
+            await renderComponent();
+
+            await context.button('Reject...').click();
+            await context.button('Reject').click();
+
+            reportedError.verifyNoError();
+            context.prompts.alertWasShown('Enter a rejection reason first');
+            expect(rejectRequest).toBeNull();
+        });
+
+        it('rejects session with reason', async () => {
+            const rejectedSession = session({
+                rejectedBy: 'admin@example.com',
+            });
+            rejectResponse = {
+                success: true,
+                result: rejectedSession,
+            };
+            await renderComponent();
+
+            await context.button('Reject...').click();
+            await context.input('message').change('Not recognised');
+            await context.button('Reject').click();
+
+            reportedError.verifyNoError();
+            expect(rejectSessionId).toEqual(sessionId);
+            expect(rejectRequest).toEqual({ reason: 'Not recognised' });
+            expect(context.text()).toContain('Rejected by admin@example.com');
+        });
+
+        it('shows errors when reject fails', async () => {
+            rejectResponse = {
+                success: false,
+                errors: ['Reject failed'],
+                warnings: ['Reject warning'],
+                messages: ['Reject message'],
+            };
+            await renderComponent();
+
+            await context.button('Reject...').click();
+            await context.input('message').change('Not recognised');
+            await context.button('Reject').click();
+
+            reportedError.verifyNoError();
+            expect(context.text()).toContain('Reject failed');
+            expect(context.text()).toContain('Reject warning');
+        });
+    });
+});

--- a/CourageScores/ClientApp/src/components/service_account_sessions/SessionResponse.tsx
+++ b/CourageScores/ClientApp/src/components/service_account_sessions/SessionResponse.tsx
@@ -1,0 +1,326 @@
+﻿import { useParams } from 'react-router';
+import { stateChanged } from '../../helpers/events.ts';
+import { useEffect, useState } from 'react';
+import {
+    BootstrapDropdown,
+    IBootstrapDropdownItem,
+} from '../common/BootstrapDropdown.tsx';
+import { AccessDto } from '../../interfaces/models/dtos/Identity/AccessDto';
+import { ServiceAccountSessionDto } from '../../interfaces/models/dtos/Identity/ServiceAccountSessionDto';
+import { LoadingSpinnerSmall } from '../common/LoadingSpinnerSmall.tsx';
+import { useDependencies } from '../common/IocContainer.tsx';
+import { ApproveServiceAccountSessionDto } from '../../interfaces/models/dtos/Identity/ApproveServiceAccountSessionDto';
+import { RejectServiceAccountSessionDto } from '../../interfaces/models/dtos/Identity/RejectServiceAccountSessionDto';
+import { IClientActionResultDto } from '../common/IClientActionResultDto.ts';
+import { isEmpty } from '../../helpers/collections.ts';
+
+interface AccessTemplate {
+    name: string;
+    description: string;
+    access: AccessDto;
+}
+
+const accessTemplates: AccessTemplate[] = [
+    {
+        name: 'Superleague Tablet',
+        description: 'Superleague Tablet, for entering scores',
+        access: {
+            useWebSockets: true,
+            showDebugOptions: true,
+            enterTournamentResults: true,
+            recordScoresAsYouGo: true,
+            kioskMode: true,
+        },
+    },
+    {
+        name: 'Superleague TV',
+        description: 'Superleague TV for displaying live results',
+        access: {
+            showDebugOptions: true,
+            useWebSockets: true,
+        },
+    },
+];
+
+const accessTemplateOptions: IBootstrapDropdownItem[] = accessTemplates.map(
+    (t) => ({ value: t.name, text: t.description }),
+);
+
+type Mode = 'approve' | 'reject';
+
+export function SessionResponse() {
+    const { id } = useParams();
+    const { serviceAccountSessionApi } = useDependencies();
+    const [pin, setPin] = useState<string>('');
+    const [loading, setLoading] = useState<boolean>(false);
+    const [message, setMessage] = useState<string>('');
+    const [mode, setMode] = useState<Mode | undefined>();
+    const [accessTemplateId, setAccessTemplateId] = useState<string>('');
+    const [session, setSession] = useState<
+        ServiceAccountSessionDto | undefined
+    >(undefined);
+    const [responding, setResponding] = useState<string | undefined>(undefined);
+    const [response, setResponse] = useState<
+        IClientActionResultDto<ServiceAccountSessionDto> | undefined
+    >(undefined);
+
+    useEffect(() => {
+        // noinspection JSIgnoredPromiseFromCall
+        loadSession();
+    }, []);
+
+    async function loadSession() {
+        /* istanbul ignore next */
+        if (loading) {
+            /* istanbul ignore next */
+            return;
+        }
+
+        setLoading(true);
+
+        try {
+            const response = await serviceAccountSessionApi.get(id!);
+            setSession(response || undefined);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function approveSession() {
+        /* istanbul ignore next */
+        if (responding) {
+            /* istanbul ignore next */
+            return;
+        }
+
+        if (!accessTemplateId) {
+            alert('Select the level of access first');
+            return;
+        }
+
+        try {
+            setResponding('approving');
+
+            const request: ApproveServiceAccountSessionDto = {
+                pin: pin,
+                access: accessTemplates.find(
+                    (t) => t.name === accessTemplateId,
+                )!.access,
+            };
+            const response = await serviceAccountSessionApi.approve(
+                id!,
+                request,
+            );
+            setResponse(response);
+            await loadSession();
+        } finally {
+            setResponding(undefined);
+        }
+    }
+
+    async function rejectSession() {
+        /* istanbul ignore next */
+        if (responding) {
+            /* istanbul ignore next */
+            return;
+        }
+
+        if (!message) {
+            alert('Enter a rejection reason first');
+            return;
+        }
+
+        try {
+            setResponding('rejecting');
+
+            const request: RejectServiceAccountSessionDto = {
+                reason: message,
+            };
+            const response = await serviceAccountSessionApi.reject(
+                id!,
+                request,
+            );
+            setResponse(response);
+            await loadSession();
+        } finally {
+            setResponding(undefined);
+        }
+    }
+
+    function renderMessages(className: string, messages?: string[]) {
+        if (isEmpty(messages)) {
+            return;
+        }
+
+        return (
+            <ul>
+                {messages!.map((msg, index) => (
+                    <li className={className} key={index}>
+                        {msg}
+                    </li>
+                ))}
+            </ul>
+        );
+    }
+
+    function renderSelection(sameIpAddress?: boolean) {
+        return (
+            <>
+                <div className="d-flex justify-content-center gap-1">
+                    <button
+                        className="btn btn-primary"
+                        onClick={() => setMode('approve')}
+                        disabled={!sameIpAddress}>
+                        Approve...
+                        {sameIpAddress ? null : (
+                            <div>🚫 Your ip address is different</div>
+                        )}
+                    </button>
+                    <button
+                        className="btn btn-danger"
+                        onClick={() => setMode('reject')}>
+                        Reject...
+                    </button>
+                </div>
+            </>
+        );
+    }
+
+    function renderApprove() {
+        return (
+            <>
+                <div>
+                    <h4>Approve</h4>
+                    <p>
+                        On the original device (the tablet or the tv), beneath
+                        the QR code there should be a PIN. Enter this value in
+                        the input below and select the access level for the
+                        device.
+                    </p>
+                    <div className="d-flex flex-row align-items-center input-group">
+                        <div className="input-group-prepend">
+                            <label className="input-group-text" htmlFor="pin">
+                                Pin
+                            </label>
+                        </div>
+                        <input
+                            id="pin"
+                            value={pin}
+                            placeholder="Under QR code"
+                            onChange={stateChanged(setPin)}
+                            className="form-control"
+                        />
+                        <label className="mx-2">Access</label>
+                        <BootstrapDropdown
+                            value={accessTemplateId}
+                            onChange={async (opt) => setAccessTemplateId(opt!)}
+                            options={accessTemplateOptions}
+                        />
+                    </div>
+                </div>
+                <div className="d-flex justify-content-end gap-1 mt-2">
+                    <button
+                        className="btn btn-secondary"
+                        onClick={() => setMode(undefined)}>
+                        &larr; Back
+                    </button>
+                    <button
+                        className="btn btn-primary"
+                        onClick={approveSession}>
+                        {responding === 'approving' ? (
+                            <LoadingSpinnerSmall />
+                        ) : null}
+                        Approve
+                    </button>
+                </div>
+            </>
+        );
+    }
+
+    function renderReject() {
+        return (
+            <>
+                <div>
+                    <h4>Reject</h4>
+                    <div>
+                        <label>Reason</label>
+                        <textarea
+                            name="message"
+                            value={message}
+                            onChange={stateChanged(setMessage)}
+                            className="form-control min-height-50"
+                        />
+                    </div>
+                </div>
+                <div className="d-flex justify-content-end gap-1 mt-2">
+                    <button
+                        className="btn btn-secondary"
+                        onClick={() => setMode(undefined)}>
+                        &larr; Back
+                    </button>
+                    <button className="btn btn-primary" onClick={rejectSession}>
+                        {responding === 'rejecting' ? (
+                            <LoadingSpinnerSmall />
+                        ) : null}
+                        Reject
+                    </button>
+                </div>
+            </>
+        );
+    }
+
+    const responded = !!session?.approvedBy || !!session?.rejectedBy;
+    const sameIpAddress = session?.myIpAddress === session?.serviceIpAddress;
+    return (
+        <div className="content-background p-3 position-relative">
+            <h3>Service account session</h3>
+            <div className="position-absolute top-0 right-0 p-3">
+                {loading ? <LoadingSpinnerSmall /> : null}
+            </div>
+            <div className="justify-content-center border-1 border-secondary border-bottom mb-3 pb-3 d-flex gap-1">
+                {session ? (
+                    <>
+                        <div>
+                            <span className="fw-bold">Friendly name:</span>{' '}
+                            {session.friendlyName}
+                        </div>
+                        <div>
+                            <span className="fw-bold">Ip address:</span>{' '}
+                            {session.serviceIpAddress}
+                            {sameIpAddress ? (
+                                '✅'
+                            ) : (
+                                <span className="text-danger no-wrap">
+                                    ❌ - your ip = {session.myIpAddress}
+                                </span>
+                            )}
+                        </div>
+                    </>
+                ) : null}
+            </div>
+            {!responded ? (
+                <div>
+                    {!mode && !loading ? renderSelection(sameIpAddress) : null}
+                    {mode === 'approve' ? renderApprove() : null}
+                    {mode === 'reject' ? renderReject() : null}
+                </div>
+            ) : null}
+            {responded ? (
+                <div>
+                    {session?.rejectedBy ? (
+                        <div>Rejected by {session.rejectedBy}</div>
+                    ) : null}
+                    {session?.approvedBy ? (
+                        <div>Approved by {session.approvedBy}</div>
+                    ) : null}
+                </div>
+            ) : null}
+            {response ? (
+                <div>
+                    {renderMessages('text-danger', response!.errors)}
+                    {renderMessages('text-warning', response!.warnings)}
+                </div>
+            ) : null}
+        </div>
+    );
+}


### PR DESCRIPTION
Resolves #2235 

- [x] add tests
- [x] tidy-up ui
- [x] hide approve/reject buttons when loading
- [x] rejected requests don't show as rejected on tablet